### PR TITLE
Refactor acceptance tests

### DIFF
--- a/exoscale/provider_test.go
+++ b/exoscale/provider_test.go
@@ -2,12 +2,23 @@ package exoscale
 
 import (
 	"fmt"
+	"math/rand"
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+// Common test environment information
+const (
+	testPrefix               = "test-terraform-exoscale-provider"
+	testDescription          = "Created by the terraform-exoscale provider"
+	testZoneName             = "ch-gva-2"
+	testInstanceTemplateName = "Linux Ubuntu 18.04 LTS 64-bit"
+	testInstanceTemplateID   = "287b6306-fdeb-4dc6-855d-90c4f68f572b" // "Linux Ubuntu 18.04 LTS 64-bit" @ ch-gva-2
 )
 
 // testAttrs represents a map of expected resource attributes during acceptance tests.
@@ -106,6 +117,14 @@ func TestCheckResourceAttributes(t *testing.T) {
 	}
 }
 
-var defaultExoscaleZone = "ch-gva-2"
-var defaultExoscaleTemplate = "Linux Ubuntu 18.04 LTS 64-bit"
-var defaultExoscaleTemplateID = "287b6306-fdeb-4dc6-855d-90c4f68f572b" // "Linux Ubuntu 18.04 LTS 64-bit" @ ch-gva-2
+func testRandomString() string {
+	chars := "1234567890abcdefghijklmnopqrstuvwxyz"
+
+	rand.Seed(time.Now().UnixNano())
+	b := make([]byte, 10)
+	for i := range b {
+		b[i] = chars[rand.Int63()%int64(len(chars))]
+	}
+
+	return string(b)
+}

