### PR TITLE
ipaddress: fix resource importing by IP address

### DIFF
--- a/website/docs/r/ipaddress.html.markdown
+++ b/website/docs/r/ipaddress.html.markdown
@@ -68,7 +68,7 @@ The following attributes are exported:
 An existing Elastic IP can be imported as a resource by address or ID:
 
 ```console
-# By name
+# By address
 $ terraform import exoscale_ipaddress.myip 159.100.251.224
 
 # By ID


### PR DESCRIPTION
This change fixes a bug in the `exoscale_ipaddress` resource preventing
import by IP address.