### PR TITLE
fix empty tags after creation

### DIFF
--- a/exoscale/compute_resource.go
+++ b/exoscale/compute_resource.go
@@ -329,7 +329,7 @@ func createCompute(d *schema.ResourceData, meta interface{}) error {
 	d.Set("username", username)
 	d.Set("password", password)
 
-	return applyCompute(d, &machine)
+	return readCompute(d, meta)
 }
 
 func existsCompute(d *schema.ResourceData, meta interface{}) (bool, error) {
@@ -654,7 +654,7 @@ func deleteCompute(d *schema.ResourceData, meta interface{}) error {
 }
 
 func importCompute(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutRead))
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
 	defer cancel()
 
 	client := GetComputeClient(meta)

--- a/exoscale/ip_resource.go
+++ b/exoscale/ip_resource.go
@@ -88,7 +88,7 @@ func createElasticIP(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	return applyElasticIP(d, elasticIP)
+	return readElasticIP(d, meta)
 }
 
 func existsElasticIP(d *schema.ResourceData, meta interface{}) (bool, error) {

--- a/exoscale/security_group_resource.go
+++ b/exoscale/security_group_resource.go
@@ -78,7 +78,7 @@ func createSecurityGroup(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	return applySecurityGroup(d, &sg)
+	return readSecurityGroup(d, meta)
 }
 
 func existsSecurityGroup(d *schema.ResourceData, meta interface{}) (bool, error) {
@@ -160,7 +160,9 @@ func deleteSecurityGroup(d *schema.ResourceData, meta interface{}) error {
 }
 
 func importSecurityGroup(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutRead))
+	// XXX d.Timeout will result in a null pointer exception
+	// https://github.com/hashicorp/terraform/issues/17672
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
 	defer cancel()
 
 	client := GetComputeClient(meta)


### PR DESCRIPTION
tags weren't correctly set on a freshly created instance.

identified via the acceptance tests