### PR TITLE
ssh_keypair: fix missing private_key attribute

### DIFF
--- a/exoscale/resource_exoscale_ssh_keypair.go
+++ b/exoscale/resource_exoscale_ssh_keypair.go
@@ -80,6 +80,12 @@ func resourceSSHKeypairCreate(d *schema.ResourceData, meta interface{}) error {
 			return err
 		}
 		keypair = resp.(*egoscale.SSHKeyPair)
+
+		// We have to set this attribute now instead of later in resourceSSHKeypairApply, because once we go
+		// through resourceSSHKeypairRead we'll have lost the information.
+		if err := d.Set("private_key", keypair.PrivateKey); err != nil {
+			return err
+		}
 	}
 
 	d.SetId(keypair.Name)
@@ -154,12 +160,6 @@ func resourceSSHKeypairApply(d *schema.ResourceData, keypair *egoscale.SSHKeyPai
 
 	if err := d.Set("fingerprint", keypair.Fingerprint); err != nil {
 		return err
-	}
-
-	if keypair.PrivateKey != "" {
-		if err := d.Set("private_key", keypair.PrivateKey); err != nil {
-			return err
-		}
 	}
 
 	return nil

--- a/exoscale/resource_exoscale_ssh_keypair_test.go
+++ b/exoscale/resource_exoscale_ssh_keypair_test.go
@@ -7,26 +7,35 @@ import (
 
 	"github.com/exoscale/egoscale"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
 var (
-	testAccResourceSSHKeyName = testPrefix + "-" + testRandomString()
-	testAccResourceSSHKey     = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDN7L45b4vO2ytH68ZU" +
+	testAccResourceSSHKeyName1 = testPrefix + "-" + testRandomString()
+	testAccResourceSSHKeyName2 = testPrefix + "-" + testRandomString()
+	testAccResourceSSHKey2     = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDN7L45b4vO2ytH68ZU" +
 		"C5PMS1b7JG78zGslwcJ0zolE5BuxsCYor248/FKGC5TXrME+yBu/uLqaAkioq4Wp1PzP6Zy5jEowWQDO" +
 		"deER7uu1GgZShcvly2Oaf/UKLqTdwL+U3tCknqHY63fOAi1lBwmNTUu1uZ24iNiogfhXwQn7HJLQK9vf" +
 		"oGwg+/qJIzeswR6XDa6qh0fuzdxWQ4JWHw2s8fv8WvGOlklmAg/uEi1kF5D6R7kJpOVaE20FLnT4sjA8" +
 		"1iErhMIH77OaZqQKiyVH3i5m/lkQI/2e25ml8aculaWzHOs4ctd7l+K1ZWFYje3qMBY1sar1gd787eaqk6RZ"
-	testAccResourceSSHKeyFingerprint = "4d:31:21:c4:77:9f:19:91:6e:84:9d:7c:12:a8:11:1f"
+	testAccResourceSSHKeyFingerprint2 = "4d:31:21:c4:77:9f:19:91:6e:84:9d:7c:12:a8:11:1f"
 
 	testAccResourceSSHKeypairConfig = fmt.Sprintf(`
+resource "exoscale_ssh_keypair" "key" {
+  name = "%s"
+}
+`,
+		testAccResourceSSHKeyName1)
+
+	testAccResourceSSHKeypairConfigWithPubkey = fmt.Sprintf(`
 resource "exoscale_ssh_keypair" "key" {
   name       = "%s"
   public_key = "%s"
 }
 `,
-		testAccResourceSSHKeyName,
-		testAccResourceSSHKey)
+		testAccResourceSSHKeyName2,
+		testAccResourceSSHKey2)
 )
 
 func TestAccResourceSSHKeypair(t *testing.T) {
@@ -43,8 +52,21 @@ func TestAccResourceSSHKeypair(t *testing.T) {
 					testAccCheckResourceSSHKeypairExists("exoscale_ssh_keypair.key", sshkey),
 					testAccCheckResourceSSHKeypair(sshkey),
 					testAccCheckResourceSSHKeypairAttributes(testAttrs{
-						"public_key":  ValidateString(testAccResourceSSHKey),
-						"fingerprint": ValidateString(testAccResourceSSHKeyFingerprint),
+						"name":        ValidateString(testAccResourceSSHKeyName1),
+						"fingerprint": validation.NoZeroValues,
+						"private_key": validation.NoZeroValues,
+					}),
+				),
+			},
+			{
+				Config: testAccResourceSSHKeypairConfigWithPubkey,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckResourceSSHKeypairExists("exoscale_ssh_keypair.key", sshkey),
+					testAccCheckResourceSSHKeypair(sshkey),
+					testAccCheckResourceSSHKeypairAttributes(testAttrs{
+						"name":        ValidateString(testAccResourceSSHKeyName2),
+						"public_key":  ValidateString(testAccResourceSSHKey2),
+						"fingerprint": ValidateString(testAccResourceSSHKeyFingerprint2),
 					}),
 				),
 			},
@@ -56,8 +78,8 @@ func TestAccResourceSSHKeypair(t *testing.T) {
 				ImportStateCheck: func(s []*terraform.InstanceState) error {
 					return checkResourceAttributes(
 						testAttrs{
-							"name":        ValidateString(testAccResourceSSHKeyName),
-							"fingerprint": ValidateString(testAccResourceSSHKeyFingerprint),
+							"name":        ValidateString(testAccResourceSSHKeyName2),
+							"fingerprint": ValidateString(testAccResourceSSHKeyFingerprint2),
 						},
 						s[0].Attributes)
 				},
@@ -79,6 +101,7 @@ func testAccCheckResourceSSHKeypairExists(n string, sshkey *egoscale.SSHKeyPair)
 
 		client := GetComputeClient(testAccProvider.Meta())
 		sshkey.Name = rs.Primary.ID
+		sshkey.Fingerprint = "" // Reset fingerprint to avoid side-effects from previous test steps
 		resp, err := client.Get(sshkey)
 		if err != nil {
 			return err


### PR DESCRIPTION
This changes fixes a bug in the `exoscale_ssh_keypair` resource, where
if a user created a resource without specifying an SSH public key to
register the private key of the key pair created by the API would not be
stored properly in the resource's attributes.

Fixes #49.