### PR TITLE
provider: deprecated token

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ resource plugin.  Additional documentation can be found in the examples director
 ```hcl
 provider "exoscale" {
   version = "~> 0.9"
-  token = "EXO..."
+  key = "EXO..."
   secret = "..."
 
   timeout = 60  # default: waits 60 seconds in total for a resource
@@ -43,7 +43,7 @@ provider "exoscale" {
 }
 ```
 
-You are required to provide at least the API token and secret key in order
+You are required to provide at least the API key and secret in order
 to make use of the remaining Terraform resources.
 
 The `timeout` is the maximum amount of time (in seconds, default: `60`) to wait
@@ -63,7 +63,7 @@ secret = "..."
 ### Environment variables
 
 You can specify the environment variables for these using
-- **`token`**: ```EXOSCALE_KEY```, ```EXOSCALE_API_KEY```, ```CLOUDSTACK_KEY```, or ```CLOUDSTACK_API_KEY```;
+- **`key`**: ```EXOSCALE_KEY```, ```EXOSCALE_API_KEY```, ```CLOUDSTACK_KEY```, or ```CLOUDSTACK_API_KEY```;
 - **`secret`**: ```EXOSCALE_SECRET```, ```EXOSCALE_SECRET_KEY```, ```CLOUDSTACK_SECRET```, or ```CLOUDSTACK_SECRET_KEY```;
 - **`config`**: ```EXOSCALE_CONFIG```, or ```CLOUDSTACK_CONFIG```;
 - **`profile`**: ```EXOSCALE_PROFILE```, or ```CLOUDSTACK_PROFILE```;

--- a/examples/cloud-init/config.tf
+++ b/examples/cloud-init/config.tf
@@ -3,7 +3,7 @@ provider "template" {
 }
 
 provider "exoscale" {
-  version = "~> 0.9"
-  token = "${var.token}"
+  version = "~> 0.9.13"
+  key = "${var.key}"
   secret = "${var.secret}"
 }

--- a/examples/cloud-init/terraform.tfvars.example
+++ b/examples/cloud-init/terraform.tfvars.example
@@ -1,5 +1,5 @@
 # API Key
-token = "EXO..."
+key = "EXO..."
 # Secret Key
 secret = "..."
 # SSH Key pair

--- a/examples/cloud-init/variables.tf
+++ b/examples/cloud-init/variables.tf
@@ -1,4 +1,4 @@
-variable "token" {}
+variable "key" {}
 variable "secret" {}
 variable "key_pair" {}
 

--- a/examples/import-compute/config.tf
+++ b/examples/import-compute/config.tf
@@ -1,5 +1,5 @@
 provider "exoscale" {
-  version = "~> 0.9"
-  token = "${var.token}"
+  version = "~> 0.9.13"
+  key = "${var.key}"
   secret = "${var.secret}"
 }

--- a/examples/import-compute/terraform.tfvars.example
+++ b/examples/import-compute/terraform.tfvars.example
@@ -1,4 +1,4 @@
 # API Key
-token = "EXO..."
+key = "EXO..."
 # Secret Key
 secret = "..." 

--- a/examples/import-compute/variables.tf
+++ b/examples/import-compute/variables.tf
@@ -1,2 +1,2 @@
-variable "token" {}
+variable "key" {}
 variable "secret" {}

--- a/examples/multi-private-network/main.tf
+++ b/examples/multi-private-network/main.tf
@@ -3,7 +3,7 @@ provider "template" {
 }
 
 provider "exoscale" {
-  version = "~> 0.9.8"
-  token = "${var.token}"
+  version = "~> 0.9.13"
+  key = "${var.key}"
   secret = "${var.secret}"
 }

--- a/examples/multi-private-network/terraform.tfvars.example
+++ b/examples/multi-private-network/terraform.tfvars.example
@@ -1,5 +1,5 @@
 # API Key
-token = "EXO..."
+key = "EXO..."
 # Secret Key
 secret = "..."
 # SSH Key pair

--- a/examples/multi-private-network/variables.tf
+++ b/examples/multi-private-network/variables.tf
@@ -1,5 +1,6 @@
-variable "token" {}
+variable "key" {}
 variable "secret" {}
+
 variable "key_pair" {}
 
 variable "zone" {

--- a/exoscale/client.go
+++ b/exoscale/client.go
@@ -13,7 +13,7 @@ const defaultDelayBeforeRetry = 5 // seconds
 
 // BaseConfig represents the provider structure
 type BaseConfig struct {
-	token           string
+	key             string
 	secret          string
 	timeout         int
 	computeEndpoint string
@@ -24,7 +24,7 @@ type BaseConfig struct {
 
 func getClient(endpoint string, meta interface{}) *egoscale.Client {
 	config := meta.(BaseConfig)
-	return egoscale.NewClient(endpoint, config.token, config.secret)
+	return egoscale.NewClient(endpoint, config.key, config.secret)
 }
 
 // GetComputeClient builds a CloudStack client


### PR DESCRIPTION
`s/token/key/`

> Warning: provider.exoscale: "token": [DEPRECATED] Use key instead

And the loading of the ini files is more verbose.

> * provider.exoscale: Config file not loaded: open /home/yoan/exoscale/terraform-provider-exoscale/examples/import-compute/clou
dstack.ini: no such file or directory 

> * provider.exoscale: Config file not loaded: open /home/yoan/ex0scale/cs/cloudstack.ini: no such file or directory
