### PR TITLE
Fix cloudstack config example keyword.

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -49,7 +49,7 @@ for async tasks to complete. Currently, this is used during the creation of
 ```ini
 [cloudstack]
 
-endpoint = "https://api.exoscale.ch/compute"
+endpoint = "https://api.exoscale.com/compute"
 key = "EXO..."
 secret = "..."
 ```

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -51,7 +51,7 @@ for async tasks to complete. Currently, this is used during the creation of
 
 endpoint = "https://api.exoscale.ch/compute"
 key = "EXO..."
-token = "..."
+secret = "..."
 ```
 
 ### Environment variables


### PR DESCRIPTION
token is not a valid keyword and by using the example one can hit the
following error: "error when getting key of section 'cloudstack':
key 'secret' not exists".