### PR TITLE
Network example: use PrivNet instead of privNet

### DIFF
--- a/website/docs/r/network.html.markdown
+++ b/website/docs/r/network.html.markdown
@@ -16,7 +16,7 @@ resource "exoscale_network" "privNet" {
   name = "myPrivNet"
   display_text = "description"
   zone = "ch-dk-2"
-  network_offering = "privNet"
+  network_offering = "PrivNet"
 
   tags {
     # ...


### PR DESCRIPTION
When `network_offering` is set to `privNet`, Terraform constantly tries to update it from `PrivNet` to `privNet`, e.g:

```
  ~ exoscale_network.production
      network_offering: "PrivNet" => "privNet"
```