### PR TITLE
compute: replace template attribute with template_id

### DIFF
--- a/examples/cloud-init/instances.tf
+++ b/examples/cloud-init/instances.tf
@@ -3,10 +3,15 @@ resource "exoscale_affinity" "swarm_manager" {
   description = "keep the swarm managers on different hypervisors"
 }
 
+data "exoscale_compute_template" "master" {
+  zone = "${var.zone}"
+  name = "${var.template}"
+}
+
 resource "exoscale_compute" "master" {
   count = "${length(var.hostnames)}"
   display_name = "${element(var.hostnames, count.index)}"
-  template = "${var.template}"
+  template_id = "${data.exoscale_compute_template.master.id}"
   zone = "${var.zone}"
   size = "Medium"
   disk_size = 50

--- a/examples/elastic-ip/main.tf
+++ b/examples/elastic-ip/main.tf
@@ -8,6 +8,11 @@ provider "exoscale" {
   secret = "${var.secret}"
 }
 
+data "exoscale_compute_template" "ubuntu" {
+  zone = "${var.zone}"
+  name = "Linux Ubuntu 18.04 LTS 64-bit"
+}
+
 resource "exoscale_ipaddress" "ingress" {
   zone = "${var.zone}"
 }
@@ -22,7 +27,7 @@ data "template_file" "cloudinit" {
 
 resource "exoscale_compute" "machine" {
   display_name = "machine"
-  template = "Linux Ubuntu 18.04 LTS 64-bit"
+  template_id = "${data.exoscale_compute_template.ubuntu.id}"
   size = "Medium"
   disk_size = "22"
   key_pair = "${var.key_pair}"

--- a/examples/exokube/main.tf
+++ b/examples/exokube/main.tf
@@ -8,12 +8,17 @@ provider "exoscale" {
   secret = "${var.secret}"
 }
 
+data "exoscale_compute_template" "exokube" {
+  zone = "${var.zone}"
+  name = "${var.template}"
+}
+
 resource "exoscale_compute" "exokube" {
   display_name = "exokube"
   size = "Medium"
   disk_size = 50
   zone = "${var.zone}"
-  template = "${var.template}"
+  template_id = "${data.exoscale_compute_template.exokube.id}"
   key_pair = "${var.key_pair}"
   ip6 = true
 

--- a/examples/import-compute/instances.tf
+++ b/examples/import-compute/instances.tf
@@ -1,9 +1,14 @@
+data "exoscale_compute_template" "debian" {
+  zone = "ch-dk-2"
+  name = "Linux Debian 9 64-bit"
+}
+
 resource "exoscale_compute" "ada" {
   display_name = "ada-lovelace"
   key_pair = "my@keypair"
   disk_size = 10
   size = "Tiny"
-  template = "Linux Debian 9 64-bit"
+  template_id = "${data.exoscale_compute_template.debian.id}"
   zone = "ch-dk-2"
 
   timeouts {

--- a/examples/ipv6/main.tf
+++ b/examples/ipv6/main.tf
@@ -4,6 +4,11 @@ provider "exoscale" {
   secret = "${var.secret}"
 }
 
+data "exoscale_compute_template" "main" {
+  zone = "${var.zone}"
+  name = "${var.template}"
+}
+
 resource "exoscale_security_group" "default" {
   name = "default-with-ipv6"
 }
@@ -30,7 +35,7 @@ resource "exoscale_security_group_rule" "default-ssh-6" {
 
 resource "exoscale_compute" "main" {
   display_name = "test-ipv6"
-  template = "${var.template}"
+  template_id = "${data.exoscale_compute_template.main.id}"
   zone = "${var.zone}"
   size = "Medium"
   disk_size = 11

--- a/examples/managed-private-network/main.tf
+++ b/examples/managed-private-network/main.tf
@@ -14,6 +14,11 @@ variable "dynamic_machines" {
   default = 2
 }
 
+data "exoscale_compute_template" "ubuntu" {
+  zone = "${var.zone}"
+  name = "Linux Ubuntu 18.04 LTS 64-bit"
+}
+
 resource "exoscale_network" "intra" {
   name = "demo-intra"
   display_text = "demo intra privnet"
@@ -30,7 +35,7 @@ resource "exoscale_compute" "static" {
 
   display_name = "demo-static-${count.index}"
 
-  template = "Linux Ubuntu 18.04 LTS 64-bit"
+  template_id = "${data.exoscale_compute_template.ubuntu.id}"
   size = "Small"
   disk_size = "10"
   security_groups = ["default"]
@@ -55,7 +60,7 @@ resource "exoscale_compute" "dynamic" {
 
   display_name = "demo-dynamic-${count.index}"
 
-  template = "Linux Ubuntu 18.04 LTS 64-bit"
+  template_id = "${data.exoscale_compute_template.ubuntu.id}"
   size = "Small"
   disk_size = "10"
   security_groups = ["default"]

--- a/examples/multi-private-network/instances.tf
+++ b/examples/multi-private-network/instances.tf
@@ -2,12 +2,17 @@ variable "machines" {
   default = 2
 }
 
+data "exoscale_compute_template" "ubuntu" {
+  zone = "${var.zone}"
+  name = "Linux Ubuntu 18.04 LTS 64-bit"
+}
+
 resource "exoscale_compute" "machine" {
   count = "${var.machines}"
 
   display_name = "demo-machine-${count.index}"
 
-  template = "Linux Ubuntu 18.04 LTS 64-bit"
+  template_id = "${data.exoscale_compute_template.ubuntu.id}"
   size = "Small"
   disk_size = "10"
   security_groups = ["default"]

--- a/examples/multipart-cloud-init/instances.tf
+++ b/examples/multipart-cloud-init/instances.tf
@@ -1,7 +1,12 @@
+data "exoscale_compute_template" "test" {
+  zone = "${var.zone}"
+  name = "${var.template}"
+}
+
 resource "exoscale_compute" "test" {
   count = "${length(var.hostnames)}"
   display_name = "${var.hostnames[count.index]}"
-  template = "${var.template}"
+  template_id = "${data.exoscale_compute_template.test.id}"
   zone = "${var.zone}"
   size = "Tiny"
   disk_size = 17

--- a/examples/rke/main.tf
+++ b/examples/rke/main.tf
@@ -8,6 +8,11 @@ provider "exoscale" {
   secret = "${var.secret}"
 }
 
+data "exoscale_compute_template" "node" {
+  zone = "${var.zone}"
+  name = "${var.template}"
+}
+
 resource "exoscale_affinity" "rke" {
   name = "rke-nodes"
   description = "keep nodes of different hosts"
@@ -50,7 +55,7 @@ resource "exoscale_security_group_rules" "rke" {
 resource "exoscale_compute" "node" {
   count = "${length(var.hostnames)}"
   display_name = "${element(var.hostnames, count.index)}"
-  template = "${var.template}"
+  template_id = "${data.exoscale_compute_template.node.id}"
   zone = "${var.zone}"
   size = "Medium"
   disk_size = 50

--- a/examples/ssh-keys/main.tf
+++ b/examples/ssh-keys/main.tf
@@ -6,9 +6,14 @@ resource "exoscale_ssh_keypair" "key" {
   name = "mykey"
 }
 
+data "exoscale_compute_template" "ubuntu" {
+  zone = "at-vie-1"
+  name = "Linux Ubuntu 18.04 LTS 64-bit"
+}
+
 resource "exoscale_compute" "vm" {
   display_name = "myvm"
-  template = "Linux Ubuntu 18.04 LTS 64-bit"
+  template_id = "${data.exoscale_compute_template.ubuntu.id}"
   size = "Medium"
   key_pair = "${exoscale_ssh_keypair.key.name}"
   disk_size = 10

--- a/exoscale/datasource_exoscale_compute_template.go
+++ b/exoscale/datasource_exoscale_compute_template.go
@@ -92,7 +92,7 @@ func datasourceComputeTemplateRead(d *schema.ResourceData, meta interface{}) err
 		return fmt.Errorf("templates list query failed: %s", err)
 	}
 
-	var template *egoscale.Template
+	var template egoscale.Template
 	nt := resp.(*egoscale.ListTemplatesResponse).Count
 	switch {
 	case nt == 0:
@@ -102,7 +102,7 @@ func datasourceComputeTemplateRead(d *schema.ResourceData, meta interface{}) err
 		return errors.New("multiple results returned, expected only one")
 
 	default:
-		template = &(resp.(*egoscale.ListTemplatesResponse).Template[0])
+		template = resp.(*egoscale.ListTemplatesResponse).Template[0]
 	}
 
 	d.SetId(template.ID.String())

--- a/exoscale/datasource_exoscale_compute_template.go
+++ b/exoscale/datasource_exoscale_compute_template.go
@@ -92,7 +92,7 @@ func datasourceComputeTemplateRead(d *schema.ResourceData, meta interface{}) err
 		return fmt.Errorf("templates list query failed: %s", err)
 	}
 
-	template := new(egoscale.Template)
+	var template *egoscale.Template
 	nt := resp.(*egoscale.ListTemplatesResponse).Count
 	switch {
 	case nt == 0:

--- a/exoscale/provider_test.go
+++ b/exoscale/provider_test.go
@@ -108,4 +108,5 @@ func TestCheckResourceAttributes(t *testing.T) {
 
 var defaultExoscaleZone = "ch-gva-2"
 var defaultExoscaleTemplate = "Linux Ubuntu 18.04 LTS 64-bit"
+var defaultExoscaleTemplateID = "095250e3-7c56-441a-a25b-100a3d3f5a6e" // "Linux Ubuntu 18.04 LTS 64-bit" @ ch-gva-2
 var defaultExoscaleNetworkOffering = "PrivNet"

--- a/exoscale/provider_test.go
+++ b/exoscale/provider_test.go
@@ -108,5 +108,5 @@ func TestCheckResourceAttributes(t *testing.T) {
 
 var defaultExoscaleZone = "ch-gva-2"
 var defaultExoscaleTemplate = "Linux Ubuntu 18.04 LTS 64-bit"
-var defaultExoscaleTemplateID = "095250e3-7c56-441a-a25b-100a3d3f5a6e" // "Linux Ubuntu 18.04 LTS 64-bit" @ ch-gva-2
+var defaultExoscaleTemplateID = "45346aba-6027-45bc-ad1e-bd1f563c2d84" // "Linux Ubuntu 18.04 LTS 64-bit" @ ch-gva-2
 var defaultExoscaleNetworkOffering = "PrivNet"

--- a/website/docs/d/compute_template.html.markdown
+++ b/website/docs/d/compute_template.html.markdown
@@ -28,7 +28,7 @@ data "exoscale_compute_template" "ubuntu" {
 resource "exoscale_compute" "my_server" {
   zone         = "${local.zone}"
   display_name = "my server"
-  template     = "${data.exoscale_compute_template.ubuntu.id}"
+  template_id  = "${data.exoscale_compute_template.ubuntu.id}"
   disk_size    = 10
   key_pair     = "my key"
 }

--- a/website/docs/r/compute.html.markdown
+++ b/website/docs/r/compute.html.markdown
@@ -15,10 +15,15 @@ Provides an Exoscale [Compute instance][compute] resource. This can be used to c
 ## Example Usage
 
 ```hcl
+data "exoscale_compute_template" "ubuntu" {
+  zone = "ch-gva-2"
+  name = "Linux Ubuntu 18.04 LTS 64-bit"
+}
+
 resource "exoscale_compute" "mymachine" {
   zone         = "ch-gva-2"
   display_name = "mymachine"
-  template     = "Linux Debian 9 64-bit"
+  template_id  = "${data.exoscale_compute_template.ubuntu.id}"
   size         = "Medium"
   disk_size    = 10
   key_pair     = "me@mymachine"
@@ -49,7 +54,8 @@ EOF
 
 * `zone` - (Required) The name of the [zone][zone] to deploy the Compute instance into.
 * `display_name` - (Required) The displayed name of the Compute instance. Note: This value is also used to set the OS' *hostname* during creation, so the value can only contain alphanumeric and hyphen ("-") characters; it can be changed to any character during a later update.
-* `template` - (Required) The name or ID of the Compute instance [template][template]. If a name is provided, only *featured* templates are available.
+* `template` - **Deprecated** (Required) The name of the Compute instance [template][template]. Only *featured* templates are available, use the `template_id` attribute instead.
+* `template_id` - (Required) The ID of the Compute instance [template][template]. Usage of the [`compute_template`][compute_template] data source is recommended.
 * `size` - (Required) The Compute instance [size][size], e.g. `Tiny`, `Small`, `Medium`, `Large` etc.
 * `disk_size` - (Required) The Compute instance root disk size in GiB (at least `10`).
 * `key_pair` - (Required) The name of the [SSH key pair][sshkeypair] to be installed.
@@ -71,16 +77,19 @@ EOF
 [cloudinit]: http://cloudinit.readthedocs.io/en/latest/
 [aag]: affinity.html
 [sg]: security_group.html
+[compute_template]: ../d/compute_template.html
 
 ## Attributes Reference
 
 The following attributes are exported:
 
 * `name` - The name of the Compute instance (*hostname*).
-* `username` - The user to use to connect to the Compute instance with SSH.
+* `username` - **Deprecated** The user to use to connect to the Compute instance with SSH. Broken, use the [`compute_template`][compute_template] data source `username` attribute instead.
 * `password` - The initial Compute instance password and/or encrypted password.
 * `ip_address` - The IP address of the Compute instance main network interface.
 * `ip6_address` - The IPv6 address of the Compute instance main network interface.
+
+[compute_template]: ../d/compute_template.html
 
 ## Import
 


### PR DESCRIPTION
This change has been prompted by issue #8, which illustrates that it's
not possible to reference an `exoscale_compute` resource `template` by
an ID (only a name) – effectively preventing the usage of custom
templates via the `exoscale_compute_template` data source.

As a consequence, the `template` attribute is now deprecated and
replaced by a new `template_id` attribute which only accepts template
IDs, which can be looked up via the `exoscale_compute_template` DS.
A collateral damage of this change is that the `username` attribute of
the resource is now also deprecated and replaced by the
`exoscale_compute_template` DS `username` attribute.

Fixes #8.