### PR TITLE
compute: key_pair, user_data force new resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ resource "exoscale_compute" "mymachine" {
 Attributes:
 
 - **`display_name`**: initial `hostname`
-- **`template`**: name from [the template](https://www.exoscale.com/templates/) 
+- **`template`**: name from [the template](https://www.exoscale.com/templates/)
 - **`size`**: size of [the instances](https://www.exoscale.com/pricing/#/compute/), e.g. Tiny, Small, Medium, Large, etc.
 - **`disk_size`**: size of the root disk in GiB (at least 10)
 - **`zone`**: name of [the data-center](https://www.exoscale.com/datacenters/)


### PR DESCRIPTION
Trying to update the `user_data` fields causes the backend to crash #68, and it shouldn't be done anyways.

Closes #77 