### PR TITLE
Add additional support for security groups to the provider plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 pkg/
 bin/
 
-src/github.com/skippbox
+src/github.com/pyr
 src/github.com/hashicorp
 src/gopkg.in/amz.v2/s3

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ build:
 
 deps:
 	go get github.com/hashicorp/terraform
-	go get github.com/skippbox/egoscale/src/egoscale
+	go get github.com/pyr/egoscale/src/egoscale
 	go get gopkg.in/amz.v2/s3
 
 clean:

--- a/README.md
+++ b/README.md
@@ -208,7 +208,6 @@ operation to succeed.
 # TODO List/Missing features
 
 ## Security Groups
-* There is currently no API in place to allow for listing what ingress/egress rules are in place for a security group once the group is created
 * Support single port declaration as well as starting/ending port ranges
 
 ## S3 Support

--- a/examples/test-affinity-compute.tf.orig
+++ b/examples/test-affinity-compute.tf.orig
@@ -8,7 +8,7 @@ resource "exoscale_affinity" "test" {
 }
 
 resource "exoscale_compute" "test" {
-    template = "ubuntu-16.04"
+    template = "Linux Ubuntu 16.04 LTS 64-bit"
     name = "test-1"
     zone = "ch-gva-2"
     size = "Micro"

--- a/examples/test-affinity-sg-compute.tf.orig
+++ b/examples/test-affinity-sg-compute.tf.orig
@@ -23,7 +23,7 @@ resource "exoscale_securitygroup" "primary" {
 
 
 resource "exoscale_compute" "test" {
-    template = "ubuntu-16.04"
+    template = "Linux Ubuntu 16.04 LTS 64-bit"
     name = "test-1"
     zone = "ch-gva-2"
     size = "Micro"

--- a/examples/test-compute.tf.orig
+++ b/examples/test-compute.tf.orig
@@ -4,7 +4,7 @@ provider "exoscale" {
 }
 
 resource "exoscale_compute" "test" {
-    template = "ubuntu-16.04"
+    template = "Linux Ubuntu 16.04 LTS 64-bit"
     name = "test-1"
     zone = "ch-gva-2"
     size = "Micro"

--- a/src/github.com/cab105/terraform-provider-exoscale/exoscale/affinity_resource.go
+++ b/src/github.com/cab105/terraform-provider-exoscale/exoscale/affinity_resource.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/skippbox/egoscale/src/egoscale"
+	"github.com/pyr/egoscale/src/egoscale"
 )
 
 func affinityResource() *schema.Resource {

--- a/src/github.com/cab105/terraform-provider-exoscale/exoscale/client.go
+++ b/src/github.com/cab105/terraform-provider-exoscale/exoscale/client.go
@@ -1,7 +1,7 @@
 package exoscale
 
 import (
-    "github.com/skippbox/egoscale/src/egoscale"
+    "github.com/pyr/egoscale/src/egoscale"
 
     "gopkg.in/amz.v2/aws"
     "gopkg.in/amz.v2/s3"

--- a/src/github.com/cab105/terraform-provider-exoscale/exoscale/compute_resource.go
+++ b/src/github.com/cab105/terraform-provider-exoscale/exoscale/compute_resource.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/skippbox/egoscale/src/egoscale"
+	"github.com/pyr/egoscale/src/egoscale"
 )
 
 func computeResource() *schema.Resource {

--- a/src/github.com/cab105/terraform-provider-exoscale/exoscale/dns_resource.go
+++ b/src/github.com/cab105/terraform-provider-exoscale/exoscale/dns_resource.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/skippbox/egoscale/src/egoscale"
+	"github.com/pyr/egoscale/src/egoscale"
 )
 
 func dnsResource() *schema.Resource {

--- a/src/github.com/cab105/terraform-provider-exoscale/exoscale/security_group_resource.go
+++ b/src/github.com/cab105/terraform-provider-exoscale/exoscale/security_group_resource.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/skippbox/egoscale/src/egoscale"
+	"github.com/pyr/egoscale/src/egoscale"
 )
 
 func securityGroupResource() *schema.Resource {

--- a/src/github.com/cab105/terraform-provider-exoscale/exoscale/security_group_resource.go
+++ b/src/github.com/cab105/terraform-provider-exoscale/exoscale/security_group_resource.go
@@ -152,11 +152,48 @@ func sgCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func sgRead(d *schema.ResourceData, meta interface{}) error {
-	/*
-	 * We cannot retrieve the ingress/egress rules at this time, and the only
-	 * thing that could possibly change on the group side is the name so do
-	 * nothing for now.
-	 */
+	client := GetClient(ComputeEndpoint, meta)
+	sgs, err := client.GetSecurityGroups()
+	if err != nil {
+		return err
+	}
+
+	var securityGroups egoscale.SecurityGroup
+	for _,v := range sgs {
+		if d.Id() == v.Id {
+			securityGroups = v
+			break;
+		}
+	}
+
+	d.Set("id", securityGroups.Id)
+	d.Set("name", securityGroups.Name)
+	d.Set("description", securityGroups.Description)
+	d.Set("ingressRules.#", len(securityGroups.IngressRules))
+	d.Set("egressRules.#", len(securityGroups.EgressRules))
+
+	for i := 0; i < len(securityGroups.IngressRules); i++ {
+		key := fmt.Sprintf("ingressRules.%d.", i)
+		d.Set(key + "sgid", securityGroups.IngressRules[i].RuleId)
+		d.Set(key + "port", securityGroups.IngressRules[i].StartPort)
+		d.Set(key + "cidr", securityGroups.IngressRules[i].Cidr)
+		d.Set(key + "protocol", securityGroups.IngressRules[i].Protocol)
+		d.Set(key + "icmpcode", securityGroups.IngressRules[i].IcmpCode)
+		d.Set(key + "icmptype", securityGroups.IngressRules[i].IcmpType)
+	}
+
+	for i := 0; i < len(securityGroups.EgressRules); i++ {
+		key := fmt.Sprintf("egressRules.%d.", i)
+		d.Set(key + "sgid", securityGroups.EgressRules[i].RuleId)
+		d.Set(key + "port", securityGroups.EgressRules[i].StartPort)
+		d.Set(key + "cidr", securityGroups.EgressRules[i].Cidr)
+		d.Set(key + "protocol", securityGroups.EgressRules[i].Protocol)
+		d.Set(key + "icmpcode", securityGroups.EgressRules[i].IcmpCode)
+		d.Set(key + "icmptype", securityGroups.EgressRules[i].IcmpType)
+	}
+
+
+
 	return nil
 }
 

--- a/src/github.com/cab105/terraform-provider-exoscale/exoscale/ssh_resource.go
+++ b/src/github.com/cab105/terraform-provider-exoscale/exoscale/ssh_resource.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/skippbox/egoscale/src/egoscale"
+	"github.com/pyr/egoscale/src/egoscale"
 )
 
 func sshResource() *schema.Resource {


### PR DESCRIPTION
Among other things, fixed the examples to use the full template name as the Exoscale user would expect to see it, and changed the egoscale plugin to pull from the pyr/egoscale instead.