### PR TITLE
doc: fix remote-exec provisioner usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ FIXES:
 DEPRECATIONS:
 
 - The `exoscale_compute` *template* attribute is now deprecated, replaced by `template_id`. See resource documentation for details ([GH-9])
+- The `exoscale_compute` *username* attribute is now deprecated, users wanting to use the *remote-exec* provisioner should now rely on the *exoscale_compute_template* data source `username` attribute. See resource documentation for details ([GH-9])
 
 IMPROVEMENTS:
 

--- a/examples/ssh-keys/main.tf
+++ b/examples/ssh-keys/main.tf
@@ -21,6 +21,8 @@ resource "exoscale_compute" "vm" {
 
   provisioner "remote-exec" {
     connection {
+      host = "${self.ip_address}"
+      user = "${data.exoscale_compute_template.ubuntu.username}"
       private_key = "${exoscale_ssh_keypair.key.private_key}"
     }
 

--- a/website/docs/r/compute.html.markdown
+++ b/website/docs/r/compute.html.markdown
@@ -93,7 +93,7 @@ The following attributes are exported:
 
 ## `remote-exec` provisioner usage
 
-If you wish to log to a `exoscale_compute` resource using the [`remote-exec`][rexec] provisioner, make sure to explicity set the SSH user to connect to the instance to the actual template username returned by the [`exoscale_compute_template`] data source:
+If you wish to log to a `exoscale_compute` resource using the [`remote-exec`][rexec] provisioner, make sure to explicity set the SSH `user` setting to connect to the instance to the actual template username returned by the [`exoscale_compute_template`][compute_template] data source:
 
 ```hcl
 data "exoscale_compute_template" "ubuntu" {

--- a/website/docs/r/compute.html.markdown
+++ b/website/docs/r/compute.html.markdown
@@ -91,6 +91,38 @@ The following attributes are exported:
 
 [compute_template]: ../d/compute_template.html
 
+## `remote-exec` provisioner usage
+
+If you wish to log to a `exoscale_compute` resource using the [`remote-exec`][rexec] provisioner, make sure to explicity set the SSH user to connect to the instance to the actual template username returned by the [`exoscale_compute_template`] data source:
+
+```hcl
+data "exoscale_compute_template" "ubuntu" {
+  zone = "ch-gva-2"
+  name = "Linux Ubuntu 18.04 LTS 64-bit"
+}
+
+resource "exoscale_compute" "mymachine" {
+  zone         = "ch-gva-2"
+  display_name = "mymachine"
+  template_id  = "${data.exoscale_compute_template.ubuntu.id}"
+  size         = "Medium"
+  disk_size    = 10
+  key_pair     = "me@mymachine"
+  state        = "Running"
+
+  provisioner "remote-exec" {
+    connection {
+      type = "ssh"
+      host = "${self.ip_address}"
+      user = "${data.exoscale_compute_template.ubuntu.username}"
+    }
+  }
+}
+```
+
+[rexec]: https://www.terraform.io/docs/provisioners/remote-exec.html
+[compute_template]: ../d/compute_template.html
+
 ## Import
 
 An existing Compute instance can be imported as a resource by name or ID. Importing a Compute instance imports the `exoscale_compute` resource as well as related [`exoscale_secondary_ipaddress`][secip] and [`exoscale_nic`][nic] resources.


### PR DESCRIPTION
This change improves the provider documentation regarding the usage of
the *remote-exec* Terraform provisioner, which starting from version
0.13.0 of our provider now requires an explicit value to be set for the
`user` setting that matches the value returned by the *compute_template*
data source `username` attribute.

Fixes #13.