### PR TITLE
ip: import ip resource using the IP address

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.9.5_x1-$(shell git rev-parse --short HEAD)
+VERSION=0.9.5_x-$(shell git rev-parse --short HEAD)
 
 GOOS?=linux
 GOARCH?=amd64

--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ or ```EXOSCALE_API_KEY```.  You can also use the cloudstack environment variable
 ### Compute
 
 ```hcl
-resource "exoscale_compute" "keylabel" {
-    display_name = 
-    template = "Linux Debian 9 64-bit" 
+resource "exoscale_compute" "mymachine" {
+    display_name = "mymachine"
+    template = "Linux Debian 9 64-bit"
     size = "Medium"
     disk_size = 10
     key_pair = "me@mymachine"
@@ -76,8 +76,8 @@ Attributes:
 - **`key_pair`**: name of the SSH key pair to be installed
 - `keyboard`: keyboard configuration (at creation time only)
 - `state`: state of the virtual machine. E.g. `Running` or `Stopped`
-- `affinity_groups`: list of [Affinity Groups][#affinity-groups]
-- `security_groups`: list of [Security Groups][#security-groups]
+- `affinity_groups`: list of [Affinity Groups](#affinity-groups)
+- `security_groups`: list of [Security Groups](#security-groups)
 - `tags`: dictionary of tags (key / value)
 
 Values:
@@ -86,7 +86,7 @@ Values:
 - `ip_address`: IP Address of the main network interface
 - `virtual_machines_id`: list of the Compute instance members of the Affinity Group
 
-### Security Groups
+### Security Group
 
 ```hcl
 resource "exoscale_security_group" "http" {
@@ -120,7 +120,7 @@ Rule attributes:
 - `cidr`: source/destination of the traffic as an IP subnet (conflicts with `user_security_group`)
 - `user_security_group`: source/destination of the traffic as a security group (conflicts with `cidr`)
 
-### (Anti-)Affinity Groups
+### (Anti-)Affinity Group
 
 Define an affinity group. Anti-affinity groups make sure than the virtual machines are not running on the same physical host.
 
@@ -152,6 +152,25 @@ resource "exoscale_ssh" "keylabel" {
 * ```name``` Defines the label in Exoscale to define the key
 * ```key``` The ssh public key that will be copied into instances declared
 
+### Elastic IP address
+
+
+```
+resource "exoscale_ipaddress" "myip" {
+    ip_address = "159.100.251.224"
+    zone = "ch-dk-2"
+}
+```
+
+Attributes:
+
+- **`zone`**: name of [the data-center](https://www.exoscale.ch/infrastructure/datacenters/)
+
+Values:
+
+- `ip_address`: IP address
+
+**NB:** it's possible to `import` the IP address resource using the IP itself rather than the ID.
 
 ### DNS
 

--- a/exoscale/compute_resource.go
+++ b/exoscale/compute_resource.go
@@ -582,8 +582,8 @@ func applyCompute(d *schema.ResourceData, machine egoscale.VirtualMachine) error
 	d.Set("zone", machine.ZoneName)
 	d.Set("state", machine.State)
 
-	if len(machine.Nic) > 0 {
-		d.Set("ip_address", machine.Nic[0].IPAddress)
+	if len(machine.Nic) > 0 && machine.Nic[0].IPAddress != nil {
+		d.Set("ip_address", machine.Nic[0].IPAddress.String())
 	} else {
 		d.Set("ip_address", "")
 	}

--- a/exoscale/nic_resource.go
+++ b/exoscale/nic_resource.go
@@ -149,10 +149,25 @@ func applyNic(d *schema.ResourceData, nic egoscale.Nic) error {
 	d.SetId(nic.ID)
 	d.Set("compute_id", nic.VirtualMachineID)
 	d.Set("network_id", nic.NetworkID)
-	d.Set("ip_address", nic.IPAddress.String())
-	d.Set("netmask", nic.Netmask.String())
-	d.Set("gateway", nic.Gateway.String())
 	d.Set("mac_address", nic.MacAddress)
+
+	if nic.IPAddress != nil {
+		d.Set("ip_address", nic.IPAddress.String())
+	} else {
+		d.Set("ip_address", "")
+	}
+
+	if nic.Netmask != nil {
+		d.Set("netmask", nic.Netmask.String())
+	} else {
+		d.Set("netmask", "")
+	}
+
+	if nic.Gateway != nil {
+		d.Set("gateway", nic.Gateway.String())
+	} else {
+		d.Set("gateway", nic.Gateway.String())
+	}
 
 	return nil
 }

--- a/exoscale/secondaryip_resource.go
+++ b/exoscale/secondaryip_resource.go
@@ -122,7 +122,12 @@ func readSecondaryIP(d *schema.ResourceData, meta interface{}) error {
 	for _, ip := range nics.Nic[0].SecondaryIP {
 		if ip.NicID == nicID {
 			d.SetId(ip.ID)
-			d.Set("ip_address", ip.IPAddress.String())
+			if ip.IPAddress != nil {
+				d.Set("ip_address", ip.IPAddress.String())
+			} else {
+				d.Set("ip_address", "")
+			}
+
 			return nil
 		}
 	}


### PR DESCRIPTION
Importing an Elastic IP address is way easier if it's done using the IP itself rather than the ID.