### PR TITLE
website: boot up

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,304 +16,12 @@ $ terraform providers
 
 Go read the article on our weblog [Terraform on Exoscale](https://www.exoscale.com/syslog/2016/09/14/terraform-with-exoscale/).
 
-## Usage
-
-What follows below is the usage instructions for fully utilizing the Exoscale
-resource plugin.  Additional documentation can be found in the examples directory.
-
-### Provider requirements
-
-```hcl
-provider "exoscale" {
-  version = "~> 0.9"
-  key = "EXO..."
-  secret = "..."
-
-  timeout = 60  # default: waits 60 seconds in total for a resource
-}
-
-# or
-
-provider "exoscale" {
-  version = "~> 0.9"
-
-  config = "cloudstack.ini"   # default: filename
-  profile = "cloudstack"      # default: section name
-}
-```
-
-You are required to provide at least the API key and secret in order
-to make use of the remaining Terraform resources.
-
-The `timeout` is the maximum amount of time (in seconds, default: `60`) to wait
-for async tasks to complete. Currently, this is used during the creation of
-`compute` and `anti-affinity` resources.
-
-### `cloudstack.ini`
-
-```ini
-[cloudstack]
-
-endpoint = "https://api.exoscale.ch/compute"
-key = "EXO..."
-secret = "..."
-```
-
-### Environment variables
-
-You can specify the environment variables for these using
-- **`key`**: ```EXOSCALE_KEY```, ```EXOSCALE_API_KEY```, ```CLOUDSTACK_KEY```, or ```CLOUDSTACK_API_KEY```;
-- **`secret`**: ```EXOSCALE_SECRET```, ```EXOSCALE_SECRET_KEY```, ```CLOUDSTACK_SECRET```, or ```CLOUDSTACK_SECRET_KEY```;
-- **`config`**: ```EXOSCALE_CONFIG```, or ```CLOUDSTACK_CONFIG```;
-- **`profile`**: ```EXOSCALE_PROFILE```, or ```CLOUDSTACK_PROFILE```;
-- **`timeout`**: `EXOSCALE_TIMEOUT` default timeout.
-- **`compute_endpoint`**: ```EXOSCALE_COMPUTE_ENDPOINT```, or ```CLOUDSTACK_ENDPOINT```;
-- **`dns_endpoint`**: ```EXOSCALE_DNS_ENDPOINT```.
 
 ## Resources
 
-### Compute
+The documentation has moved into `website`.
 
-```hcl
-resource "exoscale_compute" "mymachine" {
-  display_name = "mymachine"
-  template = "Linux Debian 9 64-bit"
-  size = "Medium"
-  disk_size = 10
-  key_pair = "me@mymachine"
-  state = "Running"
-
-  affinity_groups = []
-  security_groups = ["default"]
-
-  ip6 = true
-
-  tags {
-    production = "true"
-  }
-
-  timeouts {
-    create = "60m"
-    delete = "2h"
-  }
-}
-```
-
-Attributes:
-
-- **`display_name`**: initial `hostname`
-- **`template`**: name from [the template](https://www.exoscale.com/templates/)
-- **`size`**: size of [the instances](https://www.exoscale.com/pricing/#/compute/), e.g. Tiny, Small, Medium, Large, etc.
-- **`disk_size`**: size of the root disk in GiB (at least 10)
-- **`zone`**: name of [the data-center](https://www.exoscale.com/datacenters/)
-- `user_data`: [cloud-init](http://cloudinit.readthedocs.io/en/latest/) configuration
-- **`key_pair`**: name of the SSH key pair to be installed
-- `keyboard`: keyboard configuration (at creation time only)
-- `state`: state of the virtual machine. E.g. `Running` or `Stopped`
-- `affinity_groups`: list of [Affinity Groups](#affinity-groups)
-- `security_groups`: list of [Security Groups](#security-groups)
-- `tags`: dictionary of tags (key / value)
-- `ip6`: enable IPv6 on the main network interface controller
-
-Values:
-
-- `name`: name of the machine (`hostname`)
-- `ip_address`: IP Address of the main network interface
-- `ip6_address`: IPv6 Address of the main network interface
-
-### Security Group
-
-```hcl
-resource "exoscale_security_group" "http" {
-  name = "HTTP"
-  description = "Long text"
-
-  tags {
-    kind = "web"
-  }
-}
-
-resource "exoscale_security_group_rule" "http" {
-  security_group_id = "${exoscale_security_group.http.id}"
-  protocol = "TCP"
-  type = "INGRESS"
-  cidr = "0.0.0.0/0"
-  start_port = 80
-  end_port = 80
-}
-```
-
-Attributes:
-
-- **`name`**: name of the security group 
-- `description`: longer description
-- `tags`: dictionary of tags (key / value)
-
-Rule attributes:
-
-- **`security_group_id`**: which security group the rule applies to
-- **`protocol`**: the protocol, e.g. `TCP`, `UDP`, `ICMP`, etc.
-- **`type`**: traffic type, either `INGRESS` or `EGRESS`
-- `description`: human description
-- `start_port`, `end_port`: for `TCP`, `UDP` traffic
-- `icmp_type`, `icmp_code`: for `ICMP` traffic
-- `cidr`: source/destination of the traffic as an IP subnet (conflicts with `user_security_group`)
-- `user_security_group`: source/destination of the traffic as a security group (conflicts with `cidr`)
-
-### (Anti-)Affinity Group
-
-Define an affinity group. Anti-affinity groups make sure than the virtual machines are not running on the same physical host.
-
-```hcl
-resource "exoscale_affinity" "affinitylabel" {
-  name = "affinity name"
-  description = "long text"
-  type = "host anti-affinity"
-}
-```
-
-Attributes:
-
-- **`name`**: name of the (anti-)affinity group 
-- `description`: longer descriptions
-- `type`: type of the anti-affinity groups
-
-### SSH Resource
-
-Declare an ssh key that will be used for any current/future instances
-
-```hcl
-resource "exoscale_ssh" "keylabel" {
-  name = "keyname"
-  key = "keycontents"
-}
-```
-
-* ```name``` Defines the label in Exoscale to define the key
-* ```key``` The ssh public key that will be copied into instances declared
-
-### Elastic IP address
-
-```
-resource "exoscale_ipaddress" "myip" {
-  ip_address = "159.100.251.224"
-  zone = "ch-dk-2"
-  tags {
-    usage = "load-balancer"
-  }
-}
-```
-
-Attributes:
-
-- **`zone`**: name of [the data-center](https://www.exoscale.com/datacenters/)
-- `tags`: dictionary of tags (key / value)
-
-Values:
-
-- `ip_address`: IP address
-
-**NB:** it's possible to `import` the IP address resource using the IP itself rather than the ID.
-
-### Secondary IP Address
-
-```hcl
-resource "exoscale_secondary_ipaddress" "" {
-  compute_id = "${exoscale_compute.mymachine.id}"
-  ip_address = "${exoscale_ipaddress.myip.ip_address}"
-}
-```
-
-Attributes:
-
-- **`compute_id`**: id of the [compute resource](#compute)
-- **`ip_address`**: IP address to use, preferably this comes from an [elastic IP](#elastic-ip-address)
-
-Values:
-
-- `nic_id`: id of the NIC
-- `network_id`: id of the Network (of the NIC)
-
-### Network
-
-```hcl
-resource "exoscale_network" "privNet" {
-  name = "myPrivNet"
-  display_text = "description"
-  zone = "ch-dk-2"
-  network_offering = "privNet"
-
-  tags {
-    # ...
-  }
-}
-
-```
-
-Attributes:
-
-- **`name`** name of the network
-- **`display_text`** description of the network
-- `tags`: dictionary of tags (key / value)
-
-## NIC
-
-```hcl
-resource "exoscale_nic" "eth1" {
-  compute_id = "${exoscale_compute.mymachine.id}"
-  network_id = "${exoscale_network.privNet.id}"
-}
-```
-
-Attributes:
-
-- **`compute_id`**: ID of the compute instance
-- **`network_id`**: ID of the network instance
-
-Values:
-
-- `mac_address`: physical address of the network interface
-
-### DNS
-
-```hcl
-resource "exoscale_domain" "exo" {
-  name = "exo.exo"
-}
-
-resource "exoscale_domain_record" "glop" {
-  domain = "${exoscale_domain.exo.id}"
-  name = "glap"
-  record_type = "CNAME"
-  content = "${exoscale_domain.exo.name}"
-}
-```
-
-Attributes:
-
-- **`name`**: domain name
-
-Values:
-
-- `token`
-- `state`
-- `auto_renew`
-- `expires_on`
-
-Record attributes:
-
-- **`domain`**: domain it's linked to
-- **`name`**: name of the DNS record
-- **`record_type`**: type of the DNS record. E.g. `A`, `CNAME`, `MX`, etc.
-- **`content`**: value of the DNS record
-- `ttl`: time to live
-- `prio`: priority
-
-Record values:
-
-- `hostname`: full name, useful for linking `A` records into `CNAME`.
-
-### Storage on S3
+## Storage on S3
 
 ```hcl
 terraform = {
@@ -337,18 +45,24 @@ terraform = {
 }
 ```
 
-## Building
+## Contributing
+
+Contributions are welcome and we encourage you to build the provider locally
+before sending a pull request.
+
+### Building
 
 ```
 $ git clone https://github.com/exoscale/terraform-provider-exoscale
 $ cd terraform-provider-exoscale
 $ make build
 
-# making a release (for Exoscale staff)
+# making a release (for Exoscale staff only)
 $ make release
 ```
 
 ### Development
+
 ```
 # quick build of the provider
 $ make

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -1,0 +1,86 @@
+---
+layout: "exoscale"
+page_title: "Provider: Exoscale"
+sidebar-current: "docs-exoscale-index"
+description: |-
+  The Exoscale provider is used to interact with the many resources offered by Exoscale.com. The provider needs to be configured with the proper credentials before it can be used.
+---
+
+# Exoscale Provider
+
+## Usage
+
+What follows below is the usage instructions for fully utilizing the Exoscale
+resource plugin.  Additional documentation can be found in the examples directory.
+
+### Provider requirements
+
+```hcl
+provider "exoscale" {
+  version = "~> 0.9"
+  key = "EXO..."
+  secret = "..."
+
+  timeout = 60  # default: waits 60 seconds in total for a resource
+  delay = 5     # default: waits 5 seconds between each poll request
+}
+
+# or
+
+provider "exoscale" {
+  version = "~> 0.9"
+
+  config = "cloudstack.ini"   # default: filename
+  profile = "cloudstack"      # default: section name
+}
+```
+
+You are required to provide at least the API token and secret key in order
+to make use of the remaining Terraform resources.
+
+The `timeout` is the maximum amount of time (in seconds, default: `60`) to wait
+for async tasks to complete. Currently, this is used during the creation of
+`compute` and `anti-affinity` resources.
+
+### `cloudstack.ini`
+
+```ini
+[cloudstack]
+
+endpoint = "https://api.exoscale.ch/compute"
+key = "EXO..."
+token = "..."
+```
+
+### Environment variables
+
+You can specify the following keys using those environment variables.
+
+- `key` - `EXOSCALE_KEY`, `EXOSCALE_API_KEY`, `CLOUDSTACK_KEY`, or `CLOUDSTACK_API_KEY`;
+
+- `secret` - `EXOSCALE_SECRET`, `EXOSCALE_SECRET_KEY`, `CLOUDSTACK_SECRET`, or `CLOUDSTACK_SECRET_KEY`;
+
+- `config` - `EXOSCALE_CONFIG`, or `CLOUDSTACK_CONFIG`;
+
+- `profile` - `EXOSCALE_PROFILE`, or `CLOUDSTACK_PROFILE`;
+
+- `timeout` - `EXOSCALE_TIMEOUT` global timeout;
+
+- `compute_endpoint` - `EXOSCALE_COMPUTE_ENDPOINT`, or `CLOUDSTACK_ENDPOINT`;
+
+- `dns_endpoint` - `EXOSCALE_DNS_ENDPOINT`.
+
+## Timeouts
+
+All resources support controlling the waiting time of the four basic operations.
+
+```hcl
+resource "exoscale_..." "name" {
+  timeouts {
+    create = "1m"
+    read = "2m"
+    update = "3m"
+    delete = "4m"
+  }
+}
+```

--- a/website/docs/r/affinity_group.html.markdown
+++ b/website/docs/r/affinity_group.html.markdown
@@ -1,0 +1,49 @@
+---
+layout: "exoscale"
+page_title: "Exoscale: exoscale_affinity_group"
+sidebar_current: "docs-exoscale-affinity-group"
+description: |-
+  Manages an affinity group.
+---
+
+# exoscale_affinity_group
+
+Define an Affinity Group. `host anti-affinity` groups make sure than the virtual machines are not running on the same physical host.
+
+## Example Usage
+
+```hcl
+resource "exoscale_affinity" "affinitylabel" {
+  name = "affinity name"
+  description = "long text"
+  type = "host anti-affinity"
+}
+```
+
+## Argument Reference
+
+- `name` - (Required) name of the (anti-)Affinity Group.
+
+- `description` - longer description.
+
+- `type` - type of the Affinity Group. By default: `host anti-affinity`.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+- `id` - The id of the Affinity Group.
+
+- `virtual_machine_ids` - The id of the compute resources member of the Affinity Group.
+
+## Import
+
+Importing an Affinity Group resource is possible by name or id.
+
+```shell
+# by name
+$ terraform import exoscale_affinity_group.mygroup mygroup
+
+# by id
+$ terraform import exoscale_affinity_group.mygroup eb556678-ec59-4be6-8c54-0406ae0f6da6
+```

--- a/website/docs/r/compute.html.markdown
+++ b/website/docs/r/compute.html.markdown
@@ -1,0 +1,96 @@
+---
+layout: "exoscale"
+page_title: "Exoscale: exoscale_compute"
+sidebar_current: "docs-exoscale-compute"
+description: |-
+  Manages a compute resource.
+---
+
+# exoscale_compute
+
+Exoscale computing service allows you to create a performant
+cloud virtual machine in less than 35 seconds.
+
+## Example Usage
+
+```hcl
+resource "exoscale_compute" "mymachine" {
+  display_name = "mymachine"
+  template = "Linux Debian 9 64-bit"
+  size = "Medium"
+  disk_size = 10
+  key_pair = "me@mymachine"
+  state = "Running"
+
+  affinity_groups = []
+  security_groups = ["default"]
+
+  ip6 = false
+
+  tags {
+    production = "true"
+  }
+
+  timeouts {
+    create = "60m"
+    delete = "2h"
+  }
+}
+```
+
+## Argument Reference
+
+- `display_name` - (Required) initial `hostname`
+
+- `template` - (Required) name from [the template](https://www.exoscale.com/templates/)
+
+- `size` - (Required) size of [the instances](https://www.exoscale.com/pricing/#/compute/),
+              e.g. Tiny, Small, Medium, Large, etc.
+
+- `disk_size` - (Required) size of the root disk in GiB (at least 10)
+
+- `zone` - (Required) name of [the data-center](https://www.exoscale.com/datacenters/)
+
+- `user_data` - [cloud-init](http://cloudinit.readthedocs.io/en/latest/) configuration
+
+- `key_pair` - (Required) name of the SSH key pair to be installed
+
+- `keyboard` - keyboard configuration (at creation time only)
+
+- `state` - state of the virtual machine. E.g. `Running` or `Stopped`
+
+- `affinity_groups` - list of [Affinity Groups](affinity_group.html)
+
+- `security_groups` - list of [Security Groups](security_group.html)
+
+- `ip4` - activate IPv4 (only `true`)
+
+- `ip6` - activate IPv6 (`false` by default)
+
+- `tags` - dictionary of tags (key / value)
+
+## Attributes Reference
+
+- `name` - name of the machine (`hostname`)
+
+- `username` - User to connect when using SSH
+
+- `password` - Initial password and/or encrypted password
+
+- `ip_address` - IP Address of the main network interface
+
+- `ip6_address` - IPv6 Address of the main network interface
+
+## Import
+
+Importing Compute resource imports the compute has well as the
+[`exoscale_secondary_ipaddress`](secondary_ipaddress.html) and
+[`exoscale_nic`](nic.html).
+
+```shell
+# by name
+$ terraform import exoscale_compute.VM-1 default
+
+# by id
+$ terraform import exoscale_compute.VM-1 eb556678-ec59-4be6-8c54-0406ae0f6da6
+```

--- a/website/docs/r/domain.html.markdown
+++ b/website/docs/r/domain.html.markdown
@@ -1,0 +1,44 @@
+---
+layout: "exoscale"
+page_title: "Exoscale: exoscale_domain"
+sidebar_current: "docs-exoscale-domain"
+description: |-
+  Manages a domain.
+---
+
+# exoscale_domain
+
+Define a domain in the sense of a website address.
+
+## Usage example
+
+```hcl
+resource "exoscale_domain" "exo" {
+  name = "exo.exo"
+}
+```
+
+## Argument Reference
+
+- `name` - (Required) name of the domain.
+
+
+## Attributes Reference
+
+The following attributes are exported:
+
+- `token` - this token serves as an alternative way to manages the domain records
+
+- `state`
+
+- `auto_renew`
+
+- `expires_on` - date of expiration, if known
+
+## Import
+
+Importing a domain will import all the records (but `NS` and `SOA`).
+
+```shell
+$ terraform import exoscale_domain.exoscale-ch exoscale.ch
+```

--- a/website/docs/r/domain_record.html.markdown
+++ b/website/docs/r/domain_record.html.markdown
@@ -1,0 +1,44 @@
+---
+layout: "exoscale"
+page_title: "Exoscale: exoscale_domain_record"
+sidebar_current: "docs-exoscale-domain-record"
+description: |-
+  Manages a domain record
+---
+
+# exoscale_domain_record
+
+Defines a DNS entry linked with a domain.
+
+## Usage example
+
+```hcl
+resource "exoscale_domain_record" "glop" {
+  domain = "${exoscale_domain.exo.id}"
+  name = "glap"
+  record_type = "CNAME"
+  content = "${exoscale_domain.exo.name}"
+}
+```
+
+## Argument Reference
+
+- `domain` - (Required) domain it's linked to
+
+- `name` - (Required) name of the DNS record
+
+- `record_type` - (Required) type of the DNS record. E.g. `A`, `CNAME`, `MX`, etc.
+
+- `content` - (Required) value of the DNS record
+
+- `ttl` - time to live
+
+- `prio` - priority
+
+## Attributes Reference
+
+- `hostname` - full name, useful for linking `A` records into `CNAME`.
+
+## Import
+
+A record is imported with its domain resource.

--- a/website/docs/r/ipaddress.html.markdown
+++ b/website/docs/r/ipaddress.html.markdown
@@ -1,0 +1,46 @@
+---
+layout: "exoscale"
+page_title: "Exoscale: exoscale_ipaddress"
+sidebar_current: "docs-exoscale-ipaddress"
+description: |-
+  Manages an elastic IP address.
+---
+
+# exoscale_ipaddress
+
+The elastic IP address is an address that belongs to a specific zone and may be
+attributed to many compute. See [public_ipaddress](public_ipaddress.html).
+
+### Usage example
+
+```
+resource "exoscale_ipaddress" "myip" {
+  zone = "ch-dk-2"
+  tags {
+    usage = "load-balancer"
+  }
+}
+```
+
+## Argument Reference
+
+- `zone` - (Required) name of [the data-center](https://www.exoscale.com/datacenters/)
+
+- `tags` - dictionary of tags (key / value)
+
+## Attributes Reference
+
+- `ip_address` - IP address
+
+
+## Import
+
+Importing an Elastic IP resource is possible by name or id.
+
+```shell
+# by name
+$ terraform import exoscale_ipaddress.myip 159.100.251.224
+
+# by id
+$ terraform import exoscale_ipaddress.myip eb556678-ec59-4be6-8c54-0406ae0f6da6
+```

--- a/website/docs/r/network.html.markdown
+++ b/website/docs/r/network.html.markdown
@@ -1,0 +1,48 @@
+---
+layout: "exoscale"
+page_title: "Exoscale: exoscale_network"
+sidebar_current: "docs-exoscale-network"
+description: |-
+  Manages a private network.
+---
+
+# exoscale_network
+
+
+## Usage
+
+```hcl
+resource "exoscale_network" "privNet" {
+  name = "myPrivNet"
+  display_text = "description"
+  zone = "ch-dk-2"
+  network_offering = "privNet"
+
+  tags {
+    # ...
+  }
+}
+```
+
+## Argument Reference
+
+- `name` - (Required) name of the network
+
+- `display_text` - (Required) description of the network
+
+- `network_offering` - (Required) network offering name
+
+- `zone` - (Required) name of the zone
+
+- `tags` - dictionary of tags (key / value)
+
+
+## Import
+
+```shell
+# by name
+$ terraform import exoscale_network.net myPrivNet
+
+# by id
+$ terraform import exoscale_network.net ID
+```

--- a/website/docs/r/nic.html.markdown
+++ b/website/docs/r/nic.html.markdown
@@ -1,0 +1,33 @@
+---
+layout: "exoscale"
+page_title: "Exoscale: exoscale_nic"
+sidebar_current: "docs-exoscale-nic"
+description: |-
+  Manages a compute NIC
+---
+
+# exoscale_nic
+
+
+## Usage
+
+```hcl
+resource "exoscale_nic" "eth1" {
+  compute_id = "${exoscale_compute.mymachine.id}"
+  network_id = "${exoscale_network.privNet.id}"
+}
+```
+
+## Argument Reference
+
+- `compute_id` - (Required) identifier of the compute resource
+
+- `network_id` - (Required) identifier of the private network
+
+## Attributes Reference
+
+- `mac_address` - physical address of the network interface
+
+## Import
+
+This resource is automatically imported when you import a compute resource.

--- a/website/docs/r/secondary_ipaddress.html.markdown
+++ b/website/docs/r/secondary_ipaddress.html.markdown
@@ -1,0 +1,40 @@
+---
+layout: "exoscale"
+page_title: "Exoscale: exoscale_secondary_ipaddress"
+sidebar_current: "docs-exoscale-secondary-ipaddress"
+description: |-
+  Manages an elastic IP address assignement to a compute resource
+---
+
+# exoscale_secondary_ipaddress
+
+A Secondary IP Address expresses the attribution of an extra IP address to a
+compute resource.
+
+~> **NOTE** The network interfaces of the compute resource itself still have
+to be configured accordingly.
+
+### Secondary IP Address
+
+```hcl
+resource "exoscale_secondary_ipaddress" "" {
+  compute_id = "${exoscale_compute.mymachine.id}"
+  ip_address = "${exoscale_ipaddress.myip.ip_address}"
+}
+```
+
+## Argument Reference
+
+- `compute_id` - (Required) id of the [compute resource](compute.html)
+
+- `ip_address` - (Required) IP address to use, preferably this comes from an [elastic IP](ip_address.html)
+
+## Attributes Reference
+
+- `nic_id`: id of the NIC
+
+- `network_id`: id of the Network (of the NIC)
+
+## Import
+
+This resource is automatically imported when you import a compute resource.

--- a/website/docs/r/security_group.html.markdown
+++ b/website/docs/r/security_group.html.markdown
@@ -1,0 +1,47 @@
+---
+layout: "exoscale"
+page_title: "Exoscale: exoscale_security_group"
+sidebar_current: "docs-exoscale-security-group"
+description: |-
+  Manages a security group.
+---
+
+# exoscale_security_group
+
+Security Groups allow you to define and compose firewall rules
+making it easy to manage incoming and outgoing traffic. They
+offer the best way to 
+
+## Example usage
+
+```hcl
+resource "exoscale_security_group" "http" {
+  name = "HTTP"
+  description = "Long text"
+
+  tags {
+    kind = "web"
+  }
+}
+```
+
+## Argument Reference
+
+- `name` - (Required) name of the security group
+
+- `description` - longer description
+
+- `tags` - dictionary of tags (key / value)
+
+## Import
+
+Importing a Security Group resource imports it and the linked
+[`exoscale_security_group_rule`](security_group_rule.html).
+
+```shell
+# by name
+$ terraform import exoscale_security_group.http http
+
+# by id
+$ terraform import exoscale_security_group.http eb556678-ec59-4be6-8c54-0406ae0f6da6
+```

--- a/website/docs/r/security_group_rule.html.markdown
+++ b/website/docs/r/security_group_rule.html.markdown
@@ -1,0 +1,57 @@
+---
+layout: "exoscale"
+page_title: "Exoscale: exoscale_security_group_rule"
+sidebar_current: "docs-exoscale-security-group_rule"
+description: |-
+  Manages a rule to a security group.
+---
+
+# exoscale_security_group_rule
+
+A security group rule represents a single `ingress` or `egress` rule which has
+to be linked with to `exoscale_security_group`.
+
+## Example usage
+
+```hcl
+resource "exoscale_security_group_rule" "http" {
+  security_group_id = "${exoscale_security_group.http.id}"
+  protocol = "TCP"
+  type = "INGRESS"
+  cidr = "0.0.0.0/0"
+  start_port = 80
+  end_port = 80
+}
+```
+
+## Argument Reference
+
+- `security_group_id` - (Required) which security group by name the rule applies to
+
+- `security_group` - (Required) which security group by id the rule applies to
+
+- `protocol` - (Required) the protocol, e.g. `TCP`, `UDP`, `ICMP`, etc.
+
+- `type` - (Required) traffic type, either `INGRESS` or `EGRESS`
+
+- `description` - human description
+
+- `start_port`, `end_port` - for `TCP`, `UDP` traffic
+
+- `icmp_type`, `icmp_code` - for `ICMP` traffic
+
+- `cidr` - source/destination of the traffic as an IP subnet (conflicts with `user_security_group`)
+
+- `user_security_group_id` - source/destination of the traffic as a security group by id (conflicts with `cidr`)
+
+- `user_security_group` - source/destination of the traffic as a security group by name (conflicts with `cidr`)
+
+## Attributes Reference
+
+- `security_group` - Name of the security group
+
+- `security_group_id` - Identifier of the security group
+
+- `user_security_group` - Name of the source/destination security group
+
+- `user_security_group_id` - Identifer of the source/destination security group

--- a/website/docs/r/ssh_keypair.html.markdown
+++ b/website/docs/r/ssh_keypair.html.markdown
@@ -1,0 +1,41 @@
+---
+layout: "exoscale"
+page_title: "Exoscale: exoscale_ssh_keypair"
+sidebar_current: "docs-exoscale-ssh-keypair"
+description: |-
+  Manages an SSH key pair.
+---
+
+# exoscale_ssh_keypair
+
+Declare an SSH key that will be used for any compute instances.
+
+## Example Usage
+
+```hcl
+resource "exoscale_ssh_keypair" "keylabel" {
+  name = "keyname"
+  public_key = "keycontents"
+}
+```
+
+## Argument Reference
+
+- `name` - (Required) Defines the label in Exoscale to identify the key
+
+- `public_key` - the SSH public key that will be copied into the instances at **first** boot. If not `public_key` is provided, a `public_key` is saved locally
+
+## Attributes Reference
+
+- `fingerprint` - the unique identifier of the SSH Key Pair
+
+- `public_key` - if no public key was provided, this has been generated
+
+- `private_key` - if no public key was provided and a key was generated
+
+## Import
+
+```shell
+# by name
+$ terraform import exoscale_ssh_keypair.mykeypair name
+```

--- a/website/exoscale.erb
+++ b/website/exoscale.erb
@@ -1,0 +1,65 @@
+<% wrap_layout :inner do %>
+    <% content_for :sidebar do %>
+        <div class="docs-sidebar hidden-print affix-top" role="complimentary">
+            <ul class="nav docs-sidenav">
+                <li<%= sidebar_current("docs-home") %>>
+                    <a href="/docs/providers/index.html">All Providers</a>
+                </li>
+
+                <li<%= sidebar_current("docs-exoscale-index") %>>
+                    <a href="/docs/providers/exoscale/index.html">Exoscale Provider</a>
+                </li>
+
+                <li<%= sidebar_current("docs-exoscale-resource") %>>
+                    <a href="#">Resources</a>
+                    <ul class="nav nav-visible">
+                        <li<% sidebar_current("docs-exoscale-affinity-group") %>>
+                            <a href="/docs/providers/exoscale/r/affinity_group.html">exoscale_affinity_group</a>
+                        </li>
+
+                        <li<% sidebar_current("docs-exoscale-compute") %>>
+                            <a href="/docs/providers/exoscale/r/compute.html">exoscale_compute</a>
+                        </li>
+
+                        <li<% sidebar_current("docs-exoscale-domain") %>>
+                            <a href="/docs/providers/exoscale/r/domain.html">exoscale_domain</a>
+                        </li>
+
+                        <li<% sidebar_current("docs-exoscale-domain-record") %>>
+                            <a href="/docs/providers/exoscale/r/domain_record.html">exoscale_domain_record</a>
+                        </li>
+
+                        <li<% sidebar_current("docs-exoscale-ipaddress") %>>
+                            <a href="/docs/providers/exoscale/r/ipaddress.html">exoscale_ipaddress</a>
+                        </li>
+
+                        <li<% sidebar_current("docs-exoscale-network") %>>
+                            <a href="/docs/providers/exoscale/r/network.html">exoscale_network</a>
+                        </li>
+
+                        <li<% sidebar_current("docs-exoscale-nic") %>>
+                            <a href="/docs/providers/exoscale/r/nic.html">exoscale_nic</a>
+                        </li>
+
+                        <li<% sidebar_current("docs-exoscale-security-group") %>>
+                            <a href="/docs/providers/exoscale/r/security_group.html">exoscale_security_group</a>
+                        </li>
+
+                        <li<% sidebar_current("docs-exoscale-security-group-rule") %>>
+                            <a href="/docs/providers/exoscale/r/security_group_rule.html">exoscale_security_group_rule</a>
+                        </li>
+
+                        <li<% sidebar_current("docs-exoscale-secondary-ipaddress") %>>
+                            <a href="/docs/providers/exoscale/r/secondary_ipaddress.html">exoscale_secondary_ipaddress</a>
+                        </li>
+
+                        <li<% sidebar_current("docs-exoscale-ssh-keypair") %>>
+                            <a href="/docs/providers/exoscale/r/ssh_keypair.html">exoscale_ssh_keypair</a>
+                        </li>
+                    </ul>
+                </li>
+            </ul>
+        </div>
+    <% end %>
+    <%= yield %>
+<% end %>


### PR DESCRIPTION
Any official provider handles the website documentation locally. For the 1.0, release.

- [x] menu
- [x] provider
- [x] affinity_group
- [x] compute
- [x] domain
- [x] domain-record
- [x] ipaddress
- [x] network
- [x] nic
- [x] security group
- [x] security group rule
- [x] secondary ip address
- [x] ssh keypair (Requires #87)