### PR TITLE
Remove interpolation on variable attribute

### DIFF
--- a/examples/cloud-init/config.tf
+++ b/examples/cloud-init/config.tf
@@ -3,7 +3,7 @@ provider "template" {
 }
 
 provider "exoscale" {
-  version = "~> 0.11"
-  key = "${var.key}"
-  secret = "${var.secret}"
+  version = "~> 0.15"
+  key = var.key
+  secret = var.secret
 }

--- a/examples/cloud-init/config.tf
+++ b/examples/cloud-init/config.tf
@@ -1,5 +1,5 @@
 provider "template" {
-  version = "~> 1.0"
+  version = "~> 2.1"
 }
 
 provider "exoscale" {

--- a/examples/cloud-init/data.tf
+++ b/examples/cloud-init/data.tf
@@ -1,10 +1,10 @@
 data "template_file" "init" {
-  template = "${file("init.tpl")}"
-  count = "${length(var.hostnames)}"
+  template = file("init.tpl")
+  count = length(var.hostnames)
 
   vars {
-    ubuntu = "${var.flavor}"
-    fqdn = "${element(var.hostnames, count.index)}"
+    ubuntu = var.flavor
+    fqdn = element(var.hostnames, count.index)
   }
 }
 
@@ -12,11 +12,11 @@ data "template_cloudinit_config" "config" {
   gzip = false
   base64_encode = false
 
-  count = "${length(var.hostnames)}"
+  count = length(var.hostnames)
 
   part {
     filename = "init.cfg"
     content_type = "text/cloud-config"
-    content = "${element(data.template_file.init.*.rendered, count.index)}"
+    content = element(data.template_file.init.*.rendered, count.index)
   }
 }

--- a/examples/cloud-init/data.tf
+++ b/examples/cloud-init/data.tf
@@ -2,7 +2,7 @@ data "template_file" "init" {
   template = file("init.tpl")
   count = length(var.hostnames)
 
-  vars {
+  vars = {
     ubuntu = var.flavor
     fqdn = element(var.hostnames, count.index)
   }

--- a/examples/cloud-init/instances.tf
+++ b/examples/cloud-init/instances.tf
@@ -4,23 +4,23 @@ resource "exoscale_affinity" "swarm_manager" {
 }
 
 data "exoscale_compute_template" "master" {
-  zone = "${var.zone}"
-  name = "${var.template}"
+  zone = var.zone
+  name = var.template
 }
 
 resource "exoscale_compute" "master" {
-  count = "${length(var.hostnames)}"
-  display_name = "${element(var.hostnames, count.index)}"
-  template_id = "${data.exoscale_compute_template.master.id}"
-  zone = "${var.zone}"
+  count = length(var.hostnames)
+  display_name = element(var.hostnames, count.index)
+  template_id = data.exoscale_compute_template.master.id
+  zone = var.zone
   size = "Medium"
   disk_size = 50
 
-  key_pair = "${var.key_pair}"
-  affinity_groups = ["${exoscale_affinity.swarm_manager.name}"]
-  security_groups = ["default", "${exoscale_security_group.swarm.name}"]
+  key_pair = var.key_pair
+  affinity_groups = [exoscale_affinity.swarm_manager.name]
+  security_groups = ["default", exoscale_security_group.swarm.name]
 
-  user_data = "${element(data.template_cloudinit_config.config.*.rendered, count.index)}"
+  user_data = element(data.template_cloudinit_config.config.*.rendered, count.index)
 
   tags = {
     managedby = "terraform"
@@ -29,5 +29,5 @@ resource "exoscale_compute" "master" {
 }
 
 output "master_ips" {
-  value = "${join(",", exoscale_compute.master.*.ip_address)}"
+  value = join(",", exoscale_compute.master.*.ip_address)
 }

--- a/examples/cloud-init/security_groups.tf
+++ b/examples/cloud-init/security_groups.tf
@@ -3,7 +3,7 @@ resource "exoscale_security_group" "swarm" {
 }
 
 resource "exoscale_security_group_rule" "docker_client" {
-  security_group_id = "${exoscale_security_group.swarm.id}"
+  security_group_id = exoscale_security_group.swarm.id
   protocol = "TCP"
   type = "INGRESS"
   cidr = "0.0.0.0/0"
@@ -12,37 +12,37 @@ resource "exoscale_security_group_rule" "docker_client" {
 }
 
 resource "exoscale_security_group_rule" "docker_swarm" {
-  security_group_id = "${exoscale_security_group.swarm.id}"
+  security_group_id = exoscale_security_group.swarm.id
   protocol = "TCP"
   type = "INGRESS"
-  user_security_group_id = "${exoscale_security_group.swarm.id}"
+  user_security_group_id = exoscale_security_group.swarm.id
   start_port = 2377
   end_port = 2377
 }
 
 resource "exoscale_security_group_rule" "docker_swarm_nodes_tcp" {
-  security_group_id = "${exoscale_security_group.swarm.id}"
+  security_group_id = exoscale_security_group.swarm.id
   protocol = "TCP"
   type = "INGRESS"
-  user_security_group_id = "${exoscale_security_group.swarm.id}"
+  user_security_group_id = exoscale_security_group.swarm.id
   start_port = 7946
   end_port = 7946
 }
 
 resource "exoscale_security_group_rule" "docker_swarm_nodes_udp" {
-  security_group_id = "${exoscale_security_group.swarm.id}"
+  security_group_id = exoscale_security_group.swarm.id
   protocol = "UDP"
   type = "INGRESS"
-  user_security_group_id = "${exoscale_security_group.swarm.id}"
+  user_security_group_id = exoscale_security_group.swarm.id
   start_port = 7946
   end_port = 7946
 }
 
 resource "exoscale_security_group_rule" "docker_swarm_overlay_net" {
-  security_group_id = "${exoscale_security_group.swarm.id}"
+  security_group_id = exoscale_security_group.swarm.id
   protocol = "UDP"
   type = "INGRESS"
-  user_security_group_id = "${exoscale_security_group.swarm.id}"
+  user_security_group_id = exoscale_security_group.swarm.id
   start_port = 4789
   end_port = 4789
 }

--- a/examples/cloud-init/variables.tf
+++ b/examples/cloud-init/variables.tf
@@ -5,7 +5,7 @@ variable "key_pair" {}
 
 // hostnames are used as a source
 variable "hostnames" {
-  type = "list"
+  type = list
   default = [
     "huey",
     "dewey",

--- a/examples/dns/README.md
+++ b/examples/dns/README.md
@@ -2,7 +2,7 @@
 
 This example creats a domain `example.exo` with three records
 
-- **A** so that `example.exo` points to the IPv4 of the instance (`"${exoscale_compute.<name>.ip_address}"`)
+- **A** so that `example.exo` points to the IPv4 of the instance (`exoscale_compute.<name>.ip_address`)
 - **CNAME** to alias `www.example.exo` to `example.exo`
 - **TXT** to put a text field
 

--- a/examples/dns/main.tf
+++ b/examples/dns/main.tf
@@ -1,7 +1,7 @@
 provider "exoscale" {
-  version = "~> 0.11"
-  key = "${var.key}"
-  secret = "${var.secret}"
+  version = "~> 0.15"
+  key = var.key
+  secret = var.secret
 }
 
 resource "exoscale_domain" "exo" {
@@ -9,22 +9,22 @@ resource "exoscale_domain" "exo" {
 }
 
 resource "exoscale_domain_record" "root" {
-  domain = "${exoscale_domain.exo.name}"
+  domain = exoscale_domain.exo.name
   content = "159.100.200.1"
   name = ""
   record_type = "A"
 }
 
 resource "exoscale_domain_record" "www" {
-  domain = "${exoscale_domain.exo.name}"
-  content = "${exoscale_domain_record.root.hostname}"
+  domain = exoscale_domain.exo.name
+  content = exoscale_domain_record.root.hostname
   name = "www"
   record_type = "CNAME"
   ttl = 7200
 }
 
 resource "exoscale_domain_record" "hello" {
-  domain = "${exoscale_domain.exo.name}"
+  domain = exoscale_domain.exo.name
   content = "hello world!"
   name = ""
   record_type = "TXT"

--- a/examples/elastic-ip/main.tf
+++ b/examples/elastic-ip/main.tf
@@ -3,46 +3,46 @@ provider "template" {
 }
 
 provider "exoscale" {
-  version = "~> 0.11"
-  key = "${var.key}"
-  secret = "${var.secret}"
+  version = "~> 0.15"
+  key = var.key
+  secret = var.secret
 }
 
 data "exoscale_compute_template" "ubuntu" {
-  zone = "${var.zone}"
+  zone = var.zone
   name = "Linux Ubuntu 18.04 LTS 64-bit"
 }
 
 resource "exoscale_ipaddress" "ingress" {
-  zone = "${var.zone}"
+  zone = var.zone
   description = "my elastic IP"
 }
 
 data "template_file" "cloudinit" {
-  template = "${file("init.tpl")}"
+  template = file("init.tpl")
 
   vars {
-    eip = "${exoscale_ipaddress.ingress.ip_address}"
+    eip = exoscale_ipaddress.ingress.ip_address
   }
 }
 
 resource "exoscale_compute" "machine" {
   display_name = "machine"
-  template_id = "${data.exoscale_compute_template.ubuntu.id}"
+  template_id = data.exoscale_compute_template.ubuntu.id
   size = "Medium"
   disk_size = "22"
-  key_pair = "${var.key_pair}"
-  zone = "${var.zone}"
+  key_pair = var.key_pair
+  zone = var.zone
 
   security_groups = ["default"]
-  user_data = "${data.template_file.cloudinit.rendered}"
+  user_data = data.template_file.cloudinit.rendered
 }
 
 resource "exoscale_secondary_ipaddress" "machine" {
-  compute_id = "${exoscale_compute.machine.id}"
-  ip_address = "${exoscale_ipaddress.ingress.ip_address}"
+  compute_id = exoscale_compute.machine.id
+  ip_address = exoscale_ipaddress.ingress.ip_address
 }
 
 output "connection" {
-  value = "${format("%s@%s", exoscale_compute.machine.username, exoscale_compute.machine.ip_address)}"
+  value = format("%s@%s", exoscale_compute.machine.username, exoscale_compute.machine.ip_address)
 }

--- a/examples/elastic-ip/main.tf
+++ b/examples/elastic-ip/main.tf
@@ -1,5 +1,5 @@
 provider "template" {
-  version = "~> 1.0"
+  version = "~> 2.1"
 }
 
 provider "exoscale" {
@@ -21,7 +21,7 @@ resource "exoscale_ipaddress" "ingress" {
 data "template_file" "cloudinit" {
   template = file("init.tpl")
 
-  vars {
+  vars = {
     eip = exoscale_ipaddress.ingress.ip_address
   }
 }

--- a/examples/exokube/main.tf
+++ b/examples/exokube/main.tf
@@ -3,28 +3,28 @@ provider "template" {
 }
 
 provider "exoscale" {
-  version = "~> 0.11"
-  key = "${var.key}"
-  secret = "${var.secret}"
+  version = "~> 0.15"
+  key = var.key
+  secret = var.secret
 }
 
 data "exoscale_compute_template" "exokube" {
-  zone = "${var.zone}"
-  name = "${var.template}"
+  zone = var.zone
+  name = var.template
 }
 
 resource "exoscale_compute" "exokube" {
   display_name = "exokube"
   size = "Medium"
   disk_size = 50
-  zone = "${var.zone}"
-  template_id = "${data.exoscale_compute_template.exokube.id}"
-  key_pair = "${var.key_pair}"
+  zone = var.zone
+  template_id = data.exoscale_compute_template.exokube.id
+  key_pair = var.key_pair
   ip6 = true
 
   security_groups = [
-    "${exoscale_security_group.exokube.name}",
+    exoscale_security_group.exokube.name,
   ]
 
-  user_data = "${data.template_cloudinit_config.exokube.rendered}"
+  user_data = data.template_cloudinit_config.exokube.rendered
 }

--- a/examples/exokube/main.tf
+++ b/examples/exokube/main.tf
@@ -1,5 +1,5 @@
 provider "template" {
-  version = "~> 1.0"
+  version = "~> 2.1"
 }
 
 provider "exoscale" {

--- a/examples/exokube/output.tf
+++ b/examples/exokube/output.tf
@@ -1,5 +1,5 @@
 output "exokube_ssh" {
-  value = "${exoscale_compute.exokube.username}@${exoscale_compute.exokube.ip_address}"
+  value = exoscale_compute.exokube.username}@${exoscale_compute.exokube.ip_address
 }
 
 output "exokube_https" {

--- a/examples/exokube/output.tf
+++ b/examples/exokube/output.tf
@@ -1,5 +1,5 @@
 output "exokube_ssh" {
-  value = exoscale_compute.exokube.username}@${exoscale_compute.exokube.ip_address
+  value = format("%s@%s", exoscale_compute.exokube.username, exoscale_compute.exokube.ip_address)
 }
 
 output "exokube_https" {

--- a/examples/exokube/security_groups.tf
+++ b/examples/exokube/security_groups.tf
@@ -4,7 +4,7 @@ resource "exoscale_security_group" "exokube" {
 }
 
 resource "exoscale_security_group_rules" "exokube" {
-  security_group_id = "${exoscale_security_group.exokube.id}"
+  security_group_id = exoscale_security_group.exokube.id
 
   ingress {
     description = "Ping"

--- a/examples/exokube/user_data.tf
+++ b/examples/exokube/user_data.tf
@@ -1,7 +1,7 @@
 data "template_file" "exokube" {
   template = file("cloud-config.yaml")
 
-  vars {
+  vars = {
     fqdn = "exokube"
     ubuntu = var.ubuntu_flavor
     docker_version = var.docker_version

--- a/examples/exokube/user_data.tf
+++ b/examples/exokube/user_data.tf
@@ -1,11 +1,11 @@
 data "template_file" "exokube" {
-  template = "${file("cloud-config.yaml")}"
+  template = file("cloud-config.yaml")
 
   vars {
     fqdn = "exokube"
-    ubuntu = "${var.ubuntu_flavor}"
-    docker_version = "${var.docker_version}"
-    calico_version = "${var.calico_version}"
+    ubuntu = var.ubuntu_flavor
+    docker_version = var.docker_version
+    calico_version = var.calico_version
   }
 }
 
@@ -13,6 +13,6 @@ data "template_cloudinit_config" "exokube" {
   part {
     filename = "init.cfg"
     content_type = "text/cloud-config"
-    content = "${data.template_file.exokube.rendered}"
+    content = data.template_file.exokube.rendered
   }
 }

--- a/examples/import-compute/config.tf
+++ b/examples/import-compute/config.tf
@@ -1,5 +1,5 @@
 provider "exoscale" {
-  version = "~> 0.11"
-  key = "${var.key}"
-  secret = "${var.secret}"
+  version = "~> 0.15"
+  key = var.key
+  secret = var.secret
 }

--- a/examples/import-compute/instances.tf
+++ b/examples/import-compute/instances.tf
@@ -8,7 +8,7 @@ resource "exoscale_compute" "ada" {
   key_pair = "my@keypair"
   disk_size = 10
   size = "Tiny"
-  template_id = "${data.exoscale_compute_template.debian.id}"
+  template_id = data.exoscale_compute_template.debian.id
   zone = "ch-dk-2"
 
   timeouts {
@@ -16,5 +16,5 @@ resource "exoscale_compute" "ada" {
     delete = "2h"
   }
 
-  security_groups = ["${exoscale_security_group.default.name}"]
+  security_groups = [exoscale_security_group.default.name]
 }

--- a/examples/import-compute/security_groups.tf
+++ b/examples/import-compute/security_groups.tf
@@ -5,7 +5,7 @@ resource "exoscale_security_group" "default" {
 
 resource "exoscale_security_group_rule" "default" {
   type = "INGRESS"
-  security_group_id = "${exoscale_security_group.default.id}"
+  security_group_id = exoscale_security_group.default.id
   protocol = "ICMP"
   icmp_type = 8
   icmp_code = 0
@@ -14,7 +14,7 @@ resource "exoscale_security_group_rule" "default" {
 
 resource "exoscale_security_group_rule" "default-1" {
   type = "INGRESS"
-  security_group_id = "${exoscale_security_group.default.id}"
+  security_group_id = exoscale_security_group.default.id
   protocol = "TCP"
   start_port = 22
   end_port = 22

--- a/examples/instance-pool/main.tf
+++ b/examples/instance-pool/main.tf
@@ -27,6 +27,7 @@ resource "exoscale_instance_pool" "instancepool-test" {
 }
 
 provider "exoscale" {
+  version = "~> 0.15"
   key = var.key
   secret = var.secret
   compute_endpoint = "https://api.exoscale.com/compute"

--- a/examples/instance-pool/main.tf
+++ b/examples/instance-pool/main.tf
@@ -15,7 +15,7 @@ resource "exoscale_instance_pool" "instancepool-test" {
   name = "terraforminstancepool"
   description = "test"
   template_id = data.exoscale_compute_template.instancepool.id
-  service_offering = "Medium"
+  service_offering = "medium"
   size = 5
   disk_size = 50
   user_data = "#cloud-config\npackage_upgrade: true\n"

--- a/examples/instance-pool/main.tf
+++ b/examples/instance-pool/main.tf
@@ -7,27 +7,27 @@ variable "template" {
 }
 
 data "exoscale_compute_template" "instancepool" {
-  zone = "${var.zone}"
-  name = "${var.template}"
+  zone = var.zone
+  name = var.template
 }
 
 resource "exoscale_instance_pool" "instancepool-test" {
   name = "terraforminstancepool"
   description = "test"
-  template_id = "${data.exoscale_compute_template.instancepool.id}"
+  template_id = data.exoscale_compute_template.instancepool.id
   service_offering = "Medium"
   size = 5
   disk_size = 50
   user_data = "#cloud-config\npackage_upgrade: true\n"
   key_pair = "test"
-  zone = "${var.zone}"
+  zone = var.zone
 
   # security_group_ids = ["xxxx", "xxx"]
   # network_ids = ["xxxx", "xxx"]
 }
 
 provider "exoscale" {
-  key = "${var.key}"
-  secret = "${var.secret}"
+  key = var.key
+  secret = var.secret
   compute_endpoint = "https://api.exoscale.com/compute"
 }

--- a/examples/instance-pool/vars.tf
+++ b/examples/instance-pool/vars.tf
@@ -1,0 +1,2 @@
+variable "key" {}
+variable "secret" {}

--- a/examples/ipv6/main.tf
+++ b/examples/ipv6/main.tf
@@ -1,12 +1,12 @@
 provider "exoscale" {
-  version = "~> 0.11"
-  key = "${var.key}"
-  secret = "${var.secret}"
+  version = "~> 0.15"
+  key = var.key
+  secret = var.secret
 }
 
 data "exoscale_compute_template" "main" {
-  zone = "${var.zone}"
-  name = "${var.template}"
+  zone = var.zone
+  name = var.template
 }
 
 resource "exoscale_security_group" "default" {
@@ -15,7 +15,7 @@ resource "exoscale_security_group" "default" {
 
 resource "exoscale_security_group_rule" "default-ssh-4" {
   description = "ssh -4"
-  security_group_id = "${exoscale_security_group.default.id}"
+  security_group_id = exoscale_security_group.default.id
   protocol = "TCP"
   type = "INGRESS"
   cidr = "0.0.0.0/0"
@@ -25,7 +25,7 @@ resource "exoscale_security_group_rule" "default-ssh-4" {
 
 resource "exoscale_security_group_rule" "default-ssh-6" {
   description = "ssh -6"
-  security_group_id = "${exoscale_security_group.default.id}"
+  security_group_id = exoscale_security_group.default.id
   protocol = "TCP"
   type = "INGRESS"
   cidr = "::/0"
@@ -35,30 +35,30 @@ resource "exoscale_security_group_rule" "default-ssh-6" {
 
 resource "exoscale_compute" "main" {
   display_name = "test-ipv6"
-  template_id = "${data.exoscale_compute_template.main.id}"
-  zone = "${var.zone}"
+  template_id = data.exoscale_compute_template.main.id
+  zone = var.zone
   size = "Medium"
   disk_size = 11
 
   ip6 = true
 
-  key_pair = "${var.key_pair}"
+  key_pair = var.key_pair
   user_data = <<EOF
 #cloud-config
 manage_etc_hosts: localhost
 EOF
 
-  security_groups = ["${exoscale_security_group.default.name}"]
+  security_groups = [exoscale_security_group.default.name]
 }
 
 output "username" {
-  value = "${exoscale_compute.main.username}"
+  value = exoscale_compute.main.username
 }
 
 output "ip_address" {
-  value = "${exoscale_compute.main.ip_address}"
+  value = exoscale_compute.main.ip_address
 }
 
 output "ip6_address" {
-  value = "${exoscale_compute.main.ip6_address}"
+  value = exoscale_compute.main.ip6_address
 }

--- a/examples/ipv6/variables.tf
+++ b/examples/ipv6/variables.tf
@@ -7,5 +7,5 @@ variable "zone" {
 }
 
 variable "template" {
-  default = "Linux CentOS 7.4 64-bit"
+  default = "Linux Ubuntu 18.04 LTS 64-bit"
 }

--- a/examples/managed-private-network/main.tf
+++ b/examples/managed-private-network/main.tf
@@ -45,7 +45,7 @@ resource "exoscale_compute" "static" {
 }
 
 resource "exoscale_nic" "eth_static" {
-  count = exoscale_compute.static.count
+  count = length(exoscale_compute.static)
 
   compute_id = exoscale_compute.static.*.id[count.index]
   network_id = exoscale_network.intra.id
@@ -70,7 +70,7 @@ resource "exoscale_compute" "dynamic" {
 }
 
 resource "exoscale_nic" "eth_dynamic" {
-  count = exoscale_compute.dynamic.count
+  count = length(exoscale_compute.dynamic)
 
   compute_id = exoscale_compute.dynamic.*.id[count.index]
   network_id = exoscale_network.intra.id

--- a/examples/managed-private-network/main.tf
+++ b/examples/managed-private-network/main.tf
@@ -15,14 +15,14 @@ variable "dynamic_machines" {
 }
 
 data "exoscale_compute_template" "ubuntu" {
-  zone = "${var.zone}"
+  zone = var.zone
   name = "Linux Ubuntu 18.04 LTS 64-bit"
 }
 
 resource "exoscale_network" "intra" {
   name = "demo-intra"
   display_text = "demo intra privnet"
-  zone = "${var.zone}"
+  zone = var.zone
 
   start_ip = "10.0.0.50"
   end_ip = "10.0.0.250"
@@ -30,54 +30,54 @@ resource "exoscale_network" "intra" {
 }
 
 resource "exoscale_compute" "static" {
-  count = "${var.static_machines}"
+  count = var.static_machines
 
   display_name = "demo-static-${count.index}"
 
-  template_id = "${data.exoscale_compute_template.ubuntu.id}"
+  template_id = data.exoscale_compute_template.ubuntu.id
   size = "Small"
   disk_size = "10"
   security_groups = ["default"]
-  key_pair = "${var.key_pair}"
-  zone = "${var.zone}"
+  key_pair = var.key_pair
+  zone = var.zone
 
-  user_data = "${file("cloud-config.yaml")}"
+  user_data = file("cloud-config.yaml")
 }
 
 resource "exoscale_nic" "eth_static" {
-  count = "${exoscale_compute.static.count}"
+  count = exoscale_compute.static.count
 
-  compute_id = "${exoscale_compute.static.*.id[count.index]}"
-  network_id = "${exoscale_network.intra.id}"
+  compute_id = exoscale_compute.static.*.id[count.index]
+  network_id = exoscale_network.intra.id
 
   # static IP address
-  ip_address = "${format("10.0.0.%d", count.index + 1)}"
+  ip_address = format("10.0.0.%d", count.index + 1)
 }
 
 resource "exoscale_compute" "dynamic" {
-  count = "${var.dynamic_machines}"
+  count = var.dynamic_machines
 
   display_name = "demo-dynamic-${count.index}"
 
-  template_id = "${data.exoscale_compute_template.ubuntu.id}"
+  template_id = data.exoscale_compute_template.ubuntu.id
   size = "Small"
   disk_size = "10"
   security_groups = ["default"]
-  key_pair = "${var.key_pair}"
-  zone = "${var.zone}"
+  key_pair = var.key_pair
+  zone = var.zone
 
-  user_data = "${file("cloud-config.yaml")}"
+  user_data = file("cloud-config.yaml")
 }
 
 resource "exoscale_nic" "eth_dynamic" {
-  count = "${exoscale_compute.dynamic.count}"
+  count = exoscale_compute.dynamic.count
 
-  compute_id = "${exoscale_compute.dynamic.*.id[count.index]}"
-  network_id = "${exoscale_network.intra.id}"
+  compute_id = exoscale_compute.dynamic.*.id[count.index]
+  network_id = exoscale_network.intra.id
 }
 
 provider "exoscale" {
-  version = "~> 0.11"
-  key = "${var.key}"
-  secret = "${var.secret}"
+  version = "~> 0.15"
+  key = var.key
+  secret = var.secret
 }

--- a/examples/multi-private-network/data.tf
+++ b/examples/multi-private-network/data.tf
@@ -1,6 +1,6 @@
 data "template_file" "user_data" {
-  template = "${file("cloud-config.yaml")}"
-  count = "${var.machines}"
+  template = file("cloud-config.yaml")
+  count = var.machines
 
   vars {
     hostname = "demo-machine-${count.index}"

--- a/examples/multi-private-network/data.tf
+++ b/examples/multi-private-network/data.tf
@@ -2,7 +2,7 @@ data "template_file" "user_data" {
   template = file("cloud-config.yaml")
   count = var.machines
 
-  vars {
+  vars = {
     hostname = "demo-machine-${count.index}"
     ip_address = "192.168.0.${format("%d", 1 + count.index)}/24"
   }

--- a/examples/multi-private-network/instances.tf
+++ b/examples/multi-private-network/instances.tf
@@ -23,7 +23,7 @@ resource "exoscale_compute" "machine" {
 }
 
 resource "exoscale_nic" "eth_intra" {
-  count = exoscale_compute.machine.count
+  count = length(exoscale_compute.machine)
 
   compute_id = exoscale_compute.machine.*.id[count.index]
   network_id = exoscale_network.intra.id

--- a/examples/multi-private-network/instances.tf
+++ b/examples/multi-private-network/instances.tf
@@ -3,28 +3,28 @@ variable "machines" {
 }
 
 data "exoscale_compute_template" "ubuntu" {
-  zone = "${var.zone}"
+  zone = var.zone
   name = "Linux Ubuntu 18.04 LTS 64-bit"
 }
 
 resource "exoscale_compute" "machine" {
-  count = "${var.machines}"
+  count = var.machines
 
   display_name = "demo-machine-${count.index}"
 
-  template_id = "${data.exoscale_compute_template.ubuntu.id}"
+  template_id = data.exoscale_compute_template.ubuntu.id
   size = "Small"
   disk_size = "10"
   security_groups = ["default"]
-  key_pair = "${var.key_pair}"
-  zone = "${var.zone}"
+  key_pair = var.key_pair
+  zone = var.zone
 
-  user_data = "${element(data.template_file.user_data.*.rendered, count.index)}"
+  user_data = element(data.template_file.user_data.*.rendered, count.index)
 }
 
 resource "exoscale_nic" "eth_intra" {
-  count = "${exoscale_compute.machine.count}"
+  count = exoscale_compute.machine.count
 
-  compute_id = "${exoscale_compute.machine.*.id[count.index]}"
-  network_id = "${exoscale_network.intra.id}"
+  compute_id = exoscale_compute.machine.*.id[count.index]
+  network_id = exoscale_network.intra.id
 }

--- a/examples/multi-private-network/main.tf
+++ b/examples/multi-private-network/main.tf
@@ -3,7 +3,7 @@ provider "template" {
 }
 
 provider "exoscale" {
-  version = "~> 0.11"
-  key = "${var.key}"
-  secret = "${var.secret}"
+  version = "~> 0.15"
+  key = var.key
+  secret = var.secret
 }

--- a/examples/multi-private-network/main.tf
+++ b/examples/multi-private-network/main.tf
@@ -1,5 +1,5 @@
 provider "template" {
-  version = "~> 1.0"
+  version = "~> 2.1"
 }
 
 provider "exoscale" {

--- a/examples/multi-private-network/networks.tf
+++ b/examples/multi-private-network/networks.tf
@@ -1,5 +1,5 @@
 resource "exoscale_network" "intra" {
   name = "demo-intra"
   display_text = "demo intra privnet"
-  zone = "${var.zone}"
+  zone = var.zone
 }

--- a/examples/multipart-cloud-init/data.tf
+++ b/examples/multipart-cloud-init/data.tf
@@ -2,7 +2,7 @@ data "template_file" "init" {
   count = length(var.hostnames)
   template = file("cloud-init.yml.tpl")
 
-  vars {
+  vars = {
     fqdn = var.hostnames[count.index]
     ubuntu = "artful"
   }
@@ -12,7 +12,7 @@ data "external" "terraform_version" {
   program = [
     "sh",
     "-c",
-    "echo \"{\\\"script\\\": \\\"#!/bin/sh\\\\necho Setup via $(terraform -v | head -n 1)\\\"}\""
+    "echo \"{\\\"script\\\": \\\"echo Setup via $(terraform -v | head -n 1)\\\"}\""
   ]
 }
 

--- a/examples/multipart-cloud-init/data.tf
+++ b/examples/multipart-cloud-init/data.tf
@@ -1,9 +1,9 @@
 data "template_file" "init" {
-  count = "${length(var.hostnames)}"
-  template = "${file("cloud-init.yml.tpl")}"
+  count = length(var.hostnames)
+  template = file("cloud-init.yml.tpl")
 
   vars {
-    fqdn = "${var.hostnames[count.index]}"
+    fqdn = var.hostnames[count.index]
     ubuntu = "artful"
   }
 }
@@ -17,7 +17,7 @@ data "external" "terraform_version" {
 }
 
 data "template_cloudinit_config" "config" {
-  count = "${length(var.hostnames)}"
+  count = length(var.hostnames)
 
   gzip = false
   base64_encode = false
@@ -25,11 +25,11 @@ data "template_cloudinit_config" "config" {
   part {
     filename = "cloud-init.yml"
     content_type = "text/cloud-config"
-    content = "${element(data.template_file.init.*.rendered, count.index)}"
+    content = element(data.template_file.init.*.rendered, count.index)
   }
 
   part {
     content_type = "text/x-shellscript"
-    content = "${data.external.terraform_version.result.script}"
+    content = data.external.terraform_version.result.script
   }
 }

--- a/examples/multipart-cloud-init/data.tf
+++ b/examples/multipart-cloud-init/data.tf
@@ -4,7 +4,7 @@ data "template_file" "init" {
 
   vars = {
     fqdn = var.hostnames[count.index]
-    ubuntu = "artful"
+    ubuntu = "bionic"
   }
 }
 

--- a/examples/multipart-cloud-init/instances.tf
+++ b/examples/multipart-cloud-init/instances.tf
@@ -1,18 +1,18 @@
 data "exoscale_compute_template" "test" {
-  zone = "${var.zone}"
-  name = "${var.template}"
+  zone = var.zone
+  name = var.template
 }
 
 resource "exoscale_compute" "test" {
-  count = "${length(var.hostnames)}"
-  display_name = "${var.hostnames[count.index]}"
-  template_id = "${data.exoscale_compute_template.test.id}"
-  zone = "${var.zone}"
+  count = length(var.hostnames)
+  display_name = var.hostnames[count.index]
+  template_id = data.exoscale_compute_template.test.id
+  zone = var.zone
   size = "Tiny"
   disk_size = 17
 
-  key_pair = "${var.key_pair}"
+  key_pair = var.key_pair
   security_groups = ["default"]
 
-  user_data = "${element(data.template_cloudinit_config.config.*.rendered, count.index)}"
+  user_data = element(data.template_cloudinit_config.config.*.rendered, count.index)
 }

--- a/examples/multipart-cloud-init/main.tf
+++ b/examples/multipart-cloud-init/main.tf
@@ -11,7 +11,7 @@ provider "null" {
 }
 
 provider "exoscale" {
-  version = "~> 0.11"
-  key = "${var.key}"
-  secret = "${var.secret}"
+  version = "~> 0.15"
+  key = var.key
+  secret = var.secret
 }

--- a/examples/multipart-cloud-init/main.tf
+++ b/examples/multipart-cloud-init/main.tf
@@ -1,5 +1,5 @@
 provider "template" {
-  version = "~> 1.0"
+  version = "~> 2.1"
 }
 
 provider "local" {
@@ -7,7 +7,7 @@ provider "local" {
 }
 
 provider "null" {
-  version = "~> 1.0"
+  version = "~> 2.1"
 }
 
 provider "exoscale" {

--- a/examples/multipart-cloud-init/outputs.tf
+++ b/examples/multipart-cloud-init/outputs.tf
@@ -1,3 +1,3 @@
 output "hostnames" {
-  value = "${join(", ", formatlist("%s@%s", exoscale_compute.test.*.username, exoscale_compute.test.*.ip_address))}"
+  value = join(", ", formatlist("%s@%s", exoscale_compute.test.*.username, exoscale_compute.test.*.ip_address))
 }

--- a/examples/multipart-cloud-init/variables.tf
+++ b/examples/multipart-cloud-init/variables.tf
@@ -3,7 +3,7 @@ variable "secret" {}
 variable "key_pair" {}
 
 variable "hostnames" {
-  type = "list"
+  type = list(string)
   default = ["alpha", "beta"]
 }
 
@@ -12,6 +12,6 @@ variable "zone" {
 }
 
 variable "template" {
-  default = "Linux Ubuntu 18.04 64-bit"
+  default = "Linux Ubuntu 18.04 LTS 64-bit"
 }
 

--- a/examples/rke/data.tf
+++ b/examples/rke/data.tf
@@ -1,16 +1,16 @@
 data "template_file" "init" {
-  template = "${file("init.tpl")}"
-  count = "${length(var.hostnames)}"
+  template = file("init.tpl")
+  count = length(var.hostnames)
 
   vars {
-    ubuntu = "${var.ubuntu-flavor}"
-    docker-version = "${var.docker-version}~ce-0~ubuntu-${var.ubuntu-flavor}"
-    hostname = "${element(var.hostnames, count.index)}"
+    ubuntu = var.ubuntu-flavor
+    docker-version = var.docker-version}~ce-0~ubuntu-${var.ubuntu-flavor
+    hostname = element(var.hostnames, count.index)
   }
 }
 
 data "template_cloudinit_config" "config" {
-  count = "${length(var.hostnames)}"
+  count = length(var.hostnames)
 
   gzip = false
   base64_encode = false
@@ -18,6 +18,6 @@ data "template_cloudinit_config" "config" {
   part {
     filename = "init.cfg"
     content_type = "text/cloud-config"
-    content = "${element(data.template_file.init.*.rendered, count.index)}"
+    content = element(data.template_file.init.*.rendered, count.index)
   }
 }

--- a/examples/rke/data.tf
+++ b/examples/rke/data.tf
@@ -2,9 +2,9 @@ data "template_file" "init" {
   template = file("init.tpl")
   count = length(var.hostnames)
 
-  vars {
+  vars = {
     ubuntu = var.ubuntu-flavor
-    docker-version = var.docker-version}~ce-0~ubuntu-${var.ubuntu-flavor
+    docker-version = format("%s~ce-0~ubuntu-%s", var.docker-version, var.ubuntu-flavor)
     hostname = element(var.hostnames, count.index)
   }
 }

--- a/examples/rke/main.tf
+++ b/examples/rke/main.tf
@@ -3,14 +3,14 @@ provider "template" {
 }
 
 provider "exoscale" {
-  version = "~> 0.11"
-  key = "${var.key}"
-  secret = "${var.secret}"
+  version = "~> 0.15"
+  key = var.key
+  secret = var.secret
 }
 
 data "exoscale_compute_template" "node" {
-  zone = "${var.zone}"
-  name = "${var.template}"
+  zone = var.zone
+  name = var.template
 }
 
 resource "exoscale_affinity" "rke" {
@@ -24,7 +24,7 @@ resource "exoscale_security_group" "rke" {
 
 // https://rancher.com/docs/rancher/v2.x/en/installation/requirements/
 resource "exoscale_security_group_rules" "rke" {
-  security_group_id = "${exoscale_security_group.rke.id}"
+  security_group_id = exoscale_security_group.rke.id
 
   ingress {
     protocol = "TCP"
@@ -40,31 +40,31 @@ resource "exoscale_security_group_rules" "rke" {
 
   ingress {
     protocol = "TCP"
-    user_security_group_list = ["${exoscale_security_group.rke.name}"]
+    user_security_group_list = [exoscale_security_group.rke.name]
     ports = ["2379-2380", "4789", "10250-10252", "10256"]
   }
 
   ingress {
     protocol = "UDP"
-    user_security_group_list = ["${exoscale_security_group.rke.name}"]
+    user_security_group_list = [exoscale_security_group.rke.name]
     ports = ["8472", "30000-32767"]
   }
 
 }
 
 resource "exoscale_compute" "node" {
-  count = "${length(var.hostnames)}"
-  display_name = "${element(var.hostnames, count.index)}"
-  template_id = "${data.exoscale_compute_template.node.id}"
-  zone = "${var.zone}"
+  count = length(var.hostnames)
+  display_name = element(var.hostnames, count.index)
+  template_id = data.exoscale_compute_template.node.id
+  zone = var.zone
   size = "Medium"
   disk_size = 50
 
-  key_pair = "${var.key_pair}"
-  affinity_groups = ["${exoscale_affinity.rke.name}"]
-  security_groups = ["default", "${exoscale_security_group.rke.name}"]
+  key_pair = var.key_pair
+  affinity_groups = [exoscale_affinity.rke.name]
+  security_groups = ["default", exoscale_security_group.rke.name]
 
-  user_data = "${element(data.template_cloudinit_config.config.*.rendered, count.index)}"
+  user_data = element(data.template_cloudinit_config.config.*.rendered, count.index)
 
   tags = {
     managedby = "terraform"
@@ -72,5 +72,5 @@ resource "exoscale_compute" "node" {
 }
 
 output "master_ips" {
-  value = "${join(",", formatlist("%s@%s", exoscale_compute.node.*.username, exoscale_compute.node.*.ip_address))}"
+  value = join(",", formatlist("%s@%s", exoscale_compute.node.*.username, exoscale_compute.node.*.ip_address))
 }

--- a/examples/rke/main.tf
+++ b/examples/rke/main.tf
@@ -1,5 +1,5 @@
 provider "template" {
-  version = "~> 1.0"
+  version = "~> 2.1"
 }
 
 provider "exoscale" {

--- a/examples/rke/variables.tf
+++ b/examples/rke/variables.tf
@@ -5,7 +5,7 @@ variable "key_pair" {}
 
 // hostnames are used as a source
 variable "hostnames" {
-  type = "list"
+  type = list(string)
   default = [
     "huey",
     "dewey",

--- a/examples/s3/main.tf
+++ b/examples/s3/main.tf
@@ -1,9 +1,9 @@
 provider "aws" {
   version = "~> 1.24"
-  access_key = "${var.key}"
-  secret_key = "${var.secret}"
+  access_key = var.key
+  secret_key = var.secret
 
-  region = "${var.zone}"
+  region = var.zone
   endpoints {
     s3 = "https://sos-${var.zone}.exo.io"
   }
@@ -19,7 +19,7 @@ provider "aws" {
 }
 
 resource "aws_s3_bucket" "testbucket" {
-  bucket = "${var.bucket}"
+  bucket = var.bucket
   acl = "public-read"
 
   lifecycle {
@@ -36,9 +36,9 @@ resource "aws_s3_bucket" "testbucket" {
  }
 
 resource "aws_s3_bucket_object" "testobj" {
-  bucket = "${aws_s3_bucket.testbucket.bucket}"
+  bucket = aws_s3_bucket.testbucket.bucket
   acl = "public-read"
   key = "some-text.txt"
   source = "some-text.txt"
-  etag   = "${md5(file("some-text.txt"))}"
+  etag   = md5(file("some-text.txt"))
 }

--- a/examples/s3/main.tf
+++ b/examples/s3/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "~> 1.24"
+  version = "~> 2.7"
   access_key = var.key
   secret_key = var.secret
 
@@ -23,7 +23,7 @@ resource "aws_s3_bucket" "testbucket" {
   acl = "public-read"
 
   lifecycle {
-    ignore_changes = ["object_lock_configuration.#"]
+    ignore_changes = [object_lock_configuration]
   }
 
   cors_rule {

--- a/examples/sos-backend/main.tf
+++ b/examples/sos-backend/main.tf
@@ -1,7 +1,7 @@
 provider "exoscale" {
-  version = "~> 0.12.1"
-  key     = "${var.key}"
-  secret  = "${var.secret}"
+  version = "~> 0.15"
+  key     = var.key
+  secret  = var.secret
 }
 
 

--- a/examples/ssh-keys/main.tf
+++ b/examples/ssh-keys/main.tf
@@ -1,5 +1,5 @@
 provider "exoscale" {
-  version = "~> 0.11"
+  version = "~> 0.15"
 }
 
 resource "exoscale_ssh_keypair" "key" {
@@ -13,17 +13,17 @@ data "exoscale_compute_template" "ubuntu" {
 
 resource "exoscale_compute" "vm" {
   display_name = "myvm"
-  template_id = "${data.exoscale_compute_template.ubuntu.id}"
+  template_id = data.exoscale_compute_template.ubuntu.id
   size = "Medium"
-  key_pair = "${exoscale_ssh_keypair.key.name}"
+  key_pair = exoscale_ssh_keypair.key.name
   disk_size = 10
   zone = "at-vie-1"
 
   provisioner "remote-exec" {
     connection {
-      host = "${self.ip_address}"
-      user = "${data.exoscale_compute_template.ubuntu.username}"
-      private_key = "${exoscale_ssh_keypair.key.private_key}"
+      host = self.ip_address
+      user = data.exoscale_compute_template.ubuntu.username
+      private_key = exoscale_ssh_keypair.key.private_key
     }
 
     inline = [

--- a/exoscale/datasource_exoscale_domain_test.go
+++ b/exoscale/datasource_exoscale_domain_test.go
@@ -22,7 +22,7 @@ resource "exoscale_domain" "exo" {
   name = "%s"
 }
 data "exoscale_domain" "domain" {
-  name = "${exoscale_domain.exo.name}"
+  name = exoscale_domain.exo.name
 }`, testAccDataSourceDomainName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccDataSourceDomainAttributes(testAttrs{

--- a/exoscale/resource_exoscale_compute_test.go
+++ b/exoscale/resource_exoscale_compute_test.go
@@ -34,7 +34,7 @@ resource "exoscale_compute" "vm" {
   display_name = "%s"
   size = "%s"
   disk_size = "%s"
-  key_pair = "${exoscale_ssh_keypair.key.name}"
+  key_pair = exoscale_ssh_keypair.key.name
 
   tags = {
     test = "terraform"
@@ -60,7 +60,7 @@ resource "exoscale_compute" "vm" {
   display_name = "%s"
   size = "%s"
   disk_size = "%s"
-  key_pair = "${exoscale_ssh_keypair.key.name}"
+  key_pair = exoscale_ssh_keypair.key.name
 
   tags = {
     test = "terraform"
@@ -90,7 +90,7 @@ resource "exoscale_compute" "vm" {
   display_name = "%s"
   size = "%s"
   disk_size = "%s"
-  key_pair = "${exoscale_ssh_keypair.key.name}"
+  key_pair = exoscale_ssh_keypair.key.name
 
   user_data = <<EOF
 #cloud-config

--- a/exoscale/resource_exoscale_domain_record_test.go
+++ b/exoscale/resource_exoscale_domain_record_test.go
@@ -30,7 +30,7 @@ resource "exoscale_domain" "exo" {
 }
 
 resource "exoscale_domain_record" "mx" {
-  domain      = "${exoscale_domain.exo.id}"
+  domain      = exoscale_domain.exo.id
   name        = "%s"
   record_type = "%s"
   content     = "%s"
@@ -52,7 +52,7 @@ resource "exoscale_domain" "exo" {
 }
 
 resource "exoscale_domain_record" "mx" {
-  domain      = "${exoscale_domain.exo.id}"
+  domain      = exoscale_domain.exo.id
   name        = "%s"
   record_type = "%s"
   content     = "%s"

--- a/exoscale/resource_exoscale_instance_pool_test.go
+++ b/exoscale/resource_exoscale_instance_pool_test.go
@@ -39,7 +39,7 @@ resource "exoscale_instance_pool" "pool" {
   service_offering = "%s"
   size = %d
   disk_size = %d
-  key_pair = "${exoscale_ssh_keypair.key.name}"
+  key_pair = exoscale_ssh_keypair.key.name
   user_data = <<EOF
 %s
 EOF
@@ -72,7 +72,7 @@ resource "exoscale_instance_pool" "pool" {
   service_offering = "%s"
   size = %d
   disk_size = %d
-  key_pair = "${exoscale_ssh_keypair.key.name}"
+  key_pair = exoscale_ssh_keypair.key.name
   user_data = <<EOF
 %s
 EOF

--- a/exoscale/resource_exoscale_nic_test.go
+++ b/exoscale/resource_exoscale_nic_test.go
@@ -35,7 +35,7 @@ resource "exoscale_compute" "vm" {
   template_id = "%s"
   size = "Micro"
   disk_size = "10"
-  key_pair = "${exoscale_ssh_keypair.key.name}"
+  key_pair = exoscale_ssh_keypair.key.name
 }
 
 resource "exoscale_network" "net" {
@@ -47,8 +47,8 @@ resource "exoscale_network" "net" {
 }
 
 resource "exoscale_nic" "nic" {
-  compute_id = "${exoscale_compute.vm.id}"
-  network_id = "${exoscale_network.net.id}"
+  compute_id = exoscale_compute.vm.id
+  network_id = exoscale_network.net.id
   ip_address = "%s"
 }
 `,
@@ -71,7 +71,7 @@ resource "exoscale_compute" "vm" {
   template_id = "%s"
   size = "Micro"
   disk_size = "10"
-  key_pair = "${exoscale_ssh_keypair.key.name}"
+  key_pair = exoscale_ssh_keypair.key.name
 }
 
 resource "exoscale_network" "net" {
@@ -83,8 +83,8 @@ resource "exoscale_network" "net" {
 }
 
 resource "exoscale_nic" "nic" {
-  compute_id = "${exoscale_compute.vm.id}"
-  network_id = "${exoscale_network.net.id}"
+  compute_id = exoscale_compute.vm.id
+  network_id = exoscale_network.net.id
   ip_address = "%s"
 }
 `,

--- a/exoscale/resource_exoscale_security_group_rule_test.go
+++ b/exoscale/resource_exoscale_security_group_rule_test.go
@@ -28,7 +28,7 @@ resource "exoscale_security_group" "sg" {
 }
 
 resource "exoscale_security_group_rule" "cidr" {
-  security_group_id = "${exoscale_security_group.sg.id}"
+  security_group_id = exoscale_security_group.sg.id
   protocol = "%s"
   type = "%s"
   cidr = "%s"
@@ -50,12 +50,12 @@ resource "exoscale_security_group" "sg" {
 }
 
 resource "exoscale_security_group_rule" "usg" {
-  security_group = "${exoscale_security_group.sg.name}"
+  security_group = exoscale_security_group.sg.name
   protocol = "%s"
   type = "%s"
   icmp_type = %d
   icmp_code = %d
-  user_security_group = "${exoscale_security_group.sg.name}"
+  user_security_group = exoscale_security_group.sg.name
 }
 `,
 		testAccResourceSecurityGroupRuleSecurityGroupName,

--- a/exoscale/resource_exoscale_security_group_rules_test.go
+++ b/exoscale/resource_exoscale_security_group_rules_test.go
@@ -22,7 +22,7 @@ resource "exoscale_security_group" "sg" {
 }
 
 resource "exoscale_security_group_rules" "rules" {
-  security_group_id = "${exoscale_security_group.sg.id}"
+  security_group_id = exoscale_security_group.sg.id
 
   ingress {
     protocol = "ICMP"
@@ -42,7 +42,7 @@ resource "exoscale_security_group_rules" "rules" {
     protocol = "TCP"
     cidr_list = ["10.0.0.0/24", "::/0"]
     ports = ["22", "8000-8888"]
-    user_security_group_list = ["${exoscale_security_group.sg.name}", "default"]
+    user_security_group_list = [exoscale_security_group.sg.name, "default"]
   }
 
   egress {
@@ -62,7 +62,7 @@ resource "exoscale_security_group" "sg" {
 }
 
 resource "exoscale_security_group_rules" "rules" {
-  security_group_id = "${exoscale_security_group.sg.id}"
+  security_group_id = exoscale_security_group.sg.id
 
   ingress {
     protocol = "ICMP"
@@ -82,7 +82,7 @@ resource "exoscale_security_group_rules" "rules" {
     protocol = "TCP"
     cidr_list = ["10.0.0.0/24", "::/0"]
     ports = ["2222", "8000-8888"]
-    user_security_group_list = ["${exoscale_security_group.sg.name}", "default"]
+    user_security_group_list = [exoscale_security_group.sg.name, "default"]
   }
 
   egress {

--- a/website/docs/d/compute_template.html.markdown
+++ b/website/docs/d/compute_template.html.markdown
@@ -21,14 +21,14 @@ locals {
 }
 
 data "exoscale_compute_template" "ubuntu" {
-  zone = "${local.zone}"
+  zone = local.zone
   name = "Linux Ubuntu 18.04 LTS 64-bit"
 }
 
 resource "exoscale_compute" "my_server" {
-  zone         = "${local.zone}"
+  zone         = local.zone
   display_name = "my server"
-  template_id  = "${data.exoscale_compute_template.ubuntu.id}"
+  template_id  = data.exoscale_compute_template.ubuntu.id
   disk_size    = 10
   key_pair     = "my key"
 }

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -17,7 +17,7 @@ resource plugin.  Additional documentation can be found in the examples director
 
 ```hcl
 provider "exoscale" {
-  version = "~> 0.11"
+  version = "~> 0.15"
   key = "EXO..."
   secret = "..."
 
@@ -30,7 +30,7 @@ provider "exoscale" {
 
 ```hcl
 provider "exoscale" {
-  version = "~> 0.11"
+  version = "~> 0.15"
 
   config = "cloudstack.ini"   # default: filename
   region = "cloudstack"       # default: section name

--- a/website/docs/r/compute.html.markdown
+++ b/website/docs/r/compute.html.markdown
@@ -23,7 +23,7 @@ data "exoscale_compute_template" "ubuntu" {
 resource "exoscale_compute" "mymachine" {
   zone         = "ch-gva-2"
   display_name = "mymachine"
-  template_id  = "${data.exoscale_compute_template.ubuntu.id}"
+  template_id  = data.exoscale_compute_template.ubuntu.id
   size         = "Medium"
   disk_size    = 10
   key_pair     = "me@mymachine"
@@ -104,7 +104,7 @@ data "exoscale_compute_template" "ubuntu" {
 resource "exoscale_compute" "mymachine" {
   zone         = "ch-gva-2"
   display_name = "mymachine"
-  template_id  = "${data.exoscale_compute_template.ubuntu.id}"
+  template_id  = data.exoscale_compute_template.ubuntu.id
   size         = "Medium"
   disk_size    = 10
   key_pair     = "me@mymachine"
@@ -113,8 +113,8 @@ resource "exoscale_compute" "mymachine" {
   provisioner "remote-exec" {
     connection {
       type = "ssh"
-      host = "${self.ip_address}"
-      user = "${data.exoscale_compute_template.ubuntu.username}"
+      host = self.ip_address
+      user = data.exoscale_compute_template.ubuntu.username
     }
   }
 }

--- a/website/docs/r/domain_record.html.markdown
+++ b/website/docs/r/domain_record.html.markdown
@@ -20,17 +20,17 @@ resource "exoscale_domain" "example" {
 }
 
 resource "exoscale_domain_record" "myserver" {
-  domain      = "${exoscale_domain.example.id}"
+  domain      = exoscale_domain.example.id
   name        = "myserver"
   record_type = "A"
   content     = "1.2.3.4"
 }
 
 resource "exoscale_domain_record" "myserver_alias" {
-  domain      = "${exoscale_domain.example.id}"
+  domain      = exoscale_domain.example.id
   name        = "myserver-new"
   record_type = "CNAME"
-  content     = "${exoscale_domain_record.myserver.hostname}"
+  content     = exoscale_domain_record.myserver.hostname
 }
 ```
 

--- a/website/docs/r/instance_pool.html.markdown
+++ b/website/docs/r/instance_pool.html.markdown
@@ -28,26 +28,26 @@ resource "exoscale_security_group" "web" {
 }
 
 resource "exoscale_network" "web_privnet" {
-  zone = "${var.zone}"
+  zone = var.zone
   name = "web-privnet"
 }
 
 data "exoscale_compute_template" "mywebapp" {
-  zone = "${var.zone}"
+  zone = var.zone
   name = "mywebapp"
   filter = "mine"
 }
 
 resource "exoscale_instance_pool" "webapp" {
-  zone = "${var.zone}"
+  zone = var.zone
   name = "webapp"
-  template_id = "${data.exoscale_compute_template.mywebbapp.id}"
+  template_id = data.exoscale_compute_template.mywebbapp.id
   size = 3
   service_offering = "Medium"
   disk_size = 50
   description = "This is the production environment for my webapp"
   user_data = "#cloud-config\npackage_upgrade: true\n"
-  key_pair = "${exoscale_ssh_keypair.key.name}"
+  key_pair = exoscale_ssh_keypair.key.name
 
   security_group_ids = [${exoscale_security_group.web.id}]
   network_ids = [${exoscale_network.web_privnet.id}]

--- a/website/docs/r/nic.html.markdown
+++ b/website/docs/r/nic.html.markdown
@@ -24,8 +24,8 @@ resource "exoscale_network" "oob" {
 }
 
 resource "exoscale_nic" "oob" {
-  compute_id = "${exoscale_compute.vm1.id}"
-  network_id = "${exoscale_network.oob.id}"
+  compute_id = exoscale_compute.vm1.id
+  network_id = exoscale_network.oob.id
 }
 ```
 

--- a/website/docs/r/secondary_ipaddress.html.markdown
+++ b/website/docs/r/secondary_ipaddress.html.markdown
@@ -27,8 +27,8 @@ resource "exoscale_ipaddress" "vip" {
 }
 
 resource "exoscale_secondary_ipaddress" "vip" {
-  compute_id = "${exoscale_compute.vm1.id}"
-  ip_address = "${exoscale_ipaddress.vip.ip_address}"
+  compute_id = exoscale_compute.vm1.id
+  ip_address = exoscale_ipaddress.vip.ip_address
 }
 ```
 

--- a/website/docs/r/security_group_rule.html.markdown
+++ b/website/docs/r/security_group_rule.html.markdown
@@ -20,7 +20,7 @@ resource "exoscale_security_group" "webservers" {
 }
 
 resource "exoscale_security_group_rule" "http" {
-  security_group_id = "${exoscale_security_group.webservers.id}"
+  security_group_id = exoscale_security_group.webservers.id
   type              = "INGRESS"
   protocol          = "TCP"
   cidr              = "0.0.0.0/0" # "::/0" for IPv6

--- a/website/docs/r/security_group_rules.html.markdown
+++ b/website/docs/r/security_group_rules.html.markdown
@@ -20,7 +20,7 @@ resource "exoscale_security_group" "webservers" {
 }
 
 resource "exoscale_security_group_rules" "admin" {
-  security_group = "${exoscale_security_group.webservers.name}"
+  security_group = exoscale_security_group.webservers.name
 
   ingress {
     protocol                 = "ICMP"
@@ -36,7 +36,7 @@ resource "exoscale_security_group_rules" "admin" {
 }
 
 resource "exoscale_security_group_rules" "web" {
-  security_group_id = "${exoscale_security_group.webservers.id}"
+  security_group_id = exoscale_security_group.webservers.id
 
   ingress {
     protocol  = "TCP"


### PR DESCRIPTION
```
Warning: Interpolation-only expressions are deprecated

  on main.tf line 15, in resource "exoscale_domain_record" "myserver":
  15:   domain      = "${exoscale_domain.example.id}"
```
Interpolation on variables are now deprecated.
I change all `"${exoscale_domain.example.id}"` -> `exoscale_domain.example.id`

✅  PASS:

- [x]  All acceptance tests

- [x]  All examples