### PR TITLE
Add host + scheme provider configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ go:
 - 1.9
 - tip
 
-cache: apt
-
 install:
   - make devdeps
 

--- a/src/github.com/exoscale/terraform-provider-exoscale/exoscale/affinity_resource.go
+++ b/src/github.com/exoscale/terraform-provider-exoscale/exoscale/affinity_resource.go
@@ -29,7 +29,7 @@ func affinityResource() *schema.Resource {
 }
 
 func affinityCreate(d *schema.ResourceData, meta interface{}) error {
-	client := GetClient(ComputeEndpoint, meta)
+	client := GetComputeClient(meta)
 
 	jobid, err := client.CreateAffinityGroup(d.Get("name").(string))
 	if err != nil {
@@ -75,7 +75,7 @@ func affinityCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func affinityRead(d *schema.ResourceData, meta interface{}) error {
-	client := GetClient(ComputeEndpoint, meta)
+	client := GetComputeClient(meta)
 	groups, err := client.GetAffinityGroups()
 	if err != nil {
 		return err
@@ -92,7 +92,7 @@ func affinityRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func affinityDelete(d *schema.ResourceData, meta interface{}) error {
-	client := GetClient(ComputeEndpoint, meta)
+	client := GetComputeClient(meta)
 
 	log.Printf("## name: %s\n", d.Get("name").(string))
 	_, err := client.DeleteAffinityGroup(d.Get("name").(string))

--- a/src/github.com/exoscale/terraform-provider-exoscale/exoscale/client.go
+++ b/src/github.com/exoscale/terraform-provider-exoscale/exoscale/client.go
@@ -7,26 +7,44 @@ import (
 	"gopkg.in/amz.v2/s3"
 )
 
-const ComputeEndpoint = "https://api.exoscale.ch/compute"
-const DNSEndpoint = "https://api.exoscale.ch/dns"
-const S3Endpoint = "https://sos.exo.io"
+const defaultComputeEndpoint = "https://api.exoscale.ch/compute"
+const defaultDnsEndpoint = "https://api.exoscale.ch/dns"
+const defaultS3Endpoint = "https://sos.exo.io"
+const defaultTimeout = 60
 
+// BaseConfig represents the provider structure
 type BaseConfig struct {
-	token   string
-	secret  string
-	timeout int
+	token            string
+	secret           string
+	timeout          int
+	compute_endpoint string
+	dns_endpoint     string
+	s3_endpoint      string
 }
 
-func GetClient(endpoint string, meta interface{}) *egoscale.Client {
+func getClient(endpoint string, meta interface{}) *egoscale.Client {
 	config := meta.(BaseConfig)
 	return egoscale.NewClient(endpoint, config.token, config.secret)
 }
 
+// GetComputeClient builds a CloudStack client
+func GetComputeClient(meta interface{}) *egoscale.Client {
+	config := meta.(BaseConfig)
+	return getClient(config.compute_endpoint, meta)
+}
+
+// GetDnsClient builds a DNS client
+func GetDnsClient(meta interface{}) *egoscale.Client {
+	config := meta.(BaseConfig)
+	return getClient(config.dns_endpoint, meta)
+}
+
+// GetS3Client builds a S3 client to (CH-GV1 region)
 func GetS3Client(meta interface{}) *s3.S3 {
 	config := meta.(BaseConfig)
 	var exo1 = aws.Region{
 		Name:                 "CH-GV1",
-		S3Endpoint:           S3Endpoint,
+		S3Endpoint:           config.s3_endpoint,
 		S3LocationConstraint: false,
 	}
 

--- a/src/github.com/exoscale/terraform-provider-exoscale/exoscale/compute_resource.go
+++ b/src/github.com/exoscale/terraform-provider-exoscale/exoscale/compute_resource.go
@@ -85,7 +85,7 @@ func computeResource() *schema.Resource {
 }
 
 func resourceCreate(d *schema.ResourceData, meta interface{}) error {
-	client := GetClient(ComputeEndpoint, meta)
+	client := GetComputeClient(meta)
 	topo, err := client.GetTopology()
 	if err != nil {
 		return err
@@ -194,7 +194,7 @@ func resourceCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceRead(d *schema.ResourceData, meta interface{}) error {
-	client := GetClient(ComputeEndpoint, meta)
+	client := GetComputeClient(meta)
 	machine, err := client.GetVirtualMachine(d.Id())
 
 	if err != nil {
@@ -235,7 +235,7 @@ func resourceUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceDelete(d *schema.ResourceData, meta interface{}) error {
-	client := GetClient(ComputeEndpoint, meta)
+	client := GetComputeClient(meta)
 
 	resp, err := client.DestroyVirtualMachine(d.Id())
 

--- a/src/github.com/exoscale/terraform-provider-exoscale/exoscale/dns_resource.go
+++ b/src/github.com/exoscale/terraform-provider-exoscale/exoscale/dns_resource.go
@@ -66,7 +66,7 @@ func dnsResource() *schema.Resource {
 }
 
 func dnsCreate(d *schema.ResourceData, meta interface{}) error {
-	client := GetClient(DNSEndpoint, meta)
+	client := GetDnsClient(meta)
 
 	domain, err := client.CreateDomain(d.Get("name").(string))
 	if err != nil {
@@ -98,7 +98,7 @@ func dnsCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func dnsRead(d *schema.ResourceData, meta interface{}) error {
-	client := GetClient(DNSEndpoint, meta)
+	client := GetDnsClient(meta)
 
 	domain, err := client.GetDomain(d.Get("name").(string))
 	if err != nil {
@@ -132,7 +132,7 @@ func dnsRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func dnsUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := GetClient(DNSEndpoint, meta)
+	client := GetDnsClient(meta)
 	err := client.DeleteDomain(d.Get("name").(string))
 	if err != nil {
 		return err
@@ -142,7 +142,7 @@ func dnsUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func dnsDelete(d *schema.ResourceData, meta interface{}) error {
-	client := GetClient(DNSEndpoint, meta)
+	client := GetDnsClient(meta)
 
 	err := client.DeleteDomain(d.Get("name").(string))
 	return err

--- a/src/github.com/exoscale/terraform-provider-exoscale/exoscale/provider.go
+++ b/src/github.com/exoscale/terraform-provider-exoscale/exoscale/provider.go
@@ -1,6 +1,7 @@
 package exoscale
 
 import (
+	"fmt"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -24,8 +25,30 @@ func Provider() terraform.ResourceProvider {
 			"timeout": {
 				Type:        schema.TypeInt,
 				Required:    true,
-				DefaultFunc: schema.EnvDefaultFunc("EXOSCALE_TIMEOUT", 60),
-				Description: "Timeout in seconds for waiting on compute resources to become available",
+				DefaultFunc: schema.EnvDefaultFunc("EXOSCALE_TIMEOUT", defaultTimeout),
+				Description: fmt.Sprintf(
+					"Timeout in seconds for waiting on compute resources to become available (by default: %d)",
+					defaultTimeout),
+			},
+			"compute_endpoint": {
+				Type:     schema.TypeString,
+				Required: true,
+				DefaultFunc: schema.MultiEnvDefaultFunc(
+					[]string{"EXOSCALE_COMPUTE_ENDPOINT", "CLOUDSTACK_ENDPOINT"},
+					defaultComputeEndpoint),
+				Description: fmt.Sprintf("Exoscale CloudStack API endpoint (by default: %s)", defaultComputeEndpoint),
+			},
+			"dns_endpoint": {
+				Type:        schema.TypeString,
+				Required:    true,
+				DefaultFunc: schema.EnvDefaultFunc("EXOSCALE_DNS_ENDPOINT", defaultDnsEndpoint),
+				Description: fmt.Sprintf("Exoscale DNS API endpoint (by default: %s)", defaultDnsEndpoint),
+			},
+			"s3_endpoint": {
+				Type:        schema.TypeString,
+				Required:    true,
+				DefaultFunc: schema.EnvDefaultFunc("EXOSCALE_S3_ENDPOINT", defaultS3Endpoint),
+				Description: fmt.Sprintf("Exoscale DNS API endpoint (by default: %s)", defaultS3Endpoint),
 			},
 		},
 
@@ -45,9 +68,12 @@ func Provider() terraform.ResourceProvider {
 
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	baseConfig := BaseConfig{
-		token:   d.Get("token").(string),
-		secret:  d.Get("secret").(string),
-		timeout: d.Get("timeout").(int),
+		token:            d.Get("token").(string),
+		secret:           d.Get("secret").(string),
+		timeout:          d.Get("timeout").(int),
+		compute_endpoint: d.Get("compute_endpoint").(string),
+		dns_endpoint:     d.Get("dns_endpoint").(string),
+		s3_endpoint:      d.Get("s3_endpoint").(string),
 	}
 
 	return baseConfig, nil

--- a/src/github.com/exoscale/terraform-provider-exoscale/exoscale/security_group_resource.go
+++ b/src/github.com/exoscale/terraform-provider-exoscale/exoscale/security_group_resource.go
@@ -91,7 +91,7 @@ func securityGroupResource() *schema.Resource {
 
 func sgCreate(d *schema.ResourceData, meta interface{}) error {
 	var i int
-	client := GetClient(ComputeEndpoint, meta)
+	client := GetComputeClient(meta)
 
 	ingressLength := d.Get("ingress_rules.#").(int)
 	egressLength := d.Get("egress_rules.#").(int)
@@ -148,7 +148,7 @@ func sgCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func sgRead(d *schema.ResourceData, meta interface{}) error {
-	client := GetClient(ComputeEndpoint, meta)
+	client := GetComputeClient(meta)
 	sgs, err := client.GetSecurityGroups()
 	if err != nil {
 		return err
@@ -192,7 +192,7 @@ func sgRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func sgDelete(d *schema.ResourceData, meta interface{}) error {
-	client := GetClient(ComputeEndpoint, meta)
+	client := GetComputeClient(meta)
 	err := client.DeleteSecurityGroup(d.Get("name").(string))
 	if err != nil {
 		return err

--- a/src/github.com/exoscale/terraform-provider-exoscale/exoscale/ssh_resource.go
+++ b/src/github.com/exoscale/terraform-provider-exoscale/exoscale/ssh_resource.go
@@ -35,7 +35,7 @@ func sshResource() *schema.Resource {
 }
 
 func sshCreate(d *schema.ResourceData, meta interface{}) error {
-	client := GetClient(ComputeEndpoint, meta)
+	client := GetComputeClient(meta)
 	name := d.Get("name").(string)
 	found, err := findKey(name, client)
 	if err != nil {
@@ -59,7 +59,7 @@ func sshCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func sshRead(d *schema.ResourceData, meta interface{}) error {
-	client := GetClient(ComputeEndpoint, meta)
+	client := GetComputeClient(meta)
 	name := d.Id()
 	fingerprint, err := findKey(name, client)
 	if err != nil {
@@ -72,7 +72,7 @@ func sshRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func sshDelete(d *schema.ResourceData, meta interface{}) error {
-	client := GetClient(ComputeEndpoint, meta)
+	client := GetComputeClient(meta)
 	name := d.Id()
 	found, err := findKey(name, client)
 	if err != nil {


### PR DESCRIPTION
One can now change those values at will, by default.

```hcl
    provider "exoscale" {
      token = ...
      secret = ...
      host = "api.exoscale.ch"
      scheme = "https"
    }
```

or via the environment using `EXOSCALE_HOST` and `EXOSCALE_SCHEME`.

It doesn't conform to the CloudStack provider... but there is nothing new about it. https://www.terraform.io/docs/providers/cloudstack/index.html