### PR TITLE
add SOS backend example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -57,6 +57,10 @@ Using the [Terraform AWS Provider](https://www.terraform.io/docs/providers/aws/)
 
 A sample single node Kubernetes cluster to act as a [Minikube][minikube] on Exoscale.
 
+## [SOS Terraform Backend](sos-backend)
+
+Using an Exoscale SOS bucket to persist `.tfstate` changes.
+
 ## External examples
 
 - Oliver Moser's: [Prometheus Service Discovery Demo](https://github.com/olmoser/infracoders-reloaded)

--- a/examples/sos-backend/README.md
+++ b/examples/sos-backend/README.md
@@ -1,0 +1,13 @@
+# SOS as a Terraform Backend
+
+This example implements the [Terraform S3 backend](https://www.terraform.io/docs/backends/types/s3.html) to persist `.tfstate` in an [SOS](https://community.exoscale.com/api/sos/) bucket.
+
+Create a new SOS bucket to hold your `.tfstate` and update the backend `bucket` parameter accordingly.
+
+The S3 backend is coupled to some AWS-specific nomenclature such that in order to authenticate your `terraform` commands, you'll have to bind `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` to your Exoscale API key + secret.
+
+```
+$ export AWS_ACCESS_KEY_ID=$EXOSCALE_API_KEY
+$ export AWS_SECRET_ACCESS_KEY=$EXOSCALE_API_SECRET
+$ terraform init
+```

--- a/examples/sos-backend/main.tf
+++ b/examples/sos-backend/main.tf
@@ -1,0 +1,23 @@
+provider "exoscale" {
+  version = "~> 0.12.1"
+  key     = "${var.key}"
+  secret  = "${var.secret}"
+}
+
+
+terraform {
+  backend "s3" {
+    bucket   = "example-provisioning-bucket"
+    key      = "terraform.tfstate"
+    region   = "ch-gva-2"
+    endpoint = "https://sos-ch-gva-2.exo.io"
+
+    # Skip AWS-specific local config validation
+    # https://www.terraform.io/docs/backends/types/s3.html#skip_credentials_validation
+    #
+    # Skip AWS IAM validation
+    skip_credentials_validation = true
+    # Skip AWS region validation
+    skip_region_validation = true
+  }
+}

--- a/examples/sos-backend/variables.tf
+++ b/examples/sos-backend/variables.tf
@@ -1,0 +1,2 @@
+variable "key" {}
+variable "secret" {}


### PR DESCRIPTION
I figured this out on my own so I thought I'd contribute it.

Let me know if you'd like this documented in the top-level terraform-provider-exoscale docs.