### PR TITLE
client: use DefaultPooledClient

### DIFF
--- a/exoscale/client.go
+++ b/exoscale/client.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/exoscale/egoscale"
+	"github.com/hashicorp/go-cleanhttp"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/logging"
 )
 
@@ -31,6 +32,7 @@ func getClient(endpoint string, meta interface{}) *egoscale.Client {
 	cs := egoscale.NewClient(endpoint, config.key, config.secret)
 
 	cs.Timeout = config.timeout
+	cs.HTTPClient = cleanhttp.DefaultPooledClient()
 	cs.HTTPClient.Timeout = config.timeout
 
 	if logging.IsDebugOrHigher() {

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ require (
 	github.com/aws/aws-sdk-go v1.21.7 // indirect
 	github.com/exoscale/egoscale v0.18.1
 	github.com/gopherjs/gopherjs v0.0.0-20190430165422-3e4dfb77656c // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.1
 	github.com/hashicorp/terraform-plugin-sdk v1.1.0
 	github.com/jtolds/gls v4.2.1+incompatible // indirect
 	github.com/mattn/go-colorable v0.1.1 // indirect


### PR DESCRIPTION
By using the `DefaultPooledClient`, the provider will be more gentle with the backend (probably).

https://github.com/hashicorp/terraform/blob/master/vendor/github.com/hashicorp/go-cleanhttp/cleanhttp.go#L49-L57