### PR TITLE
compute: add a new "hostname" resource attribute

### DIFF
--- a/exoscale/resource_exoscale_compute.go
+++ b/exoscale/resource_exoscale_compute.go
@@ -771,6 +771,7 @@ func resourceComputeUpdate(d *schema.ResourceData, meta interface{}) error {
 	d.SetPartial("user_data")
 	d.SetPartial("user_data_base64")
 	d.SetPartial("display_name")
+	d.SetPartial("hostname")
 	d.SetPartial("security_groups")
 
 	if (initialState == "Running" && rebootRequired) || startRequired {

--- a/exoscale/resource_exoscale_compute.go
+++ b/exoscale/resource_exoscale_compute.go
@@ -17,6 +17,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 )
 
+const computeHostnameRegexp = `^[a-zA-Z0-9][a-zA-Z0-9\-]+$`
+
 func resourceComputeIDString(d resourceIDStringer) string {
 	return resourceIDString(d, "exoscale_compute")
 }
@@ -53,13 +55,23 @@ func resourceCompute() *schema.Resource {
 			ForceNew: true,
 		},
 		"name": {
-			Type:     schema.TypeString,
-			Computed: true,
+			Type:       schema.TypeString,
+			Computed:   true,
+			Deprecated: "use `hostname` attribute instead",
 		},
 		"display_name": {
 			Type:     schema.TypeString,
 			Optional: true,
 			Computed: true,
+		},
+		"hostname": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Computed: true,
+			ValidateFunc: validation.StringMatch(
+				regexp.MustCompile(computeHostnameRegexp),
+				"alphanumeric and hyphen characters",
+			),
 		},
 		"size": {
 			Type:     schema.TypeString,
@@ -207,9 +219,16 @@ func resourceComputeCreate(d *schema.ResourceData, meta interface{}) error {
 	client := GetComputeClient(meta)
 
 	displayName := d.Get("display_name").(string)
-	hostName := regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9\-]+$`)
-	if !hostName.MatchString(displayName) {
-		return errors.New("at creation time, the `display_name` must match a value compatible with the `hostname` (alpha-numeric and hyphens")
+	instanceName := ""
+	if _, ok := d.GetOk("hostname"); ok {
+		instanceName = d.Get("hostname").(string)
+	} else if displayName != "" {
+		instanceName = displayName
+		if !regexp.MustCompile(computeHostnameRegexp).MatchString(instanceName) {
+			return errors.New("if the `hostname` attribute is not set, the `display_name` attribute is used " +
+				"instead and its value must be compatible with an instance hostname (contain only alphanumeric " +
+				"and hyphen characters)")
+		}
 	}
 
 	// ServiceOffering
@@ -327,7 +346,7 @@ func resourceComputeCreate(d *schema.ResourceData, meta interface{}) error {
 	details["ip6"] = strconv.FormatBool(d.Get("ip6").(bool))
 
 	req := &egoscale.DeployVirtualMachine{
-		Name:               displayName,
+		Name:               instanceName,
 		DisplayName:        displayName,
 		RootDiskSize:       int64(diskSize),
 		KeyPair:            d.Get("key_pair").(string),
@@ -549,6 +568,11 @@ func resourceComputeUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	if d.HasChange("display_name") {
 		req.DisplayName = d.Get("display_name").(string)
+	}
+
+	if d.HasChange("hostname") {
+		req.Name = d.Get("hostname").(string)
+		rebootRequired = true
 	}
 
 	if d.HasChange("user_data") {
@@ -882,7 +906,11 @@ func resourceComputeImport(d *schema.ResourceData, meta interface{}) ([]*schema.
 }
 
 func resourceComputeApply(d *schema.ResourceData, machine *egoscale.VirtualMachine) error {
+	// This should go away once the attribute has been phased out
 	if err := d.Set("name", machine.Name); err != nil {
+		return err
+	}
+	if err := d.Set("hostname", machine.Name); err != nil {
 		return err
 	}
 	if err := d.Set("display_name", machine.DisplayName); err != nil {

--- a/exoscale/resource_exoscale_compute_test.go
+++ b/exoscale/resource_exoscale_compute_test.go
@@ -11,17 +11,18 @@ import (
 )
 
 var (
-	testAccResourceComputeSSHKeyName        = testPrefix + "-" + testRandomString()
-	testAccResourceComputeSecurityGroupName = testPrefix + "-" + testRandomString()
-	testAccResourceComputeZoneName          = testZoneName
-	testAccResourceComputeTemplateName      = testInstanceTemplateName
-	testAccResourceComputeTemplateID        = testInstanceTemplateID
-	testAccResourceComputeName              = testPrefix + "-" + testRandomString()
-	testAccResourceComputeNameUpdated       = testAccResourceComputeName + "-updated"
-	testAccResourceComputeSize              = "Micro"
-	testAccResourceComputeSizeUpdated       = "Small"
-	testAccResourceComputeDiskSize          = "10"
-	testAccResourceComputeDiskSizeUpdated   = "15"
+	testAccResourceComputeSSHKeyName         = testPrefix + "-" + testRandomString()
+	testAccResourceComputeSecurityGroupName  = testPrefix + "-" + testRandomString()
+	testAccResourceComputeZoneName           = testZoneName
+	testAccResourceComputeTemplateName       = testInstanceTemplateName
+	testAccResourceComputeTemplateID         = testInstanceTemplateID
+	testAccResourceComputeDisplayName        = testPrefix + "-" + testRandomString()
+	testAccResourceComputeDisplayNameUpdated = testAccResourceComputeDisplayName + "-updated"
+	testAccResourceComputeHostname           = testPrefix + "-" + testRandomString()
+	testAccResourceComputeSize               = "Micro"
+	testAccResourceComputeSizeUpdated        = "Small"
+	testAccResourceComputeDiskSize           = "10"
+	testAccResourceComputeDiskSizeUpdated    = "15"
 
 	testAccResourceComputeConfigCreateTemplateByName = fmt.Sprintf(`
 resource "exoscale_ssh_keypair" "key" {
@@ -44,7 +45,7 @@ resource "exoscale_compute" "vm" {
 		testAccResourceComputeSSHKeyName,
 		testAccResourceComputeZoneName,
 		testAccResourceComputeTemplateName,
-		testAccResourceComputeName,
+		testAccResourceComputeDisplayName,
 		testAccResourceComputeSize,
 		testAccResourceComputeDiskSize,
 	)
@@ -70,7 +71,7 @@ resource "exoscale_compute" "vm" {
 		testAccResourceComputeSSHKeyName,
 		testAccResourceComputeTemplateID,
 		testAccResourceComputeZoneName,
-		testAccResourceComputeName,
+		testAccResourceComputeDisplayName,
 		testAccResourceComputeSize,
 		testAccResourceComputeDiskSize,
 	)
@@ -88,6 +89,7 @@ resource "exoscale_compute" "vm" {
   template_id = "%s"
   zone = "%s"
   display_name = "%s"
+  hostname = "%s"
   size = "%s"
   disk_size = "%s"
   key_pair = exoscale_ssh_keypair.key.name
@@ -113,7 +115,8 @@ EOF
 		testAccResourceComputeSecurityGroupName,
 		testAccResourceComputeTemplateID,
 		testAccResourceComputeZoneName,
-		testAccResourceComputeNameUpdated,
+		testAccResourceComputeDisplayNameUpdated,
+		testAccResourceComputeHostname,
 		testAccResourceComputeSizeUpdated,
 		testAccResourceComputeDiskSizeUpdated,
 		testAccResourceComputeSecurityGroupName,
@@ -138,7 +141,9 @@ func TestAccResourceCompute(t *testing.T) {
 					testAccCheckResourceComputeAttributes(testAttrs{
 						"template":     ValidateString(testAccResourceComputeTemplateName),
 						"template_id":  ValidateString(testAccResourceComputeTemplateID),
-						"display_name": ValidateString(testAccResourceComputeName),
+						"display_name": ValidateString(testAccResourceComputeDisplayName),
+						"hostname":     ValidateString(testAccResourceComputeDisplayName),
+						"name":         ValidateString(testAccResourceComputeDisplayName),
 						"size":         ValidateString(testAccResourceComputeSize),
 						"disk_size":    ValidateString(testAccResourceComputeDiskSize),
 						"key_pair":     ValidateString(testAccResourceComputeSSHKeyName),
@@ -153,7 +158,9 @@ func TestAccResourceCompute(t *testing.T) {
 					testAccCheckResourceCompute(vm),
 					testAccCheckResourceComputeAttributes(testAttrs{
 						"template_id":  ValidateString(testAccResourceComputeTemplateID),
-						"display_name": ValidateString(testAccResourceComputeName),
+						"display_name": ValidateString(testAccResourceComputeDisplayName),
+						"hostname":     ValidateString(testAccResourceComputeDisplayName),
+						"name":         ValidateString(testAccResourceComputeDisplayName),
 						"size":         ValidateString(testAccResourceComputeSize),
 						"disk_size":    ValidateString(testAccResourceComputeDiskSize),
 						"key_pair":     ValidateString(testAccResourceComputeSSHKeyName),
@@ -169,7 +176,9 @@ func TestAccResourceCompute(t *testing.T) {
 					testAccCheckResourceCompute(vm),
 					testAccCheckResourceComputeAttributes(testAttrs{
 						"template_id":       ValidateString(testAccResourceComputeTemplateID),
-						"display_name":      ValidateString(testAccResourceComputeNameUpdated),
+						"display_name":      ValidateString(testAccResourceComputeDisplayNameUpdated),
+						"hostname":          ValidateString(testAccResourceComputeHostname),
+						"name":              ValidateString(testAccResourceComputeHostname),
 						"size":              ValidateString(testAccResourceComputeSizeUpdated),
 						"disk_size":         ValidateString(testAccResourceComputeDiskSizeUpdated),
 						"key_pair":          ValidateString(testAccResourceComputeSSHKeyName),
@@ -188,7 +197,9 @@ func TestAccResourceCompute(t *testing.T) {
 					return checkResourceAttributes(
 						testAttrs{
 							"template_id":       ValidateString(testAccResourceComputeTemplateID),
-							"display_name":      ValidateString(testAccResourceComputeNameUpdated),
+							"display_name":      ValidateString(testAccResourceComputeDisplayNameUpdated),
+							"hostname":          ValidateString(testAccResourceComputeHostname),
+							"name":              ValidateString(testAccResourceComputeHostname),
 							"size":              ValidateString(testAccResourceComputeSizeUpdated),
 							"disk_size":         ValidateString(testAccResourceComputeDiskSizeUpdated),
 							"key_pair":          ValidateString(testAccResourceComputeSSHKeyName),

--- a/website/docs/r/compute.html.markdown
+++ b/website/docs/r/compute.html.markdown
@@ -53,7 +53,8 @@ EOF
 ## Argument Reference
 
 * `zone` - (Required) The name of the [zone][zone] to deploy the Compute instance into.
-* `display_name` - (Required) The displayed name of the Compute instance. Note: This value is also used to set the OS' *hostname* during creation, so the value can only contain alphanumeric and hyphen ("-") characters; it can be changed to any character during a later update.
+* `display_name` - (Required) The displayed name of the Compute instance. Note: if the `hostname` attribute is not set, this attribute is also used to set the OS' *hostname* during creation, so the value must contain only alphanumeric and hyphen ("-") characters; it can be changed to any character during a later update.
+* `hostname` - The Compute instance hostname, must contain only alphanumeric and hyphen ("-") characters. Note: updating this attribute's value requires to reboot the instance.
 * `template` - (Required) The name of the Compute instance [template][template]. Only *featured* templates are available, if you want to reference *custom templates* use the `template_id` attribute instead.
 * `template_id` - (Required) The ID of the Compute instance [template][template]. Usage of the [`compute_template`][compute_template] data source is recommended.
 * `size` - (Required) The Compute instance [size][size], e.g. `Tiny`, `Small`, `Medium`, `Large` etc.
@@ -83,7 +84,7 @@ EOF
 
 The following attributes are exported:
 
-* `name` - The name of the Compute instance (*hostname*).
+* `name` - **Deprecated** The Compute instance *hostname*. Use the `hostname` attribute instead.
 * `username` - The user to use to connect to the Compute instance with SSH. If you've referenced a *custom template* in the resource, use the [`compute_template`][compute_template] data source `username` attribute instead.
 * `password` - The initial Compute instance password and/or encrypted password.
 * `ip_address` - The IP address of the Compute instance main network interface.

--- a/website/docs/r/compute.html.markdown
+++ b/website/docs/r/compute.html.markdown
@@ -53,12 +53,12 @@ EOF
 ## Argument Reference
 
 * `zone` - (Required) The name of the [zone][zone] to deploy the Compute instance into.
-* `display_name` - (Required) The displayed name of the Compute instance. Note: if the `hostname` attribute is not set, this attribute is also used to set the OS' *hostname* during creation, so the value must contain only alphanumeric and hyphen ("-") characters; it can be changed to any character during a later update.
-* `hostname` - The Compute instance hostname, must contain only alphanumeric and hyphen ("-") characters. Note: updating this attribute's value requires to reboot the instance.
 * `template` - (Required) The name of the Compute instance [template][template]. Only *featured* templates are available, if you want to reference *custom templates* use the `template_id` attribute instead.
 * `template_id` - (Required) The ID of the Compute instance [template][template]. Usage of the [`compute_template`][compute_template] data source is recommended.
 * `size` - (Required) The Compute instance [size][size], e.g. `Tiny`, `Small`, `Medium`, `Large` etc.
 * `disk_size` - (Required) The Compute instance root disk size in GiB (at least `10`).
+* `display_name` - The displayed name of the Compute instance. Note: if the `hostname` attribute is not set, this attribute is also used to set the OS' *hostname* during creation, so the value must contain only alphanumeric and hyphen ("-") characters; it can be changed to any character during a later update. If neither `display_name` or `hostname` attributes are set, a random value will be generated automatically server-side.
+* `hostname` - The Compute instance hostname, must contain only alphanumeric and hyphen ("-") characters. If neither `display_name` or `hostname` attributes are set, a random value will be generated automatically server-side. Note: updating this attribute's value requires to reboot the instance.
 * `key_pair` - The name of the [SSH key pair][sshkeypair] to be installed.
 * `user_data` - A [cloud-init][cloudinit] configuration. Whenever possible don't base64-encode neither gzip it yourself, as this will be automatically taken care of on your behalf by the provider.
 * `keyboard` - The keyboard layout configuration (at creation time only). Supported values are: `de`, `de-ch`, `es`, `fi`, `fr`, `fr-be`, `fr-ch`, `is`, `it`, `jp`, `nl-be`, `no`, `pt`, `uk`, `us`.


### PR DESCRIPTION
This change introduces a new `hostname` attribute for the
`exoscale_compute` resource to enable users to set a Compute instance's
hostname independently from the display name. It also deprecates the
`name` attribute, replaced by `hostname`.