### PR TITLE
Improve non-existent NLB handling

### DIFF
--- a/exoscale/resource_exoscale_nlb.go
+++ b/exoscale/resource_exoscale_nlb.go
@@ -130,6 +130,9 @@ func resourceNLBExists(d *schema.ResourceData, meta interface{}) (bool, error) {
 
 	nlb, err := findNLB(ctx, d, meta)
 	if err != nil {
+		if err == egoscale.ErrNotFound {
+			return false, nil
+		}
 		return false, err
 	}
 


### PR DESCRIPTION
This change fixes a bug where `exoscale_nlb` resource wouldn't handle
a non-existent NLB correctly if it's been deleted manually.

Fixes #73