### PR TITLE
instance_pool: support disk_size attribute update

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,12 +57,12 @@ In order to test the provider, you can simply run `make test`.
 $ make test
 ```
 
-In order to run the full suite of Acceptance tests, run `make testacc`.
+In order to run the full suite of Acceptance tests, run `make test-acc`.
 
 *Note:* Acceptance tests create real resources, and often cost money to run.
 
 ```sh
-$ make testacc
+$ make test-acc
 ```
 
 In order to test a specific part of the acceptance test suite, you may run:

--- a/exoscale/resource_exoscale_instance_pool.go
+++ b/exoscale/resource_exoscale_instance_pool.go
@@ -57,7 +57,6 @@ func resourceInstancePool() *schema.Resource {
 			Type:     schema.TypeInt,
 			Computed: true,
 			Optional: true,
-			ForceNew: true,
 		},
 		"description": {
 			Type:     schema.TypeString,
@@ -312,6 +311,10 @@ func resourceInstancePoolUpdate(d *schema.ResourceData, meta interface{}) error 
 
 	if d.HasChange("template_id") {
 		req.TemplateID = egoscale.MustParseUUID(d.Get("template_id").(string))
+	}
+
+	if d.HasChange("disk_size") {
+		req.RootDiskSize = d.Get("disk_size").(int)
 	}
 
 	if d.HasChange("ipv6") {

--- a/exoscale/resource_exoscale_instance_pool_test.go
+++ b/exoscale/resource_exoscale_instance_pool_test.go
@@ -22,6 +22,7 @@ var (
 	testAccResourceInstancePoolServiceOffering = "medium"
 	testAccResourceInstancePoolSize            = 2
 	testAccResourceInstancePoolDiskSize        = 10
+	testAccResourceInstancePoolDiskSizeUpdated = 20
 	testAccResourceInstancePoolSizeUpdated     = 1
 	testAccResourceInstancePoolUserData        = `#cloud-config
 package_upgrade: true
@@ -90,7 +91,7 @@ EOF
 		testAccResourceInstancePoolTemplateID,
 		testAccResourceInstancePoolServiceOffering,
 		testAccResourceInstancePoolSizeUpdated,
-		testAccResourceInstancePoolDiskSize,
+		testAccResourceInstancePoolDiskSizeUpdated,
 		testAccResourceInstancePoolUserData,
 	)
 )
