### PR TITLE
Set Running state if state is Migrating in compute

### DIFF
--- a/exoscale/resource_exoscale_compute.go
+++ b/exoscale/resource_exoscale_compute.go
@@ -892,6 +892,8 @@ func resourceComputeApply(d *schema.ResourceData, machine *egoscale.VirtualMachi
 	if err := d.Set("zone", machine.ZoneName); err != nil {
 		return err
 	}
+
+	// don't converge state for migrating instances
 	state := machine.State
 	if state == "Migrating" {
 		state = "Running"

--- a/exoscale/resource_exoscale_compute.go
+++ b/exoscale/resource_exoscale_compute.go
@@ -892,7 +892,11 @@ func resourceComputeApply(d *schema.ResourceData, machine *egoscale.VirtualMachi
 	if err := d.Set("zone", machine.ZoneName); err != nil {
 		return err
 	}
-	if err := d.Set("state", machine.State); err != nil {
+	state := machine.State
+	if state == "Migrating" {
+		state = "Running"
+	}
+	if err := d.Set("state", state); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Dont try to converge state for migrating instances

```
...
]
        size               = "Medium"
      ~ state              = "Migrating" -> "Running"
        tags               = {
...
```