### PR TITLE
compute: allow security_groups/affinity_groups to be computed

### DIFF
--- a/examples/cloud-init/security_groups.tf
+++ b/examples/cloud-init/security_groups.tf
@@ -19,7 +19,7 @@ resource "exoscale_security_group_rule" "docker_swarm" {
   security_group_id = "${exoscale_security_group.swarm.id}"
   protocol = "TCP"
   type = "INGRESS"
-  user_security_group = "${exoscale_security_group.swarm.id}"
+  user_security_group_id = "${exoscale_security_group.swarm.id}"
   start_port = 2377
   end_port = 2377
 }
@@ -28,7 +28,7 @@ resource "exoscale_security_group_rule" "docker_swarm_nodes_tcp" {
   security_group_id = "${exoscale_security_group.swarm.id}"
   protocol = "TCP"
   type = "INGRESS"
-  user_security_group = "${exoscale_security_group.swarm.id}"
+  user_security_group_id = "${exoscale_security_group.swarm.id}"
   start_port = 7946
   end_port = 7946
 }
@@ -37,7 +37,7 @@ resource "exoscale_security_group_rule" "docker_swarm_nodes_udp" {
   security_group_id = "${exoscale_security_group.swarm.id}"
   protocol = "UDP"
   type = "INGRESS"
-  user_security_group = "${exoscale_security_group.swarm.id}"
+  user_security_group_id = "${exoscale_security_group.swarm.id}"
   start_port = 7946
   end_port = 7946
 }
@@ -46,7 +46,7 @@ resource "exoscale_security_group_rule" "docker_swarm_overlay_net" {
   security_group_id = "${exoscale_security_group.swarm.id}"
   protocol = "UDP"
   type = "INGRESS"
-  user_security_group = "${exoscale_security_group.swarm.id}"
+  user_security_group_id = "${exoscale_security_group.swarm.id}"
   start_port = 4789
   end_port = 4789
 }

--- a/exoscale/compute_resource.go
+++ b/exoscale/compute_resource.go
@@ -93,6 +93,7 @@ func computeResource() *schema.Resource {
 		"affinity_groups": {
 			Type:     schema.TypeSet,
 			Optional: true,
+			Computed: true,
 			Set:      schema.HashString,
 			Elem: &schema.Schema{
 				Type: schema.TypeString,
@@ -101,6 +102,7 @@ func computeResource() *schema.Resource {
 		"security_groups": {
 			Type:     schema.TypeSet,
 			Optional: true,
+			Computed: true,
 			Set:      schema.HashString,
 			Elem: &schema.Schema{
 				Type: schema.TypeString,
@@ -286,13 +288,6 @@ func readCompute(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 	d.Set("disk_size", volume.Size>>30) // B to GiB
-
-	// tags
-	tags := make(map[string]interface{})
-	for _, tag := range machine.Tags {
-		tags[tag.Key] = tag.Value
-	}
-	d.Set("tags", tags)
 
 	return applyCompute(d, *machine)
 }
@@ -585,6 +580,27 @@ func applyCompute(d *schema.ResourceData, machine egoscale.VirtualMachine) error
 	} else {
 		d.Set("ip_address", "")
 	}
+
+	// affinity groups
+	affinityGroups := make([]string, len(machine.AffinityGroup))
+	for i, ag := range machine.AffinityGroup {
+		affinityGroups[i] = ag.Name
+	}
+	d.Set("affinity_groups", affinityGroups)
+
+	// security groups
+	securityGroups := make([]string, len(machine.SecurityGroup))
+	for i, sg := range machine.SecurityGroup {
+		securityGroups[i] = sg.Name
+	}
+	d.Set("security_groups", securityGroups)
+
+	// tags
+	tags := make(map[string]interface{})
+	for _, tag := range machine.Tags {
+		tags[tag.Key] = tag.Value
+	}
+	d.Set("tags", tags)
 
 	// Connection info for the provisioners
 	d.SetConnInfo(map[string]string{


### PR DESCRIPTION
**Issue**

If you created a compute instance without any security groups, it tried to apply an empty state at the next plan operation.

```
  ~ exoscale_compute.ada
      security_groups.#:          "1" => "0"
      security_groups.3814588639: "default" => ""

```

**New behaviour**

It reads the security groups (`Computed`) and allows you to no specify it in the definition.

```
exoscale_compute.ada:
  id = c5690b44-705e-46d1-9808-6e740abe8bde
  affinity_groups.# = 0
  display_name = ada-lovelace
  security_groups.# = 1
  security_groups.3814588639 = default
  ...
```

Look ma', no security groups.

```hcl
resource "exoscale_compute" "ada" {
  #security_groups
}
```