### PR TITLE
Fix SG rules conflicting constraints doc

### DIFF
--- a/exoscale/resource_exoscale_security_group_rule.go
+++ b/exoscale/resource_exoscale_security_group_rule.go
@@ -54,7 +54,7 @@ func resourceSecurityGroupRule() *schema.Resource {
 				Optional:      true,
 				ForceNew:      true,
 				ValidateFunc:  validation.IsCIDRNetwork(0, 128),
-				ConflictsWith: []string{"user_security_group"},
+				ConflictsWith: []string{"user_security_group", "user_security_group_id"},
 			},
 			"protocol": {
 				Type:         schema.TypeString,

--- a/website/docs/r/security_group_rule.html.markdown
+++ b/website/docs/r/security_group_rule.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # exoscale\_security\_group\_rule
 
-Provides an Exoscale [Security Group][r-security_group] Rule resource. This can be used to create and delete Security Group Rules.
+Provides an Exoscale [Security Group][r-security_group] rule resource. This can be used to create and delete Security Group rules.
 
 
 ## Example usage
@@ -35,21 +35,19 @@ resource "exoscale_security_group_rule" "http" {
 * `security_group_id` - (Required) The Security Group ID the rule applies to.
 * `type` - (Required) The traffic direction to match (`INGRESS` or `EGRESS`).
 * `protocol` - (Required) The network protocol to match. Supported values are: `TCP`, `UDP`, `ICMP`, `ICMPv6`, `AH`, `ESP`, `GRE`, `IPIP` and `ALL`.
-* `description` - A free-form text describing the Security Group Rule purpose.
+* `description` - A free-form text describing the Security Group rule purpose.
 * `start_port`/`end_port` - A `TCP`/`UDP` port range to match.
-* `icmp_type`/`icmp_code` - An `ICMP`/`ICMPv6` [type/code][icmp] to match.
-* `cidr` - A source (for ingress)/destination (for egress) IP subnet to match (conflicts with `user_security_group`).
-* `user_security_group_id` - A source (for ingress)/destination (for egress) Security Group ID to match (conflicts with `cidr`).
-* `user_security_group` - A source (for ingress)/destination (for egress) Security Group name to match (conflicts with `cidr`).
+* `icmp_type`/`icmp_code` - An ICMP/ICMPv6 [type/code][icmp] to match.
+* `cidr` - A source (for ingress)/destination (for egress) IP subnet (in [CIDR notation][cidr]) to match (conflicts with `user_security_group`/`security_group_id`).
+* `user_security_group_id` - A source (for ingress)/destination (for egress) Security Group ID to match (conflicts with `cidr`/`security_group)`).
+* `user_security_group` - A source (for ingress)/destination (for egress) Security Group name to match (conflicts with `cidr`/`security_group_id`).
 
 
 ## Attributes Reference
 
 In addition to the arguments listed above, the following attributes are exported:
 
-* `security_group` - The name of the Security Group the rule applies to.
-* `security_group_id` - The ID of the Security Group the rule applies to.
-* `user_security_group` - The name of the source (for ingress)/destination (for egress) Security Group to match.
+* n/a
 
 
 ## Import
@@ -57,5 +55,6 @@ In addition to the arguments listed above, the following attributes are exported
 This resource is automatically imported when importing an `exoscale_security_group` resource.
 
 
+[cidr]: https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing#CIDR_notation
 [icmp]: https://en.wikipedia.org/wiki/Internet_Control_Message_Protocol#Control_messages
 [r-security_group]: security_group.html

--- a/website/docs/r/security_group_rules.html.markdown
+++ b/website/docs/r/security_group_rules.html.markdown
@@ -48,24 +48,28 @@ resource "exoscale_security_group_rules" "web" {
 
 ## Arguments Reference
 
-* `security_group` - (Required) The Security Group name the rules apply to.
-* `security_group_id` - (Required) The Security Group ID the rules apply to.
+* `security_group` - (Required) The Security Group name the rules apply to (conflicts with `security_group_id`).
+* `security_group_id` - (Required) The Security Group ID the rules apply to (conficts with `security_group)`.
+* `ingress`/`egress` - A Security Group rule definition.
+
+`ingress`/`egress`:
+
 * `protocol` - (Required) The network protocol to match. Supported values are: `TCP`, `UDP`, `ICMP`, `ICMPv6`, `AH`, `ESP`, `GRE`, `IPIP` and `ALL`.
-* `description` - A free-form text describing the Security Group Rule purpose.
+* `description` - A free-form text describing the Security Group rule purpose.
 * `ports` - A list of ports or port ranges (`start_port-end_port`).
-* `icmp_type`/`icmp_code` - An `ICMP`/`ICMPv6` [type/code][icmp] to match.
-* `cidr_list` - A list of source (for ingress)/destination (for egress) IP subnet to match (conflicts with `user_security_group`).
-* `user_security_group_list` - A source (for ingress)/destination (for egress) of the traffic identified by a security group
+* `icmp_type`/`icmp_code` - An ICMP/ICMPv6 [type/code][icmp] to match.
+* `cidr_list` - A list of source (for ingress)/destination (for egress) IP subnet (in [CIDR notation][cidr]) to match.
+* `user_security_group_list` - A source (for ingress)/destination (for egress) of the traffic identified by a Security Group.
 
 
 ## Attributes Reference
 
 In addition to the arguments listed above, the following attributes are exported:
 
-* `security_group` - The name of the Security Group the rules apply to.
-* `security_group_id` - The ID of the Security Group the rules apply to.
+* n/a
 
 
+[cidr]: https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing#CIDR_notation
 [icmp]: https://en.wikipedia.org/wiki/Internet_Control_Message_Protocol#Control_messages
 [r-security_group]: security_group.html
 


### PR DESCRIPTION
This change adds missing attributes conflicting constraints and fixes
the documentation for the `exoscale_security_group_rule*` resources.