--- a/exoscale/resource_exoscale_affinity_test.go
+++ b/exoscale/resource_exoscale_affinity_test.go
@@ -2,11 +2,27 @@ package exoscale
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/exoscale/egoscale"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+var (
+	testAccResourceAffinityName        = testPrefix + "-" + testRandomString()
+	testAccResourceAffinityDescription = testDescription
+
+	testAccResourceAffinityConfig = fmt.Sprintf(`
+resource "exoscale_affinity" "ag" {
+  name = "%s"
+  description = "%s"
+}
+`,
+		testAccResourceAffinityName,
+		testAccResourceAffinityDescription,
+	)
 )
 
 func TestAccResourceAffinity(t *testing.T) {
@@ -23,8 +39,8 @@ func TestAccResourceAffinity(t *testing.T) {
 					testAccCheckResourceAffinityExists("exoscale_affinity.ag", ag),
 					testAccCheckResourceAffinity(ag),
 					testAccCheckResourceAffinityAttributes(testAttrs{
-						"name":        ValidateString("terraform-test-affinity"),
-						"description": ValidateString("Terraform Acceptance Test"),
+						"name":        ValidateString(testAccResourceAffinityName),
+						"description": ValidateString(testAccResourceAffinityDescription),
 						"type":        ValidateString("host anti-affinity"),
 					}),
 				),
@@ -36,8 +52,8 @@ func TestAccResourceAffinity(t *testing.T) {
 				ImportStateCheck: func(s []*terraform.InstanceState) error {
 					return checkResourceAttributes(
 						testAttrs{
-							"name":        ValidateString("terraform-test-affinity"),
-							"description": ValidateString("Terraform Acceptance Test"),
+							"name":        ValidateString(testAccResourceAffinityName),
+							"description": ValidateString(testAccResourceAffinityDescription),
 							"type":        ValidateString("host anti-affinity"),
 						},
 						s[0].Attributes)
@@ -125,10 +141,3 @@ func testAccCheckResourceAffinityDestroy(s *terraform.State) error {
 
 	return errors.New("Affinity Group still exists")
 }
-
-var testAccResourceAffinityConfig = `
-resource "exoscale_affinity" "ag" {
-  name = "terraform-test-affinity"
-  description = "Terraform Acceptance Test"
-}
-`

--- a/exoscale/resource_exoscale_compute_test.go
+++ b/exoscale/resource_exoscale_compute_test.go
@@ -68,8 +68,8 @@ resource "exoscale_compute" "vm" {
 }
 `,
 		testAccResourceComputeSSHKeyName,
-		testInstanceTemplateID,
-		testZoneName,
+		testAccResourceComputeTemplateID,
+		testAccResourceComputeZoneName,
 		testAccResourceComputeName,
 		testAccResourceComputeSize,
 		testAccResourceComputeDiskSize,
@@ -111,8 +111,8 @@ EOF
 `,
 		testAccResourceComputeSSHKeyName,
 		testAccResourceComputeSecurityGroupName,
-		testInstanceTemplateID,
-		testZoneName,
+		testAccResourceComputeTemplateID,
+		testAccResourceComputeZoneName,
 		testAccResourceComputeNameUpdated,
 		testAccResourceComputeSizeUpdated,
 		testAccResourceComputeDiskSizeUpdated,
@@ -136,8 +136,8 @@ func TestAccResourceCompute(t *testing.T) {
 					testAccCheckResourceComputeExists("exoscale_compute.vm", vm),
 					testAccCheckResourceCompute(vm),
 					testAccCheckResourceComputeAttributes(testAttrs{
-						"template":     ValidateString(testInstanceTemplateName),
-						"template_id":  ValidateString(testInstanceTemplateID),
+						"template":     ValidateString(testAccResourceComputeTemplateName),
+						"template_id":  ValidateString(testAccResourceComputeTemplateID),
 						"display_name": ValidateString(testAccResourceComputeName),
 						"size":         ValidateString(testAccResourceComputeSize),
 						"disk_size":    ValidateString(testAccResourceComputeDiskSize),
@@ -152,7 +152,7 @@ func TestAccResourceCompute(t *testing.T) {
 					testAccCheckResourceComputeExists("exoscale_compute.vm", vm),
 					testAccCheckResourceCompute(vm),
 					testAccCheckResourceComputeAttributes(testAttrs{
-						"template_id":  ValidateString(testInstanceTemplateID),
+						"template_id":  ValidateString(testAccResourceComputeTemplateID),
 						"display_name": ValidateString(testAccResourceComputeName),
 						"size":         ValidateString(testAccResourceComputeSize),
 						"disk_size":    ValidateString(testAccResourceComputeDiskSize),
@@ -168,7 +168,7 @@ func TestAccResourceCompute(t *testing.T) {
 					testAccCheckResourceComputeExists("exoscale_compute.vm", vm),
 					testAccCheckResourceCompute(vm),
 					testAccCheckResourceComputeAttributes(testAttrs{
-						"template_id":       ValidateString(testInstanceTemplateID),
+						"template_id":       ValidateString(testAccResourceComputeTemplateID),
 						"display_name":      ValidateString(testAccResourceComputeNameUpdated),
 						"size":              ValidateString(testAccResourceComputeSizeUpdated),
 						"disk_size":         ValidateString(testAccResourceComputeDiskSizeUpdated),
@@ -187,7 +187,7 @@ func TestAccResourceCompute(t *testing.T) {
 				ImportStateCheck: func(s []*terraform.InstanceState) error {
 					return checkResourceAttributes(
 						testAttrs{
-							"template_id":       ValidateString(testInstanceTemplateID),
+							"template_id":       ValidateString(testAccResourceComputeTemplateID),
 							"display_name":      ValidateString(testAccResourceComputeNameUpdated),
 							"size":              ValidateString(testAccResourceComputeSizeUpdated),
 							"disk_size":         ValidateString(testAccResourceComputeDiskSizeUpdated),

--- a/exoscale/resource_exoscale_domain_record_test.go
+++ b/exoscale/resource_exoscale_domain_record_test.go
@@ -12,6 +12,63 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
+var (
+	testAccResourceDomainRecordDomainName     = testPrefix + "-" + testRandomString() + ".net"
+	testAccResourceDomainRecordName           = "mail1"
+	testAccResourceDomainRecordNameUpdated    = "mail2"
+	testAccResourceDomainRecordType           = "MX"
+	testAccResourceDomainRecordContent        = "mta1"
+	testAccResourceDomainRecordContentUpdated = "mta2"
+	testAccResourceDomainRecordPrio           = 10
+	testAccResourceDomainRecordPrioUpdated    = 20
+	testAccResourceDomainRecordTTL            = 10
+	testAccResourceDomainRecordTTLUpdated     = 20
+
+	testAccResourceDomainRecordConfigCreate = fmt.Sprintf(`
+resource "exoscale_domain" "exo" {
+  name = "%s"
+}
+
+resource "exoscale_domain_record" "mx" {
+  domain      = "${exoscale_domain.exo.id}"
+  name        = "%s"
+  record_type = "%s"
+  content     = "%s"
+  prio        = %d
+  ttl         = %d
+}
+`,
+		testAccResourceDomainRecordDomainName,
+		testAccResourceDomainRecordName,
+		testAccResourceDomainRecordType,
+		testAccResourceDomainRecordContent,
+		testAccResourceDomainRecordPrio,
+		testAccResourceDomainRecordTTL,
+	)
+
+	testAccResourceDomainRecordConfigUpdate = fmt.Sprintf(`
+resource "exoscale_domain" "exo" {
+  name = "%s"
+}
+
+resource "exoscale_domain_record" "mx" {
+  domain      = "${exoscale_domain.exo.id}"
+  name        = "%s"
+  record_type = "%s"
+  content     = "%s"
+  prio        = %d
+  ttl         = %d
+}
+`,
+		testAccResourceDomainRecordDomainName,
+		testAccResourceDomainRecordNameUpdated,
+		testAccResourceDomainRecordType,
+		testAccResourceDomainRecordContentUpdated,
+		testAccResourceDomainRecordPrioUpdated,
+		testAccResourceDomainRecordTTLUpdated,
+	)
+)
+
 func TestAccResourceDomainRecord(t *testing.T) {
 	domain := new(egoscale.DNSDomain)
 	record := new(egoscale.DNSRecord)
@@ -28,11 +85,11 @@ func TestAccResourceDomainRecord(t *testing.T) {
 					testAccCheckResourceDomainRecordExists("exoscale_domain_record.mx", domain, record),
 					testAccCheckResourceDomainRecord(record),
 					testAccCheckResourceDomainRecordAttributes(testAttrs{
-						"name":        ValidateString("mail1"),
-						"record_type": ValidateString("MX"),
-						"content":     ValidateString("mta1"),
-						"prio":        ValidateString("10"),
-						"ttl":         ValidateString("10"),
+						"name":        ValidateString(testAccResourceDomainRecordName),
+						"record_type": ValidateString(testAccResourceDomainRecordType),
+						"content":     ValidateString(testAccResourceDomainRecordContent),
+						"prio":        ValidateString(fmt.Sprint(testAccResourceDomainRecordPrio)),
+						"ttl":         ValidateString(fmt.Sprint(testAccResourceDomainRecordTTL)),
 					}),
 				),
 			},
@@ -43,11 +100,11 @@ func TestAccResourceDomainRecord(t *testing.T) {
 					testAccCheckResourceDomainRecordExists("exoscale_domain_record.mx", domain, record),
 					testAccCheckResourceDomainRecord(record),
 					testAccCheckResourceDomainRecordAttributes(testAttrs{
-						"name":        ValidateString("mail2"),
-						"record_type": ValidateString("MX"),
-						"content":     ValidateString("mta2"),
-						"prio":        ValidateString("20"),
-						"ttl":         ValidateString("20"),
+						"name":        ValidateString(testAccResourceDomainRecordNameUpdated),
+						"record_type": ValidateString(testAccResourceDomainRecordType),
+						"content":     ValidateString(testAccResourceDomainRecordContentUpdated),
+						"prio":        ValidateString(fmt.Sprint(testAccResourceDomainRecordPrioUpdated)),
+						"ttl":         ValidateString(fmt.Sprint(testAccResourceDomainRecordTTLUpdated)),
 					}),
 				),
 			},
@@ -58,11 +115,11 @@ func TestAccResourceDomainRecord(t *testing.T) {
 				ImportStateCheck: func(s []*terraform.InstanceState) error {
 					return checkResourceAttributes(
 						testAttrs{
-							"name":        ValidateString("mail2"),
-							"record_type": ValidateString("MX"),
-							"content":     ValidateString("mta2"),
-							"prio":        ValidateString("20"),
-							"ttl":         ValidateString("20"),
+							"name":        ValidateString(testAccResourceDomainRecordNameUpdated),
+							"record_type": ValidateString(testAccResourceDomainRecordType),
+							"content":     ValidateString(testAccResourceDomainRecordContentUpdated),
+							"prio":        ValidateString(fmt.Sprint(testAccResourceDomainRecordPrioUpdated)),
+							"ttl":         ValidateString(fmt.Sprint(testAccResourceDomainRecordTTLUpdated)),
 						},
 						s[0].Attributes)
 				},
@@ -143,35 +200,3 @@ func testAccCheckResourceDomainRecordDestroy(s *terraform.State) error {
 	}
 	return nil
 }
-
-var testAccResourceDomainRecordConfigCreate = fmt.Sprintf(`
-resource "exoscale_domain" "exo" {
-  name = "%s"
-}
-
-resource "exoscale_domain_record" "mx" {
-  domain      = "${exoscale_domain.exo.id}"
-  name        = "mail1"
-  record_type = "MX"
-  content     = "mta1"
-  prio        = 10
-  ttl         = 10
-}
-`,
-	testDomain)
-
-var testAccResourceDomainRecordConfigUpdate = fmt.Sprintf(`
-resource "exoscale_domain" "exo" {
-  name = "%s"
-}
-
-resource "exoscale_domain_record" "mx" {
-  domain      = "${exoscale_domain.exo.id}"
-  name        = "mail2"
-  record_type = "MX"
-  content     = "mta2"
-  ttl         = 20
-  prio        = 20
-}
-`,
-	testDomain)

--- a/exoscale/resource_exoscale_domain_test.go
+++ b/exoscale/resource_exoscale_domain_test.go
@@ -11,8 +11,16 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-const (
-	testDomain = "terraform-test.exo"
+var (
+	testAccResourceDomainName = testPrefix + "-" + testRandomString() + ".net"
+
+	testAccDNSDomainCreate = fmt.Sprintf(`
+resource "exoscale_domain" "exo" {
+  name = "%s"
+}
+`,
+		testAccResourceDomainName,
+	)
 )
 
 func TestAccResourceDomain(t *testing.T) {
@@ -29,7 +37,7 @@ func TestAccResourceDomain(t *testing.T) {
 					testAccCheckResourceDomainExists("exoscale_domain.exo", domain),
 					testAccCheckResourceDomain(domain),
 					testAccCheckResourceDomainAttributes(testAttrs{
-						"name":       ValidateString(testDomain),
+						"name":       ValidateString(testAccResourceDomainName),
 						"state":      ValidateString("hosted"),
 						"auto_renew": ValidateString("false"),
 						"expires_on": ValidateString(""),
@@ -44,7 +52,7 @@ func TestAccResourceDomain(t *testing.T) {
 				ImportStateCheck: func(s []*terraform.InstanceState) error {
 					return checkResourceAttributes(
 						testAttrs{
-							"name":       ValidateString(testDomain),
+							"name":       ValidateString(testAccResourceDomainName),
 							"state":      ValidateString("hosted"),
 							"auto_renew": ValidateString("false"),
 							"expires_on": ValidateString(""),
@@ -126,10 +134,3 @@ func testAccCheckResourceDomainDestroy(s *terraform.State) error {
 	}
 	return nil
 }
-
-var testAccDNSDomainCreate = fmt.Sprintf(`
-resource "exoscale_domain" "exo" {
-  name = "%s"
-}
-`,
-	testDomain)

--- a/exoscale/resource_exoscale_ipaddress_test.go
+++ b/exoscale/resource_exoscale_ipaddress_test.go
@@ -10,23 +10,71 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-const (
-	testIPHealthcheckMode1              = "http"
-	testIPHealthcheckPort1        int64 = 80
-	testIPHealthcheckPath1              = "/health"
-	testIPHealthcheckInterval1    int64 = 10
-	testIPHealthcheckTimeout1     int64 = 5
-	testIPHealthcheckStrikesOk1   int64 = 1
-	testIPHealthcheckStrikesFail1       = 2
-	testIPHealthcheckMode2              = "http"
-	testIPHealthcheckPort2        int64 = 8000
-	testIPHealthcheckPath2              = "/healthz"
-	testIPHealthcheckInterval2    int64 = 5
-	testIPHealthcheckTimeout2     int64 = 2
-	testIPHealthcheckStrikesOk2   int64 = 2
-	testIPHealthcheckStrikesFail2 int64 = 3
-	testIPDescription1                  = "IPAdress 1"
-	testIPDescription2                  = "IPAdress 2"
+var (
+	testAccResourceIPAddressZoneName                            = testZoneName
+	testAccResourceIPAddressDescription                         = testDescription
+	testAccResourceIPAddressHealthcheckMode                     = "http"
+	testAccResourceIPAddressHealthcheckPort               int64 = 80
+	testAccResourceIPAddressHealthcheckPortUpdated        int64 = 8000
+	testAccResourceIPAddressHealthcheckPath                     = "/health"
+	testAccResourceIPAddressHealthcheckPathUpdated              = "/healthz"
+	testAccResourceIPAddressHealthcheckInterval           int64 = 10
+	testAccResourceIPAddressHealthcheckIntervalUpdated    int64 = 5
+	testAccResourceIPAddressHealthcheckTimeout            int64 = 5
+	testAccResourceIPAddressHealthcheckTimeoutUpdated     int64 = 2
+	testAccResourceIPAddressHealthcheckStrikesOk          int64 = 1
+	testAccResourceIPAddressHealthcheckStrikesOkUpdated   int64 = 2
+	testAccResourceIPAddressHealthcheckStrikesFail        int64 = 2
+	testAccResourceIPAddressHealthcheckStrikesFailUpdated int64 = 3
+
+	testAccIPAddressConfigCreate = fmt.Sprintf(`
+resource "exoscale_ipaddress" "eip" {
+  zone = "%s"
+  healthcheck_mode = "%s"
+  healthcheck_port = %d
+  healthcheck_path = "%s"
+  healthcheck_interval = %d
+  healthcheck_timeout = %d
+  healthcheck_strikes_ok = %d
+  healthcheck_strikes_fail = %d
+  tags = {
+    test = "acceptance"
+  }
+}
+`,
+		testAccResourceIPAddressZoneName,
+		testAccResourceIPAddressHealthcheckMode,
+		testAccResourceIPAddressHealthcheckPort,
+		testAccResourceIPAddressHealthcheckPath,
+		testAccResourceIPAddressHealthcheckInterval,
+		testAccResourceIPAddressHealthcheckTimeout,
+		testAccResourceIPAddressHealthcheckStrikesOk,
+		testAccResourceIPAddressHealthcheckStrikesFail,
+	)
+
+	testAccIPAddressConfigUpdate = fmt.Sprintf(`
+resource "exoscale_ipaddress" "eip" {
+  zone = "%s"
+  description = "%s"
+  healthcheck_mode = "%s"
+  healthcheck_port = %d
+  healthcheck_path = "%s"
+  healthcheck_interval = %d
+  healthcheck_timeout = %d
+  healthcheck_strikes_ok = %d
+  healthcheck_strikes_fail = %d
+}
+`,
+		testAccResourceIPAddressZoneName,
+		testAccResourceIPAddressDescription,
+		testAccResourceIPAddressHealthcheckMode,
+		testAccResourceIPAddressHealthcheckPortUpdated,
+		testAccResourceIPAddressHealthcheckPathUpdated,
+		testAccResourceIPAddressHealthcheckIntervalUpdated,
+		testAccResourceIPAddressHealthcheckTimeoutUpdated,
+		testAccResourceIPAddressHealthcheckStrikesOkUpdated,
+		testAccResourceIPAddressHealthcheckStrikesFailUpdated,
+	)
 )
 
 func TestAccResourceIPAddress(t *testing.T) {
@@ -43,14 +91,13 @@ func TestAccResourceIPAddress(t *testing.T) {
 					testAccCheckIPAddressExists("exoscale_ipaddress.eip", eip),
 					testAccCheckIPAddressCreate(eip),
 					testAccCheckIPAddressAttributes(testAttrs{
-						"healthcheck_mode":         ValidateString(testIPHealthcheckMode1),
-						"healthcheck_port":         ValidateString(fmt.Sprint(testIPHealthcheckPort1)),
-						"healthcheck_path":         ValidateString(testIPHealthcheckPath1),
-						"healthcheck_interval":     ValidateString(fmt.Sprint(testIPHealthcheckInterval1)),
-						"healthcheck_timeout":      ValidateString(fmt.Sprint(testIPHealthcheckTimeout1)),
-						"healthcheck_strikes_ok":   ValidateString(fmt.Sprint(testIPHealthcheckStrikesOk1)),
-						"healthcheck_strikes_fail": ValidateString(fmt.Sprint(testIPHealthcheckStrikesFail1)),
-						"description":              ValidateString(testIPDescription1),
+						"healthcheck_mode":         ValidateString(testAccResourceIPAddressHealthcheckMode),
+						"healthcheck_port":         ValidateString(fmt.Sprint(testAccResourceIPAddressHealthcheckPort)),
+						"healthcheck_path":         ValidateString(testAccResourceIPAddressHealthcheckPath),
+						"healthcheck_interval":     ValidateString(fmt.Sprint(testAccResourceIPAddressHealthcheckInterval)),
+						"healthcheck_timeout":      ValidateString(fmt.Sprint(testAccResourceIPAddressHealthcheckTimeout)),
+						"healthcheck_strikes_ok":   ValidateString(fmt.Sprint(testAccResourceIPAddressHealthcheckStrikesOk)),
+						"healthcheck_strikes_fail": ValidateString(fmt.Sprint(testAccResourceIPAddressHealthcheckStrikesFail)),
 					}),
 				),
 			},
@@ -60,14 +107,14 @@ func TestAccResourceIPAddress(t *testing.T) {
 					testAccCheckIPAddressExists("exoscale_ipaddress.eip", eip),
 					testAccCheckIPAddressUpdate(eip),
 					testAccCheckIPAddressAttributes(testAttrs{
-						"healthcheck_mode":         ValidateString(testIPHealthcheckMode2),
-						"healthcheck_port":         ValidateString(fmt.Sprint(testIPHealthcheckPort2)),
-						"healthcheck_path":         ValidateString(testIPHealthcheckPath2),
-						"healthcheck_interval":     ValidateString(fmt.Sprint(testIPHealthcheckInterval2)),
-						"healthcheck_timeout":      ValidateString(fmt.Sprint(testIPHealthcheckTimeout2)),
-						"healthcheck_strikes_ok":   ValidateString(fmt.Sprint(testIPHealthcheckStrikesOk2)),
-						"healthcheck_strikes_fail": ValidateString(fmt.Sprint(testIPHealthcheckStrikesFail2)),
-						"description":              ValidateString(testIPDescription2),
+						"description":              ValidateString(testAccResourceIPAddressDescription),
+						"healthcheck_mode":         ValidateString(testAccResourceIPAddressHealthcheckMode),
+						"healthcheck_port":         ValidateString(fmt.Sprint(testAccResourceIPAddressHealthcheckPortUpdated)),
+						"healthcheck_path":         ValidateString(testAccResourceIPAddressHealthcheckPathUpdated),
+						"healthcheck_interval":     ValidateString(fmt.Sprint(testAccResourceIPAddressHealthcheckIntervalUpdated)),
+						"healthcheck_timeout":      ValidateString(fmt.Sprint(testAccResourceIPAddressHealthcheckTimeoutUpdated)),
+						"healthcheck_strikes_ok":   ValidateString(fmt.Sprint(testAccResourceIPAddressHealthcheckStrikesOkUpdated)),
+						"healthcheck_strikes_fail": ValidateString(fmt.Sprint(testAccResourceIPAddressHealthcheckStrikesFailUpdated)),
 					}),
 				),
 			},
@@ -78,14 +125,14 @@ func TestAccResourceIPAddress(t *testing.T) {
 				ImportStateCheck: func(s []*terraform.InstanceState) error {
 					return checkResourceAttributes(
 						testAttrs{
-							"healthcheck_mode":         ValidateString(testIPHealthcheckMode2),
-							"healthcheck_port":         ValidateString(fmt.Sprint(testIPHealthcheckPort2)),
-							"healthcheck_path":         ValidateString(testIPHealthcheckPath2),
-							"healthcheck_interval":     ValidateString(fmt.Sprint(testIPHealthcheckInterval2)),
-							"healthcheck_timeout":      ValidateString(fmt.Sprint(testIPHealthcheckTimeout2)),
-							"healthcheck_strikes_ok":   ValidateString(fmt.Sprint(testIPHealthcheckStrikesOk2)),
-							"healthcheck_strikes_fail": ValidateString(fmt.Sprint(testIPHealthcheckStrikesFail2)),
-							"description":              ValidateString(testIPDescription2),
+							"description":              ValidateString(testAccResourceIPAddressDescription),
+							"healthcheck_mode":         ValidateString(testAccResourceIPAddressHealthcheckMode),
+							"healthcheck_port":         ValidateString(fmt.Sprint(testAccResourceIPAddressHealthcheckPortUpdated)),
+							"healthcheck_path":         ValidateString(testAccResourceIPAddressHealthcheckPathUpdated),
+							"healthcheck_interval":     ValidateString(fmt.Sprint(testAccResourceIPAddressHealthcheckIntervalUpdated)),
+							"healthcheck_timeout":      ValidateString(fmt.Sprint(testAccResourceIPAddressHealthcheckTimeoutUpdated)),
+							"healthcheck_strikes_ok":   ValidateString(fmt.Sprint(testAccResourceIPAddressHealthcheckStrikesOkUpdated)),
+							"healthcheck_strikes_fail": ValidateString(fmt.Sprint(testAccResourceIPAddressHealthcheckStrikesFailUpdated)),
 						},
 						s[0].Attributes)
 				},
@@ -130,39 +177,39 @@ func testAccCheckIPAddressCreate(eip *egoscale.IPAddress) resource.TestCheckFunc
 		if eip.Healthcheck == nil {
 			return errors.New("IP healthcheck is nil")
 		}
-		if eip.Healthcheck.Mode != testIPHealthcheckMode1 {
+		if eip.Healthcheck.Mode != testAccResourceIPAddressHealthcheckMode {
 			return fmt.Errorf("expected IP healthcheck mode %v, got %v",
-				testIPHealthcheckMode1,
+				testAccResourceIPAddressHealthcheckMode,
 				eip.Healthcheck.Mode)
 		}
-		if eip.Healthcheck.Port != testIPHealthcheckPort1 {
+		if eip.Healthcheck.Port != testAccResourceIPAddressHealthcheckPort {
 			return fmt.Errorf("expected IP healthcheck port %v, got %v",
-				testIPHealthcheckPort1,
+				testAccResourceIPAddressHealthcheckPort,
 				eip.Healthcheck.Port)
 		}
-		if eip.Healthcheck.Path != testIPHealthcheckPath1 {
+		if eip.Healthcheck.Path != testAccResourceIPAddressHealthcheckPath {
 			return fmt.Errorf("expected IP healthcheck path %v, got %v",
-				testIPHealthcheckPath1,
+				testAccResourceIPAddressHealthcheckPath,
 				eip.Healthcheck.Path)
 		}
-		if eip.Healthcheck.Interval != testIPHealthcheckInterval1 {
+		if eip.Healthcheck.Interval != testAccResourceIPAddressHealthcheckInterval {
 			return fmt.Errorf("expected IP healthcheck interval %v, got %v",
-				testIPHealthcheckInterval1,
+				testAccResourceIPAddressHealthcheckInterval,
 				eip.Healthcheck.Interval)
 		}
-		if eip.Healthcheck.Timeout != testIPHealthcheckTimeout1 {
+		if eip.Healthcheck.Timeout != testAccResourceIPAddressHealthcheckTimeout {
 			return fmt.Errorf("expected IP healthcheck timeout %v, got %v",
-				testIPHealthcheckTimeout1,
+				testAccResourceIPAddressHealthcheckTimeout,
 				eip.Healthcheck.Timeout)
 		}
-		if eip.Healthcheck.StrikesOk != testIPHealthcheckStrikesOk1 {
+		if eip.Healthcheck.StrikesOk != testAccResourceIPAddressHealthcheckStrikesOk {
 			return fmt.Errorf("expected IP healthcheck strikes-ok %v, got %v",
-				testIPHealthcheckStrikesOk1,
+				testAccResourceIPAddressHealthcheckStrikesOk,
 				eip.Healthcheck.StrikesOk)
 		}
-		if eip.Healthcheck.StrikesFail != testIPHealthcheckStrikesFail1 {
+		if eip.Healthcheck.StrikesFail != testAccResourceIPAddressHealthcheckStrikesFail {
 			return fmt.Errorf("expected IP healthcheck strikes-fail %v, got %v",
-				testIPHealthcheckStrikesFail1,
+				testAccResourceIPAddressHealthcheckStrikesFail,
 				eip.Healthcheck.StrikesFail)
 		}
 
@@ -179,39 +226,39 @@ func testAccCheckIPAddressUpdate(eip *egoscale.IPAddress) resource.TestCheckFunc
 		if eip.Healthcheck == nil {
 			return errors.New("IP healthcheck is nil")
 		}
-		if eip.Healthcheck.Mode != testIPHealthcheckMode2 {
+		if eip.Healthcheck.Mode != testAccResourceIPAddressHealthcheckMode {
 			return fmt.Errorf("expected IP healthcheck mode %v, got %v",
-				testIPHealthcheckMode2,
+				testAccResourceIPAddressHealthcheckMode,
 				eip.Healthcheck.Mode)
 		}
-		if eip.Healthcheck.Port != testIPHealthcheckPort2 {
+		if eip.Healthcheck.Port != testAccResourceIPAddressHealthcheckPortUpdated {
 			return fmt.Errorf("expected IP healthcheck port %v, got %v",
-				testIPHealthcheckPort2,
+				testAccResourceIPAddressHealthcheckPortUpdated,
 				eip.Healthcheck.Port)
 		}
-		if eip.Healthcheck.Path != testIPHealthcheckPath2 {
+		if eip.Healthcheck.Path != testAccResourceIPAddressHealthcheckPathUpdated {
 			return fmt.Errorf("expected IP healthcheck path %v, got %v",
-				testIPHealthcheckPath2,
+				testAccResourceIPAddressHealthcheckPathUpdated,
 				eip.Healthcheck.Path)
 		}
-		if eip.Healthcheck.Interval != testIPHealthcheckInterval2 {
+		if eip.Healthcheck.Interval != testAccResourceIPAddressHealthcheckIntervalUpdated {
 			return fmt.Errorf("expected IP healthcheck interval %v, got %v",
-				testIPHealthcheckInterval2,
+				testAccResourceIPAddressHealthcheckIntervalUpdated,
 				eip.Healthcheck.Interval)
 		}
-		if eip.Healthcheck.Timeout != testIPHealthcheckTimeout2 {
+		if eip.Healthcheck.Timeout != testAccResourceIPAddressHealthcheckTimeoutUpdated {
 			return fmt.Errorf("expected IP healthcheck timeout %v, got %v",
-				testIPHealthcheckTimeout2,
+				testAccResourceIPAddressHealthcheckTimeoutUpdated,
 				eip.Healthcheck.Timeout)
 		}
-		if eip.Healthcheck.StrikesOk != testIPHealthcheckStrikesOk2 {
+		if eip.Healthcheck.StrikesOk != testAccResourceIPAddressHealthcheckStrikesOkUpdated {
 			return fmt.Errorf("expected IP healthcheck strikes-ok %v, got %v",
-				testIPHealthcheckStrikesOk2,
+				testAccResourceIPAddressHealthcheckStrikesOkUpdated,
 				eip.Healthcheck.StrikesOk)
 		}
-		if eip.Healthcheck.StrikesFail != testIPHealthcheckStrikesFail2 {
+		if eip.Healthcheck.StrikesFail != testAccResourceIPAddressHealthcheckStrikesFailUpdated {
 			return fmt.Errorf("expected IP healthcheck strikes-fail %v, got %v",
-				testIPHealthcheckStrikesFail2,
+				testAccResourceIPAddressHealthcheckStrikesFailUpdated,
 				eip.Healthcheck.StrikesFail)
 		}
 
@@ -263,54 +310,3 @@ func testAccCheckIPAddressDestroy(s *terraform.State) error {
 	}
 	return nil
 }
-
-var testAccIPAddressConfigCreate = fmt.Sprintf(`
-resource "exoscale_ipaddress" "eip" {
-  zone = %q
-  description = %q
-  healthcheck_mode = "%s"
-  healthcheck_port = %d
-  healthcheck_path = "%s"
-  healthcheck_interval = %d
-  healthcheck_timeout = %d
-  healthcheck_strikes_ok = %d
-  healthcheck_strikes_fail = %d
-  tags = {
-    test = "acceptance"
-  }
-}
-`,
-	defaultExoscaleZone,
-	testIPDescription1,
-	testIPHealthcheckMode1,
-	testIPHealthcheckPort1,
-	testIPHealthcheckPath1,
-	testIPHealthcheckInterval1,
-	testIPHealthcheckTimeout1,
-	testIPHealthcheckStrikesOk1,
-	testIPHealthcheckStrikesFail1,
-)
-
-var testAccIPAddressConfigUpdate = fmt.Sprintf(`
-resource "exoscale_ipaddress" "eip" {
-  zone = %q
-  description = %q
-  healthcheck_mode = "%s"
-  healthcheck_port = %d
-  healthcheck_path = "%s"
-  healthcheck_interval = %d
-  healthcheck_timeout = %d
-  healthcheck_strikes_ok = %d
-  healthcheck_strikes_fail = %d
-}
-`,
-	defaultExoscaleZone,
-	testIPDescription2,
-	testIPHealthcheckMode2,
-	testIPHealthcheckPort2,
-	testIPHealthcheckPath2,
-	testIPHealthcheckInterval2,
-	testIPHealthcheckTimeout2,
-	testIPHealthcheckStrikesOk2,
-	testIPHealthcheckStrikesFail2,
-)

--- a/exoscale/resource_exoscale_security_group_test.go
+++ b/exoscale/resource_exoscale_security_group_test.go
@@ -10,9 +10,18 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-const (
-	testSecurityGroupName        = "terraform-test-security-group"
-	testSecurityGroupDescription = "Terraform Security Group Test"
+var (
+	testAccResourceSecurityGroupName        = testPrefix + "-" + testRandomString()
+	testAccResourceSecurityGroupDescription = testDescription
+
+	testAccResourceSecurityGroupConfig = fmt.Sprintf(`
+resource "exoscale_security_group" "sg" {
+  name = "%s"
+  description = "%s"
+}
+`,
+		testAccResourceSecurityGroupName,
+		testAccResourceSecurityGroupDescription)
 )
 
 func TestAccResourceSecurityGroup(t *testing.T) {
@@ -29,7 +38,8 @@ func TestAccResourceSecurityGroup(t *testing.T) {
 					testAccCheckResourceSecurityGroupExists("exoscale_security_group.sg", sg),
 					testAccCheckResourceSecurityGroup(sg),
 					testAccCheckResourceSecurityGroupAttributes(testAttrs{
-						"description": ValidateString(testSecurityGroupDescription),
+						"name":        ValidateString(testAccResourceSecurityGroupName),
+						"description": ValidateString(testAccResourceSecurityGroupDescription),
 					}),
 				),
 			},
@@ -40,8 +50,8 @@ func TestAccResourceSecurityGroup(t *testing.T) {
 				ImportStateCheck: func(s []*terraform.InstanceState) error {
 					return checkResourceAttributes(
 						testAttrs{
-							"name":        ValidateString(testSecurityGroupName),
-							"description": ValidateString(testSecurityGroupDescription),
+							"name":        ValidateString(testAccResourceSecurityGroupName),
+							"description": ValidateString(testAccResourceSecurityGroupDescription),
 						},
 						s[0].Attributes)
 				},
@@ -128,12 +138,3 @@ func testAccCheckResourceSecurityGroupDestroy(s *terraform.State) error {
 	}
 	return errors.New("Security Group still exists")
 }
-
-var testAccResourceSecurityGroupConfig = fmt.Sprintf(`
-resource "exoscale_security_group" "sg" {
-  name = "%s"
-  description = "%s"
-}
-`,
-	testSecurityGroupName,
-	testSecurityGroupDescription)

--- a/exoscale/resource_exoscale_ssh_keypair_test.go
+++ b/exoscale/resource_exoscale_ssh_keypair_test.go
@@ -10,10 +10,23 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-const (
-	testSSHKey            = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDN7L45b4vO2ytH68ZUC5PMS1b7JG78zGslwcJ0zolE5BuxsCYor248/FKGC5TXrME+yBu/uLqaAkioq4Wp1PzP6Zy5jEowWQDOdeER7uu1GgZShcvly2Oaf/UKLqTdwL+U3tCknqHY63fOAi1lBwmNTUu1uZ24iNiogfhXwQn7HJLQK9vfoGwg+/qJIzeswR6XDa6qh0fuzdxWQ4JWHw2s8fv8WvGOlklmAg/uEi1kF5D6R7kJpOVaE20FLnT4sjA81iErhMIH77OaZqQKiyVH3i5m/lkQI/2e25ml8aculaWzHOs4ctd7l+K1ZWFYje3qMBY1sar1gd787eaqk6RZ"
-	testSSHKeyFingerprint = "4d:31:21:c4:77:9f:19:91:6e:84:9d:7c:12:a8:11:1f"
-	testSSHKeyName        = "terraform-test-keypair"
+var (
+	testAccResourceSSHKeyName = testPrefix + "-" + testRandomString()
+	testAccResourceSSHKey     = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDN7L45b4vO2ytH68ZU" +
+		"C5PMS1b7JG78zGslwcJ0zolE5BuxsCYor248/FKGC5TXrME+yBu/uLqaAkioq4Wp1PzP6Zy5jEowWQDO" +
+		"deER7uu1GgZShcvly2Oaf/UKLqTdwL+U3tCknqHY63fOAi1lBwmNTUu1uZ24iNiogfhXwQn7HJLQK9vf" +
+		"oGwg+/qJIzeswR6XDa6qh0fuzdxWQ4JWHw2s8fv8WvGOlklmAg/uEi1kF5D6R7kJpOVaE20FLnT4sjA8" +
+		"1iErhMIH77OaZqQKiyVH3i5m/lkQI/2e25ml8aculaWzHOs4ctd7l+K1ZWFYje3qMBY1sar1gd787eaqk6RZ"
+	testAccResourceSSHKeyFingerprint = "4d:31:21:c4:77:9f:19:91:6e:84:9d:7c:12:a8:11:1f"
+
+	testAccResourceSSHKeypairConfig = fmt.Sprintf(`
+resource "exoscale_ssh_keypair" "key" {
+  name       = "%s"
+  public_key = "%s"
+}
+`,
+		testAccResourceSSHKeyName,
+		testAccResourceSSHKey)
 )
 
 func TestAccResourceSSHKeypair(t *testing.T) {
@@ -30,8 +43,8 @@ func TestAccResourceSSHKeypair(t *testing.T) {
 					testAccCheckResourceSSHKeypairExists("exoscale_ssh_keypair.key", sshkey),
 					testAccCheckResourceSSHKeypair(sshkey),
 					testAccCheckResourceSSHKeypairAttributes(testAttrs{
-						"public_key":  ValidateString(testSSHKey),
-						"fingerprint": ValidateString(testSSHKeyFingerprint),
+						"public_key":  ValidateString(testAccResourceSSHKey),
+						"fingerprint": ValidateString(testAccResourceSSHKeyFingerprint),
 					}),
 				),
 			},
@@ -43,8 +56,8 @@ func TestAccResourceSSHKeypair(t *testing.T) {
 				ImportStateCheck: func(s []*terraform.InstanceState) error {
 					return checkResourceAttributes(
 						testAttrs{
-							"name":        ValidateString(testSSHKeyName),
-							"fingerprint": ValidateString(testSSHKeyFingerprint),
+							"name":        ValidateString(testAccResourceSSHKeyName),
+							"fingerprint": ValidateString(testAccResourceSSHKeyFingerprint),
 						},
 						s[0].Attributes)
 				},
@@ -120,12 +133,3 @@ func testAccCheckResourceSSHKeypairDestroy(s *terraform.State) error {
 	}
 	return errors.New("SSH Keypair still exists")
 }
-
-var testAccResourceSSHKeypairConfig = fmt.Sprintf(`
-resource "exoscale_ssh_keypair" "key" {
-  name       = "%s"
-  public_key = "%s"
-}
-`,
-	testSSHKeyName,
-	testSSHKey)


### PR DESCRIPTION
This change refactors the resources acceptances tests to make them more
consistent and more reliable using randomly generated resource names to
avoid name collisions.