### PR TITLE
compute: reinstate "template" resource attribute

### DIFF
--- a/exoscale/resource_exoscale_compute_test.go
+++ b/exoscale/resource_exoscale_compute_test.go
@@ -21,7 +21,7 @@ func TestAccResourceCompute(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				// This should go away once `template` attribute is phased out
-				Config: testAccResourceComputeConfigCreateDeprecated,
+				Config: testAccResourceComputeConfigCreateTemplateByName,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceComputeExists("exoscale_compute.vm", vm),
 					testAccCheckResourceCompute(vm),
@@ -37,7 +37,7 @@ func TestAccResourceCompute(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccResourceComputeConfigCreate,
+				Config: testAccResourceComputeConfigCreateTemplateByID,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceComputeExists("exoscale_compute.vm", vm),
 					testAccCheckResourceCompute(vm),
@@ -173,8 +173,7 @@ func testAccCheckResourceComputeDestroy(s *terraform.State) error {
 	return errors.New("Compute instance still exists")
 }
 
-// This should go away once `template` attribute is phased out
-var testAccResourceComputeConfigCreateDeprecated = fmt.Sprintf(`
+var testAccResourceComputeConfigCreateTemplateByName = fmt.Sprintf(`
 resource "exoscale_ssh_keypair" "key" {
   name = "terraform-test-keypair"
 }
@@ -200,7 +199,7 @@ resource "exoscale_compute" "vm" {
 	defaultExoscaleZone,
 )
 
-var testAccResourceComputeConfigCreate = fmt.Sprintf(`
+var testAccResourceComputeConfigCreateTemplateByID = fmt.Sprintf(`
 resource "exoscale_ssh_keypair" "key" {
   name = "terraform-test-keypair"
 }

--- a/website/docs/r/compute.html.markdown
+++ b/website/docs/r/compute.html.markdown
@@ -54,7 +54,7 @@ EOF
 
 * `zone` - (Required) The name of the [zone][zone] to deploy the Compute instance into.
 * `display_name` - (Required) The displayed name of the Compute instance. Note: This value is also used to set the OS' *hostname* during creation, so the value can only contain alphanumeric and hyphen ("-") characters; it can be changed to any character during a later update.
-* `template` - **Deprecated** (Required) The name of the Compute instance [template][template]. Only *featured* templates are available, use the `template_id` attribute instead.
+* `template` - (Required) The name of the Compute instance [template][template]. Only *featured* templates are available, if you want to reference *custom templates* use the `template_id` attribute instead.
 * `template_id` - (Required) The ID of the Compute instance [template][template]. Usage of the [`compute_template`][compute_template] data source is recommended.
 * `size` - (Required) The Compute instance [size][size], e.g. `Tiny`, `Small`, `Medium`, `Large` etc.
 * `disk_size` - (Required) The Compute instance root disk size in GiB (at least `10`).
@@ -84,7 +84,7 @@ EOF
 The following attributes are exported:
 
 * `name` - The name of the Compute instance (*hostname*).
-* `username` - **Deprecated** The user to use to connect to the Compute instance with SSH. Broken, use the [`compute_template`][compute_template] data source `username` attribute instead.
+* `username` - The user to use to connect to the Compute instance with SSH. If you've referenced a *custom template* in the resource, use the [`compute_template`][compute_template] data source `username` attribute instead.
 * `password` - The initial Compute instance password and/or encrypted password.
 * `ip_address` - The IP address of the Compute instance main network interface.
 * `ip6_address` - The IPv6 address of the Compute instance main network interface.


### PR DESCRIPTION
This change reinstates the compute resource `template` attribute
deprecated in version 0.13.0. Both `template` and `template_id` are
still conflicting, but can be used interchangeably until pending next
major backward-incompatible version.