### PR TITLE
Port value is not required for protocols AH, ESP, GRE and IPIP

### DIFF
--- a/exoscale/resource_exoscale_security_group_rules.go
+++ b/exoscale/resource_exoscale_security_group_rules.go
@@ -605,6 +605,9 @@ func ruleToAuthorize(ctx context.Context, client *egoscale.Client, rule map[stri
 		req.IcmpType = uint8(rule["icmp_type"].(int))
 		req.IcmpCode = uint8(rule["icmp_code"].(int))
 		rs = append(rs, req)
+	} else if protocol == "AH" || protocol == "ESP" || protocol == "GRE" || protocol == "IPIP" {
+		req.Protocol = protocol
+		rs = append(rs, req)
 	} else {
 		ports := preparePorts(rule["ports"].(*schema.Set))
 		for _, portRange := range ports {


### PR DESCRIPTION
We currently can't create SG rules for the protocols AH, ESP, GRE and IPIP without a dummy port 0.
Applying doesn't create the rules and doesn't trigger any error.

Example:
```hcl
provider "exoscale" {
  version = "~> 0.18.2"
  timeout = 120
}

resource "exoscale_security_group" "ipip-test-sg" {
  name        = "ipip-test-sg"
  description = "testtesttest"
}

resource "exoscale_security_group_rules" "ipip-test-rules-ipip" {
  security_group_id = exoscale_security_group.ipip-test-sg.id
  ingress {
    protocol = "IPIP"
    # ports    = ["0"]
    cidr_list = ["0.0.0.0/0", "::/0"]
  }
}

resource "exoscale_security_group_rules" "ipip-test-rules-ah" {
  security_group_id = exoscale_security_group.ipip-test-sg.id
  ingress {
    protocol = "AH"
    # ports    = ["0"]
    cidr_list = ["0.0.0.0/0", "::/0"]
  }
}

resource "exoscale_security_group_rules" "ipip-test-rules-esp" {
  security_group_id = exoscale_security_group.ipip-test-sg.id
  ingress {
    protocol = "ESP"
    # ports    = ["0"]
    cidr_list = ["0.0.0.0/0", "::/0"]
  }
}

resource "exoscale_security_group_rules" "ipip-test-rules-gre" {
  security_group_id = exoscale_security_group.ipip-test-sg.id
  ingress {
    protocol = "GRE"
    # ports    = ["0"]
    cidr_list = ["0.0.0.0/0", "::/0"]
  }
}
```

When I run it with the patched version it works as expected:
![Screenshot from 2020-09-21 15-18-44](https://user-images.githubusercontent.com/6826348/93771807-467c6f80-fc1e-11ea-9b81-4b441db97e0a.png)
