### PR TITLE
Add provider version to HTTP client User-Agent

### DIFF
--- a/exoscale/provider.go
+++ b/exoscale/provider.go
@@ -12,6 +12,7 @@ import (
 	"github.com/exoscale/egoscale"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/terraform-providers/terraform-provider-exoscale/version"
 	"gopkg.in/ini.v1"
 )
 
@@ -236,7 +237,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		gzipUserData:    d.Get("gzip_user_data").(bool),
 	}
 
-	egoscale.UserAgent = fmt.Sprintf("Exoscale-Terraform-Provider/0 %s", egoscale.UserAgent)
+	egoscale.UserAgent = fmt.Sprintf("Exoscale-Terraform-Provider/%s %s", version.ProviderVersion, egoscale.UserAgent)
 
 	return baseConfig, nil
 }

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,7 @@
+package version
+
+var (
+	// ProviderVersion is set to the release version of
+	// the binary during the automated release process.
+	ProviderVersion = "dev"
+)


### PR DESCRIPTION
This change adds the stable release version number to the HTTP client
User-Agent. The release version value in `version/version.go` is set by the HashiCorp Terraform release pipeline during the release process.