@@ -132,7 +133,7 @@ func TestAccResourceInstancePool(t *testing.T) {
 						"template_id":        ValidateString(testAccResourceInstancePoolTemplateID),
 						"service_offering":   ValidateString(testAccResourceInstancePoolServiceOffering),
 						"size":               ValidateString(fmt.Sprint(testAccResourceInstancePoolSizeUpdated)),
-						"disk_size":          ValidateString(fmt.Sprint(testAccResourceInstancePoolDiskSize)),
+						"disk_size":          ValidateString(fmt.Sprint(testAccResourceInstancePoolDiskSizeUpdated)),
 						"key_pair":           ValidateString(testAccResourceInstancePoolSSHKeyName),
 						"ipv6":               ValidateString("true"),
 						"virtual_machines.#": ValidateStringNot("0"),
@@ -153,7 +154,7 @@ func TestAccResourceInstancePool(t *testing.T) {
 							"template_id":      ValidateString(testAccResourceInstancePoolTemplateID),
 							"service_offering": ValidateString(testAccResourceInstancePoolServiceOffering),
 							"size":             ValidateString(fmt.Sprint(testAccResourceInstancePoolSizeUpdated)),
-							"disk_size":        ValidateString(fmt.Sprint(testAccResourceInstancePoolDiskSize)),
+							"disk_size":        ValidateString(fmt.Sprint(testAccResourceInstancePoolDiskSizeUpdated)),
 							"key_pair":         ValidateString(testAccResourceInstancePoolSSHKeyName),
 							"ipv6":             ValidateString("true"),
 						},

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/exoscale/terraform-provider-exoscale
 
 require (
 	github.com/deepmap/oapi-codegen v1.3.12 // indirect
-	github.com/exoscale/egoscale v0.31.2
+	github.com/exoscale/egoscale v0.32.0
 	github.com/gofrs/uuid v3.3.0+incompatible // indirect
 	github.com/gopherjs/gopherjs v0.0.0-20190430165422-3e4dfb77656c // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.1

--- a/go.sum
+++ b/go.sum
@@ -44,10 +44,8 @@ github.com/deepmap/oapi-codegen v1.3.12/go.mod h1:suMvK7+rKlx3+tpa8ByptmvoXbAV70
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/exoscale/egoscale v0.31.1 h1:X1TJoQLrptkR7++kKxPDwrBRmxXgLo7h25R94E35Rfs=
-github.com/exoscale/egoscale v0.31.1/go.mod h1:BFi2GNsnsrALev3+gFO/HIQADBQhqJ41S0QrNEB2GJw=
-github.com/exoscale/egoscale v0.31.2 h1:gMUDagMrSscgHo9cAqY/1v7kuIfiuzEmsP1SZNsC0qQ=
-github.com/exoscale/egoscale v0.31.2/go.mod h1:BFi2GNsnsrALev3+gFO/HIQADBQhqJ41S0QrNEB2GJw=
+github.com/exoscale/egoscale v0.32.0 h1:G9wV2xiVg5Q7VVmf6FX/thuVNQMQR7m8duUDWIZ/Uic=
+github.com/exoscale/egoscale v0.32.0/go.mod h1:BFi2GNsnsrALev3+gFO/HIQADBQhqJ41S0QrNEB2GJw=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=

--- a/vendor/github.com/exoscale/egoscale/CHANGELOG.md
+++ b/vendor/github.com/exoscale/egoscale/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+0.32.0
+------
+
+- feature: add support for Instance Pool root disk size update (#448)
+
 0.31.2
 ------
 

--- a/vendor/github.com/exoscale/egoscale/instance_pool.go
+++ b/vendor/github.com/exoscale/egoscale/instance_pool.go
@@ -77,14 +77,15 @@ func (CreateInstancePool) Response() interface{} {
 
 // UpdateInstancePool represents an Instance Pool update API request.
 type UpdateInstancePool struct {
-	ID          *UUID  `json:"id"`
-	ZoneID      *UUID  `json:"zoneid"`
-	Name        string `json:"name,omitempty"`
-	Description string `json:"description,omitempty"`
-	TemplateID  *UUID  `json:"templateid,omitempty"`
-	UserData    string `json:"userdata,omitempty"`
-	IPv6        bool   `json:"ipv6,omitempty"`
-	_           bool   `name:"updateInstancePool" description:"Update an Instance Pool"`
+	ID           *UUID  `json:"id"`
+	ZoneID       *UUID  `json:"zoneid"`
+	Name         string `json:"name,omitempty"`
+	Description  string `json:"description,omitempty"`
+	TemplateID   *UUID  `json:"templateid,omitempty"`
+	RootDiskSize int    `json:"rootdisksize,omitempty"`
+	UserData     string `json:"userdata,omitempty"`
+	IPv6         bool   `json:"ipv6,omitempty"`
+	_            bool   `name:"updateInstancePool" description:"Update an Instance Pool"`
 }
 
 // Response returns an empty structure to unmarshal an Instance Pool update API response into.

--- a/vendor/github.com/exoscale/egoscale/version.go
+++ b/vendor/github.com/exoscale/egoscale/version.go
@@ -1,4 +1,4 @@
 package egoscale
 
 // Version of the library
-const Version = "0.31.2"
+const Version = "0.32.0"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -61,7 +61,7 @@ github.com/davecgh/go-spew/spew
 # github.com/deepmap/oapi-codegen v1.3.12
 github.com/deepmap/oapi-codegen/pkg/runtime
 github.com/deepmap/oapi-codegen/pkg/types
-# github.com/exoscale/egoscale v0.31.2
+# github.com/exoscale/egoscale v0.32.0
 github.com/exoscale/egoscale
 github.com/exoscale/egoscale/api/v2
 github.com/exoscale/egoscale/internal/v2


### PR DESCRIPTION
This change adds support for in-place updating of the `disk_size`
attribute of the `exoscale_instance_pool` resource, instead of
re-creating the resource.