### PR TITLE
sks_nodepool: support SG/AAG updating

### DIFF
--- a/exoscale/client.go
+++ b/exoscale/client.go
@@ -3,6 +3,7 @@ package exoscale
 import (
 	"fmt"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/exoscale/egoscale"
@@ -75,7 +76,12 @@ func getClient(endpoint string, meta interface{}) *egoscale.Client {
 			}
 			return hc
 		}()),
-	)
+		exov2.ClientOptCond(func() bool {
+			if v := os.Getenv("EXOSCALE_TRACE"); v != "" {
+				return true
+			}
+			return false
+		}, exov2.ClientOptWithTrace()))
 	if err != nil {
 		panic(fmt.Sprintf("unable to initialize Exoscale API V2 client: %v", err))
 	}

--- a/exoscale/resource_exoscale_sks_cluster.go
+++ b/exoscale/resource_exoscale_sks_cluster.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	defaultSKSClusterVersion      = "1.20.2"
+	defaultSKSClusterVersion      = "1.20.3"
 	defaultSKSClusterCNI          = "calico"
 	defaultSKSClusterServiceLevel = "pro"
 )

--- a/exoscale/resource_exoscale_sks_cluster_test.go
+++ b/exoscale/resource_exoscale_sks_cluster_test.go
@@ -30,7 +30,7 @@ resource "exoscale_sks_cluster" "test" {
   description = "%s"
 
   timeouts {
-    delete = "10m"
+    create = "10m"
   }
 }
 
@@ -63,7 +63,7 @@ resource "exoscale_sks_cluster" "test" {
   description = "%s"
 
   timeouts {
-    delete = "10m"
+    create = "10m"
   }
 }
 
@@ -76,7 +76,7 @@ resource "exoscale_sks_nodepool" "test" {
   size = 1
 
   timeouts {
-    delete = "10m"
+    create = "10m"
   }
 }
 `,

--- a/exoscale/resource_exoscale_sks_nodepool.go
+++ b/exoscale/resource_exoscale_sks_nodepool.go
@@ -65,7 +65,6 @@ func resourceSKSNodepool() *schema.Resource {
 			Optional: true,
 			Set:      schema.HashString,
 			Elem:     &schema.Schema{Type: schema.TypeString},
-			ForceNew: true,
 		},
 		"security_group_ids": {
 			Type:     schema.TypeSet,
@@ -259,6 +258,26 @@ func resourceSKSNodepoolUpdate(d *schema.ResourceData, meta interface{}) error {
 			return err
 		}
 		nodepool.InstanceTypeID = resp.(*egoscale.ServiceOffering).ID.String()
+		updated = true
+	}
+
+	if d.HasChange("anti_affinity_group_ids") {
+		if antiAffinityIDSet, ok := d.Get("anti_affinity_group_ids").(*schema.Set); ok {
+			nodepool.AntiAffinityGroupIDs = make([]string, antiAffinityIDSet.Len())
+			for i, id := range antiAffinityIDSet.List() {
+				nodepool.AntiAffinityGroupIDs[i] = id.(string)
+			}
+		}
+		updated = true
+	}
+
+	if d.HasChange("security_group_ids") {
+		if securityIDSet, ok := d.Get("security_group_ids").(*schema.Set); ok {
+			nodepool.SecurityGroupIDs = make([]string, securityIDSet.Len())
+			for i, id := range securityIDSet.List() {
+				nodepool.SecurityGroupIDs[i] = id.(string)
+			}
+		}
 		updated = true
 	}
 

--- a/exoscale/resource_exoscale_sks_nodepool_test.go
+++ b/exoscale/resource_exoscale_sks_nodepool_test.go
@@ -31,14 +31,6 @@ locals {
   zone = "%s"
 }
 
-data "exoscale_security_group" "default" {
-  name = "default"
-}
-	
-resource "exoscale_affinity" "test" {
-  name = "%s"
-}
-
 resource "exoscale_sks_cluster" "test" {
   zone = local.zone
   name = "%s"
@@ -56,8 +48,6 @@ resource "exoscale_sks_nodepool" "test" {
   instance_type = "%s"
   disk_size = %d
   size = %d
-  anti_affinity_group_ids = [exoscale_affinity.test.id]
-  security_group_ids = [data.exoscale_security_group.default.id]
 
   timeouts {
     delete = "10m"
@@ -65,7 +55,6 @@ resource "exoscale_sks_nodepool" "test" {
 }
 `,
 		testZoneName,
-		testAccResourceSKSNodepoolAntiAffinityGroupName,
 		testAccResourceSKSClusterName,
 		testAccResourceSKSNodepoolName,
 		testAccResourceSKSNodepoolDescription,
@@ -137,19 +126,17 @@ func TestAccResourceSKSNodepool(t *testing.T) {
 					testAccCheckResourceSKSNodepoolExists("exoscale_sks_nodepool.test", nodepool),
 					testAccCheckResourceSKSNodepool(nodepool),
 					testAccCheckResourceSKSNodepoolAttributes(testAttrs{
-						"created_at":                validation.NoZeroValues,
-						"description":               ValidateString(testAccResourceSKSNodepoolDescription),
-						"disk_size":                 ValidateString(fmt.Sprint(testAccResourceSKSNodepoolDiskSize)),
-						"id":                        validation.IsUUID,
-						"instance_pool_id":          validation.IsUUID,
-						"instance_type":             ValidateString(testAccResourceSKSNodepoolInstanceType),
-						"name":                      ValidateString(testAccResourceSKSNodepoolName),
-						"anti_affinity_group_ids.#": ValidateString("1"),
-						"security_group_ids.#":      ValidateString("1"),
-						"size":                      ValidateString(fmt.Sprint(testAccResourceSKSNodepoolSize)),
-						"state":                     validation.NoZeroValues,
-						"template_id":               validation.IsUUID,
-						"version":                   ValidateString(defaultSKSClusterVersion),
+						"created_at":       validation.NoZeroValues,
+						"description":      ValidateString(testAccResourceSKSNodepoolDescription),
+						"disk_size":        ValidateString(fmt.Sprint(testAccResourceSKSNodepoolDiskSize)),
+						"id":               validation.IsUUID,
+						"instance_pool_id": validation.IsUUID,
+						"instance_type":    ValidateString(testAccResourceSKSNodepoolInstanceType),
+						"name":             ValidateString(testAccResourceSKSNodepoolName),
+						"size":             ValidateString(fmt.Sprint(testAccResourceSKSNodepoolSize)),
+						"state":            validation.NoZeroValues,
+						"template_id":      validation.IsUUID,
+						"version":          ValidateString(defaultSKSClusterVersion),
 					}),
 				),
 			},

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/exoscale/terraform-provider-exoscale
 
 require (
 	github.com/deepmap/oapi-codegen v1.5.1 // indirect
-	github.com/exoscale/egoscale v0.43.1
+	github.com/exoscale/egoscale v0.44.0
 	github.com/gofrs/uuid v4.0.0+incompatible // indirect
 	github.com/gopherjs/gopherjs v0.0.0-20190430165422-3e4dfb77656c // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.1

--- a/go.sum
+++ b/go.sum
@@ -85,8 +85,8 @@ github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymF
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/exoscale/egoscale v0.43.1 h1:Lhr0UOfg3t3Y56yh1DsYCjQuUHqFvsC8iUVqvub8+0Q=
-github.com/exoscale/egoscale v0.43.1/go.mod h1:mpEXBpROAa/2i5GC0r33rfxG+TxSEka11g1PIXt9+zc=
+github.com/exoscale/egoscale v0.44.0 h1:BzIDTfA4u3TALLHO6FfvswFQkRr070PO0jKZteTNA5M=
+github.com/exoscale/egoscale v0.44.0/go.mod h1:mpEXBpROAa/2i5GC0r33rfxG+TxSEka11g1PIXt9+zc=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=

--- a/vendor/github.com/exoscale/egoscale/CHANGELOG.md
+++ b/vendor/github.com/exoscale/egoscale/CHANGELOG.md
@@ -1,6 +1,16 @@
 Changelog
 =========
 
+0.44.0
+------
+
+- feature: v2: add request tracing middleware (#474)
+- feature: v2: add support for field resetting (#476)
+- feature: v2: add support for Instance Pools management (#471)
+- feature: v2: add support for Private Networks management (#472)
+- feature: v2: add support for Anti-Affinity Groups management (#473)
+- feature: v2: add support for Security Groups management (#475)
+
 0.43.1
 ------
 

--- a/vendor/github.com/exoscale/egoscale/v2/anti_affinity_group.go
+++ b/vendor/github.com/exoscale/egoscale/v2/anti_affinity_group.go
@@ -1,0 +1,95 @@
+package v2
+
+import (
+	"context"
+
+	apiv2 "github.com/exoscale/egoscale/v2/api"
+	papi "github.com/exoscale/egoscale/v2/internal/public-api"
+)
+
+// AntiAffinityGroup represents an Anti-Affinity Group.
+type AntiAffinityGroup struct {
+	Description string
+	ID          string
+	Name        string
+}
+
+func antiAffinityGroupFromAPI(a *papi.AntiAffinityGroup) *AntiAffinityGroup {
+	return &AntiAffinityGroup{
+		Description: papi.OptionalString(a.Description),
+		ID:          papi.OptionalString(a.Id),
+		Name:        papi.OptionalString(a.Name),
+	}
+}
+
+// CreateAntiAffinityGroup creates an Anti-Affinity Group in the specified zone.
+func (c *Client) CreateAntiAffinityGroup(ctx context.Context, zone string,
+	antiAffinityGroup *AntiAffinityGroup) (*AntiAffinityGroup, error) {
+	resp, err := c.CreateAntiAffinityGroupWithResponse(
+		apiv2.WithZone(ctx, zone),
+		papi.CreateAntiAffinityGroupJSONRequestBody{
+			Description: &antiAffinityGroup.Description,
+			Name:        antiAffinityGroup.Name,
+		})
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := papi.NewPoller().
+		WithTimeout(c.timeout).
+		Poll(ctx, c.OperationPoller(zone, *resp.JSON200.Id))
+	if err != nil {
+		return nil, err
+	}
+
+	return c.GetAntiAffinityGroup(ctx, zone, *res.(*papi.Reference).Id)
+}
+
+// ListAntiAffinityGroups returns the list of existing Anti-Affinity Groups in the specified zone.
+func (c *Client) ListAntiAffinityGroups(ctx context.Context, zone string) ([]*AntiAffinityGroup, error) {
+	list := make([]*AntiAffinityGroup, 0)
+
+	resp, err := c.ListAntiAffinityGroupsWithResponse(apiv2.WithZone(ctx, zone))
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.JSON200.AntiAffinityGroups != nil {
+		for i := range *resp.JSON200.AntiAffinityGroups {
+			cluster := antiAffinityGroupFromAPI(&(*resp.JSON200.AntiAffinityGroups)[i])
+
+			list = append(list, cluster)
+		}
+	}
+
+	return list, nil
+}
+
+// GetAntiAffinityGroup returns the Anti-Affinity Group corresponding to the specified ID in the specified zone.
+func (c *Client) GetAntiAffinityGroup(ctx context.Context, zone, id string) (*AntiAffinityGroup, error) {
+	resp, err := c.GetAntiAffinityGroupWithResponse(apiv2.WithZone(ctx, zone), id)
+	if err != nil {
+		return nil, err
+	}
+
+	antiAffinityGroup := antiAffinityGroupFromAPI(resp.JSON200)
+
+	return antiAffinityGroup, nil
+}
+
+// DeleteAntiAffinityGroup deletes the specified Anti-Affinity Group in the specified zone.
+func (c *Client) DeleteAntiAffinityGroup(ctx context.Context, zone, id string) error {
+	resp, err := c.DeleteAntiAffinityGroupWithResponse(apiv2.WithZone(ctx, zone), id)
+	if err != nil {
+		return err
+	}
+
+	_, err = papi.NewPoller().
+		WithTimeout(c.timeout).
+		Poll(ctx, c.OperationPoller(zone, *resp.JSON200.Id))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/vendor/github.com/exoscale/egoscale/v2/instance_pool.go
+++ b/vendor/github.com/exoscale/egoscale/v2/instance_pool.go
@@ -1,0 +1,425 @@
+package v2
+
+import (
+	"context"
+
+	apiv2 "github.com/exoscale/egoscale/v2/api"
+	papi "github.com/exoscale/egoscale/v2/internal/public-api"
+)
+
+// InstancePool represents an Instance Pool.
+type InstancePool struct {
+	AntiAffinityGroupIDs []string `reset:"anti-affinity-groups"`
+	Description          string   `reset:"description"`
+	DiskSize             int64
+	ElasticIPIDs         []string `reset:"elastic-ips"`
+	ID                   string
+	IPv6Enabled          bool
+	InstanceIDs          []string
+	InstanceTypeID       string
+	ManagerID            string
+	Name                 string
+	PrivateNetworkIDs    []string `reset:"private-networks"`
+	SSHKey               string   `reset:"ssh-key"`
+	SecurityGroupIDs     []string `reset:"security-groups"`
+	Size                 int64
+	State                string
+	TemplateID           string
+	UserData             string `reset:"user-data"`
+
+	c    *Client
+	zone string
+}
+
+func instancePoolFromAPI(i *papi.InstancePool) *InstancePool {
+	return &InstancePool{
+		AntiAffinityGroupIDs: func() []string {
+			ids := make([]string, 0)
+
+			if i.AntiAffinityGroups != nil {
+				for _, item := range *i.AntiAffinityGroups {
+					item := item
+					ids = append(ids, *item.Id)
+				}
+			}
+
+			return ids
+		}(),
+		Description: papi.OptionalString(i.Description),
+		DiskSize:    papi.OptionalInt64(i.DiskSize),
+		ElasticIPIDs: func() []string {
+			ids := make([]string, 0)
+
+			if i.ElasticIps != nil {
+				for _, item := range *i.ElasticIps {
+					item := item
+					ids = append(ids, *item.Id)
+				}
+			}
+
+			return ids
+		}(),
+		ID:          papi.OptionalString(i.Id),
+		IPv6Enabled: papi.OptionalBool(i.Ipv6Enabled),
+		InstanceIDs: func() []string {
+			ids := make([]string, 0)
+
+			if i.Instances != nil {
+				for _, item := range *i.Instances {
+					item := item
+					ids = append(ids, *item.Id)
+				}
+			}
+
+			return ids
+		}(),
+		InstanceTypeID: papi.OptionalString(i.InstanceType.Id),
+		ManagerID:      papi.OptionalString(i.Manager.Id),
+		Name:           papi.OptionalString(i.Name),
+		PrivateNetworkIDs: func() []string {
+			ids := make([]string, 0)
+
+			if i.PrivateNetworks != nil {
+				for _, item := range *i.PrivateNetworks {
+					item := item
+					ids = append(ids, *item.Id)
+				}
+			}
+
+			return ids
+		}(),
+		SSHKey: func() string {
+			key := ""
+			if i.SshKey != nil {
+				key = papi.OptionalString(i.SshKey.Name)
+			}
+			return key
+		}(),
+		SecurityGroupIDs: func() []string {
+			ids := make([]string, 0)
+
+			if i.SecurityGroups != nil {
+				for _, item := range *i.SecurityGroups {
+					item := item
+					ids = append(ids, *item.Id)
+				}
+			}
+
+			return ids
+		}(),
+		Size:       papi.OptionalInt64(i.Size),
+		State:      papi.OptionalString(i.State),
+		TemplateID: papi.OptionalString(i.Template.Id),
+		UserData:   papi.OptionalString(i.UserData),
+	}
+}
+
+// Scale scales the Instance Pool to the specified number of instances.
+func (i *InstancePool) Scale(ctx context.Context, instances int64) error {
+	resp, err := i.c.ScaleInstancePoolWithResponse(
+		apiv2.WithZone(ctx, i.zone),
+		i.ID,
+		papi.ScaleInstancePoolJSONRequestBody{Size: instances},
+	)
+	if err != nil {
+		return err
+	}
+
+	_, err = papi.NewPoller().
+		WithTimeout(i.c.timeout).
+		Poll(ctx, i.c.OperationPoller(i.zone, *resp.JSON200.Id))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// EvictMembers evicts the specified members (identified by their Compute instance ID) from the
+// Instance Pool.
+func (i *InstancePool) EvictMembers(ctx context.Context, members []string) error {
+	resp, err := i.c.EvictInstancePoolMembersWithResponse(
+		apiv2.WithZone(ctx, i.zone),
+		i.ID,
+		papi.EvictInstancePoolMembersJSONRequestBody{Instances: &members},
+	)
+	if err != nil {
+		return err
+	}
+
+	_, err = papi.NewPoller().
+		WithTimeout(i.c.timeout).
+		Poll(ctx, i.c.OperationPoller(i.zone, *resp.JSON200.Id))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ResetField resets the specified Instance Pool field to its default value.
+// The value expected for the field parameter is a pointer to the InstancePool field to reset.
+func (i *InstancePool) ResetField(ctx context.Context, field interface{}) error {
+	resetField, err := resetFieldName(i, field)
+	if err != nil {
+		return err
+	}
+
+	resp, err := i.c.ResetInstancePoolFieldWithResponse(apiv2.WithZone(ctx, i.zone), i.ID, resetField)
+	if err != nil {
+		return err
+	}
+
+	_, err = papi.NewPoller().
+		WithTimeout(i.c.timeout).
+		Poll(ctx, i.c.OperationPoller(i.zone, *resp.JSON200.Id))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// CreateInstancePool creates an Instance Pool in the specified zone.
+func (c *Client) CreateInstancePool(ctx context.Context, zone string, instancePool *InstancePool) (*InstancePool, error) {
+	resp, err := c.CreateInstancePoolWithResponse(
+		apiv2.WithZone(ctx, zone),
+		papi.CreateInstancePoolJSONRequestBody{
+			AntiAffinityGroups: func() *[]papi.AntiAffinityGroup {
+				if l := len(instancePool.AntiAffinityGroupIDs); l > 0 {
+					list := make([]papi.AntiAffinityGroup, l)
+					for i, v := range instancePool.AntiAffinityGroupIDs {
+						v := v
+						list[i] = papi.AntiAffinityGroup{Id: &v}
+					}
+					return &list
+				}
+				return nil
+			}(),
+			Description: &instancePool.Description,
+			DiskSize:    instancePool.DiskSize,
+			ElasticIps: func() *[]papi.ElasticIp {
+				if l := len(instancePool.ElasticIPIDs); l > 0 {
+					list := make([]papi.ElasticIp, l)
+					for i, v := range instancePool.ElasticIPIDs {
+						v := v
+						list[i] = papi.ElasticIp{Id: &v}
+					}
+					return &list
+				}
+				return nil
+			}(),
+			InstanceType: papi.InstanceType{Id: &instancePool.InstanceTypeID},
+			Ipv6Enabled:  &instancePool.IPv6Enabled,
+			Name:         instancePool.Name,
+			PrivateNetworks: func() *[]papi.PrivateNetwork {
+				if l := len(instancePool.PrivateNetworkIDs); l > 0 {
+					list := make([]papi.PrivateNetwork, l)
+					for i, v := range instancePool.PrivateNetworkIDs {
+						v := v
+						list[i] = papi.PrivateNetwork{Id: &v}
+					}
+					return &list
+				}
+				return nil
+			}(),
+			SecurityGroups: func() *[]papi.SecurityGroup {
+				if l := len(instancePool.SecurityGroupIDs); l > 0 {
+					list := make([]papi.SecurityGroup, l)
+					for i, v := range instancePool.SecurityGroupIDs {
+						v := v
+						list[i] = papi.SecurityGroup{Id: &v}
+					}
+					return &list
+				}
+				return nil
+			}(),
+			Size: instancePool.Size,
+			SshKey: func() *papi.SshKey {
+				if instancePool.SSHKey != "" {
+					return &papi.SshKey{Name: &instancePool.SSHKey}
+				}
+				return nil
+			}(),
+			Template: papi.Template{Id: &instancePool.TemplateID},
+			UserData: func() *string {
+				if instancePool.UserData != "" {
+					return &instancePool.UserData
+				}
+				return nil
+			}(),
+		})
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := papi.NewPoller().
+		WithTimeout(c.timeout).
+		Poll(ctx, c.OperationPoller(zone, *resp.JSON200.Id))
+	if err != nil {
+		return nil, err
+	}
+
+	return c.GetInstancePool(ctx, zone, *res.(*papi.Reference).Id)
+}
+
+// ListInstancePools returns the list of existing Instance Pools in the specified zone.
+func (c *Client) ListInstancePools(ctx context.Context, zone string) ([]*InstancePool, error) {
+	list := make([]*InstancePool, 0)
+
+	resp, err := c.ListInstancePoolsWithResponse(apiv2.WithZone(ctx, zone))
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.JSON200.InstancePools != nil {
+		for i := range *resp.JSON200.InstancePools {
+			cluster := instancePoolFromAPI(&(*resp.JSON200.InstancePools)[i])
+			cluster.c = c
+			cluster.zone = zone
+
+			list = append(list, cluster)
+		}
+	}
+
+	return list, nil
+}
+
+// GetInstancePool returns the Instance Pool corresponding to the specified ID in the specified zone.
+func (c *Client) GetInstancePool(ctx context.Context, zone, id string) (*InstancePool, error) {
+	resp, err := c.GetInstancePoolWithResponse(apiv2.WithZone(ctx, zone), id)
+	if err != nil {
+		return nil, err
+	}
+
+	instancePool := instancePoolFromAPI(resp.JSON200)
+	instancePool.c = c
+	instancePool.zone = zone
+
+	return instancePool, nil
+}
+
+// UpdateInstancePool updates the specified Instance Pool in the specified zone.
+func (c *Client) UpdateInstancePool(ctx context.Context, zone string, instancePool *InstancePool) error {
+	resp, err := c.UpdateInstancePoolWithResponse(
+		apiv2.WithZone(ctx, zone),
+		instancePool.ID,
+		papi.UpdateInstancePoolJSONRequestBody{
+			AntiAffinityGroups: func() *[]papi.AntiAffinityGroup {
+				if l := len(instancePool.AntiAffinityGroupIDs); l > 0 {
+					list := make([]papi.AntiAffinityGroup, l)
+					for i, v := range instancePool.AntiAffinityGroupIDs {
+						v := v
+						list[i] = papi.AntiAffinityGroup{Id: &v}
+					}
+					return &list
+				}
+				return nil
+			}(),
+			Description: func() *string {
+				if instancePool.Description != "" {
+					return &instancePool.Description
+				}
+				return nil
+			}(),
+			DiskSize: func() *int64 {
+				if instancePool.DiskSize > 0 {
+					return &instancePool.DiskSize
+				}
+				return nil
+			}(),
+			ElasticIps: func() *[]papi.ElasticIp {
+				if l := len(instancePool.ElasticIPIDs); l > 0 {
+					list := make([]papi.ElasticIp, l)
+					for i, v := range instancePool.ElasticIPIDs {
+						v := v
+						list[i] = papi.ElasticIp{Id: &v}
+					}
+					return &list
+				}
+				return nil
+			}(),
+			InstanceType: func() *papi.InstanceType {
+				if instancePool.InstanceTypeID != "" {
+					return &papi.InstanceType{Id: &instancePool.InstanceTypeID}
+				}
+				return nil
+			}(),
+			Ipv6Enabled: &instancePool.IPv6Enabled,
+			Name: func() *string {
+				if instancePool.Name != "" {
+					return &instancePool.Name
+				}
+				return nil
+			}(),
+			PrivateNetworks: func() *[]papi.PrivateNetwork {
+				if l := len(instancePool.PrivateNetworkIDs); l > 0 {
+					list := make([]papi.PrivateNetwork, l)
+					for i, v := range instancePool.PrivateNetworkIDs {
+						v := v
+						list[i] = papi.PrivateNetwork{Id: &v}
+					}
+					return &list
+				}
+				return nil
+			}(),
+			SecurityGroups: func() *[]papi.SecurityGroup {
+				if l := len(instancePool.SecurityGroupIDs); l > 0 {
+					list := make([]papi.SecurityGroup, l)
+					for i, v := range instancePool.SecurityGroupIDs {
+						v := v
+						list[i] = papi.SecurityGroup{Id: &v}
+					}
+					return &list
+				}
+				return nil
+			}(),
+			SshKey: func() *papi.SshKey {
+				if instancePool.SSHKey != "" {
+					return &papi.SshKey{Name: &instancePool.SSHKey}
+				}
+				return nil
+			}(),
+			Template: func() *papi.Template {
+				if instancePool.TemplateID != "" {
+					return &papi.Template{Id: &instancePool.TemplateID}
+				}
+				return nil
+			}(),
+			UserData: func() *string {
+				if instancePool.UserData != "" {
+					return &instancePool.UserData
+				}
+				return nil
+			}(),
+		})
+	if err != nil {
+		return err
+	}
+
+	_, err = papi.NewPoller().
+		WithTimeout(c.timeout).
+		Poll(ctx, c.OperationPoller(zone, *resp.JSON200.Id))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// DeleteInstancePool deletes the specified Instance Pool in the specified zone.
+func (c *Client) DeleteInstancePool(ctx context.Context, zone, id string) error {
+	resp, err := c.DeleteInstancePoolWithResponse(apiv2.WithZone(ctx, zone), id)
+	if err != nil {
+		return err
+	}
+
+	_, err = papi.NewPoller().
+		WithTimeout(c.timeout).
+		Poll(ctx, c.OperationPoller(zone, *resp.JSON200.Id))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/vendor/github.com/exoscale/egoscale/v2/internal/public-api/public-api.gen.go
+++ b/vendor/github.com/exoscale/egoscale/v2/internal/public-api/public-api.gen.go
@@ -29,8 +29,23 @@ type AntiAffinityGroup struct {
 
 // ElasticIp defines model for elastic-ip.
 type ElasticIp struct {
-	Id *string `json:"id,omitempty"`
-	Ip *string `json:"ip,omitempty"`
+	Description *string               `json:"description,omitempty"`
+	Healthcheck *ElasticIpHealthcheck `json:"healthcheck,omitempty"`
+	Id          *string               `json:"id,omitempty"`
+	Ip          *string               `json:"ip,omitempty"`
+}
+
+// ElasticIpHealthcheck defines model for elastic-ip-healthcheck.
+type ElasticIpHealthcheck struct {
+	Interval      int64   `json:"interval"`
+	Mode          string  `json:"mode"`
+	Port          int64   `json:"port"`
+	StrikesFail   int64   `json:"strikes-fail"`
+	StrikesOk     int64   `json:"strikes-ok"`
+	Timeout       int64   `json:"timeout"`
+	TlsSkipVerify *bool   `json:"tls-skip-verify,omitempty"`
+	TlsSni        *string `json:"tls-sni,omitempty"`
+	Uri           *string `json:"uri,omitempty"`
 }
 
 // Event defines model for event.
@@ -42,17 +57,6 @@ type Event struct {
 // Event_Payload defines model for Event.Payload.
 type Event_Payload struct {
 	AdditionalProperties map[string]interface{} `json:"-"`
-}
-
-// Healthcheck defines model for healthcheck.
-type Healthcheck struct {
-	Interval *int64  `json:"interval,omitempty"`
-	Mode     string  `json:"mode"`
-	Port     int64   `json:"port"`
-	Retries  *int64  `json:"retries,omitempty"`
-	Timeout  *int64  `json:"timeout,omitempty"`
-	TlsSni   *string `json:"tls-sni,omitempty"`
-	Uri      *string `json:"uri,omitempty"`
 }
 
 // Instance defines model for instance.
@@ -112,17 +116,28 @@ type LoadBalancerServerStatus struct {
 
 // LoadBalancerService defines model for load-balancer-service.
 type LoadBalancerService struct {
-	Description       *string                     `json:"description,omitempty"`
-	Healthcheck       *Healthcheck                `json:"healthcheck,omitempty"`
-	HealthcheckStatus *[]LoadBalancerServerStatus `json:"healthcheck-status,omitempty"`
-	Id                *string                     `json:"id,omitempty"`
-	InstancePool      *InstancePool               `json:"instance-pool,omitempty"`
-	Name              *string                     `json:"name,omitempty"`
-	Port              *int64                      `json:"port,omitempty"`
-	Protocol          *string                     `json:"protocol,omitempty"`
-	State             *string                     `json:"state,omitempty"`
-	Strategy          *string                     `json:"strategy,omitempty"`
-	TargetPort        *int64                      `json:"target-port,omitempty"`
+	Description       *string                         `json:"description,omitempty"`
+	Healthcheck       *LoadBalancerServiceHealthcheck `json:"healthcheck,omitempty"`
+	HealthcheckStatus *[]LoadBalancerServerStatus     `json:"healthcheck-status,omitempty"`
+	Id                *string                         `json:"id,omitempty"`
+	InstancePool      *InstancePool                   `json:"instance-pool,omitempty"`
+	Name              *string                         `json:"name,omitempty"`
+	Port              *int64                          `json:"port,omitempty"`
+	Protocol          *string                         `json:"protocol,omitempty"`
+	State             *string                         `json:"state,omitempty"`
+	Strategy          *string                         `json:"strategy,omitempty"`
+	TargetPort        *int64                          `json:"target-port,omitempty"`
+}
+
+// LoadBalancerServiceHealthcheck defines model for load-balancer-service-healthcheck.
+type LoadBalancerServiceHealthcheck struct {
+	Interval int64   `json:"interval"`
+	Mode     string  `json:"mode"`
+	Port     int64   `json:"port"`
+	Retries  int64   `json:"retries"`
+	Timeout  int64   `json:"timeout"`
+	TlsSni   *string `json:"tls-sni,omitempty"`
+	Uri      *string `json:"uri,omitempty"`
 }
 
 // Manager defines model for manager.
@@ -276,6 +291,18 @@ type CreateAntiAffinityGroupJSONBody struct {
 	Name        string  `json:"name"`
 }
 
+// CreateElasticIpJSONBody defines parameters for CreateElasticIp.
+type CreateElasticIpJSONBody struct {
+	Description *string               `json:"description,omitempty"`
+	Healthcheck *ElasticIpHealthcheck `json:"healthcheck,omitempty"`
+}
+
+// UpdateElasticIpJSONBody defines parameters for UpdateElasticIp.
+type UpdateElasticIpJSONBody struct {
+	Description *string               `json:"description,omitempty"`
+	Healthcheck *ElasticIpHealthcheck `json:"healthcheck,omitempty"`
+}
+
 // ListEventsParams defines parameters for ListEvents.
 type ListEventsParams struct {
 	From *time.Time `json:"from,omitempty"`
@@ -352,25 +379,25 @@ type UpdateLoadBalancerJSONBody struct {
 
 // AddServiceToLoadBalancerJSONBody defines parameters for AddServiceToLoadBalancer.
 type AddServiceToLoadBalancerJSONBody struct {
-	Description  *string      `json:"description,omitempty"`
-	Healthcheck  Healthcheck  `json:"healthcheck"`
-	InstancePool InstancePool `json:"instance-pool"`
-	Name         string       `json:"name"`
-	Port         int64        `json:"port"`
-	Protocol     string       `json:"protocol"`
-	Strategy     string       `json:"strategy"`
-	TargetPort   int64        `json:"target-port"`
+	Description  *string                        `json:"description,omitempty"`
+	Healthcheck  LoadBalancerServiceHealthcheck `json:"healthcheck"`
+	InstancePool InstancePool                   `json:"instance-pool"`
+	Name         string                         `json:"name"`
+	Port         int64                          `json:"port"`
+	Protocol     string                         `json:"protocol"`
+	Strategy     string                         `json:"strategy"`
+	TargetPort   int64                          `json:"target-port"`
 }
 
 // UpdateLoadBalancerServiceJSONBody defines parameters for UpdateLoadBalancerService.
 type UpdateLoadBalancerServiceJSONBody struct {
-	Description *string      `json:"description,omitempty"`
-	Healthcheck *Healthcheck `json:"healthcheck,omitempty"`
-	Name        *string      `json:"name,omitempty"`
-	Port        *int64       `json:"port,omitempty"`
-	Protocol    *string      `json:"protocol,omitempty"`
-	Strategy    *string      `json:"strategy,omitempty"`
-	TargetPort  *int64       `json:"target-port,omitempty"`
+	Description *string                         `json:"description,omitempty"`
+	Healthcheck *LoadBalancerServiceHealthcheck `json:"healthcheck,omitempty"`
+	Name        *string                         `json:"name,omitempty"`
+	Port        *int64                          `json:"port,omitempty"`
+	Protocol    *string                         `json:"protocol,omitempty"`
+	Strategy    *string                         `json:"strategy,omitempty"`
+	TargetPort  *int64                          `json:"target-port,omitempty"`
 }
 
 // CreatePrivateNetworkJSONBody defines parameters for CreatePrivateNetwork.
@@ -498,6 +525,12 @@ type CopyTemplateJSONBody struct {
 
 // CreateAntiAffinityGroupRequestBody defines body for CreateAntiAffinityGroup for application/json ContentType.
 type CreateAntiAffinityGroupJSONRequestBody CreateAntiAffinityGroupJSONBody
+
+// CreateElasticIpRequestBody defines body for CreateElasticIp for application/json ContentType.
+type CreateElasticIpJSONRequestBody CreateElasticIpJSONBody
+
+// UpdateElasticIpRequestBody defines body for UpdateElasticIp for application/json ContentType.
+type UpdateElasticIpJSONRequestBody UpdateElasticIpJSONBody
 
 // CreateInstanceRequestBody defines body for CreateInstance for application/json ContentType.
 type CreateInstanceJSONRequestBody CreateInstanceJSONBody
@@ -711,8 +744,27 @@ type ClientInterface interface {
 	// GetAntiAffinityGroup request
 	GetAntiAffinityGroup(ctx context.Context, id string) (*http.Response, error)
 
+	// ListElasticIps request
+	ListElasticIps(ctx context.Context) (*http.Response, error)
+
+	// CreateElasticIp request  with any body
+	CreateElasticIpWithBody(ctx context.Context, contentType string, body io.Reader) (*http.Response, error)
+
+	CreateElasticIp(ctx context.Context, body CreateElasticIpJSONRequestBody) (*http.Response, error)
+
+	// DeleteElasticIp request
+	DeleteElasticIp(ctx context.Context, id string) (*http.Response, error)
+
 	// GetElasticIp request
 	GetElasticIp(ctx context.Context, id string) (*http.Response, error)
+
+	// UpdateElasticIp request  with any body
+	UpdateElasticIpWithBody(ctx context.Context, id string, contentType string, body io.Reader) (*http.Response, error)
+
+	UpdateElasticIp(ctx context.Context, id string, body UpdateElasticIpJSONRequestBody) (*http.Response, error)
+
+	// ResetElasticIpField request
+	ResetElasticIpField(ctx context.Context, id string, field string) (*http.Response, error)
 
 	// ListEvents request
 	ListEvents(ctx context.Context, params *ListEventsParams) (*http.Response, error)
@@ -741,8 +793,8 @@ type ClientInterface interface {
 
 	UpdateInstancePool(ctx context.Context, id string, body UpdateInstancePoolJSONRequestBody) (*http.Response, error)
 
-	// DeleteInstancePoolField request
-	DeleteInstancePoolField(ctx context.Context, id string, field string) (*http.Response, error)
+	// ResetInstancePoolField request
+	ResetInstancePoolField(ctx context.Context, id string, field string) (*http.Response, error)
 
 	// EvictInstancePoolMembers request  with any body
 	EvictInstancePoolMembersWithBody(ctx context.Context, id string, contentType string, body io.Reader) (*http.Response, error)
@@ -825,9 +877,6 @@ type ClientInterface interface {
 
 	UpdatePrivateNetwork(ctx context.Context, id string, body UpdatePrivateNetworkJSONRequestBody) (*http.Response, error)
 
-	// DeletePrivateNetworkField request
-	DeletePrivateNetworkField(ctx context.Context, id string, field string) (*http.Response, error)
-
 	// ListSecurityGroups request
 	ListSecurityGroups(ctx context.Context) (*http.Response, error)
 
@@ -893,8 +942,8 @@ type ClientInterface interface {
 
 	UpdateSksNodepool(ctx context.Context, id string, sksNodepoolId string, body UpdateSksNodepoolJSONRequestBody) (*http.Response, error)
 
-	// DeleteSksNodepoolField request
-	DeleteSksNodepoolField(ctx context.Context, id string, sksNodepoolId string, field string) (*http.Response, error)
+	// ResetSksNodepoolField request
+	ResetSksNodepoolField(ctx context.Context, id string, sksNodepoolId string, field string) (*http.Response, error)
 
 	// EvictSksNodepoolMembers request  with any body
 	EvictSksNodepoolMembersWithBody(ctx context.Context, id string, sksNodepoolId string, contentType string, body io.Reader) (*http.Response, error)
@@ -906,13 +955,16 @@ type ClientInterface interface {
 
 	ScaleSksNodepool(ctx context.Context, id string, sksNodepoolId string, body ScaleSksNodepoolJSONRequestBody) (*http.Response, error)
 
+	// RotateSksCcmCredentials request
+	RotateSksCcmCredentials(ctx context.Context, id string) (*http.Response, error)
+
 	// UpgradeSksCluster request  with any body
 	UpgradeSksClusterWithBody(ctx context.Context, id string, contentType string, body io.Reader) (*http.Response, error)
 
 	UpgradeSksCluster(ctx context.Context, id string, body UpgradeSksClusterJSONRequestBody) (*http.Response, error)
 
-	// DeleteSksClusterField request
-	DeleteSksClusterField(ctx context.Context, id string, field string) (*http.Response, error)
+	// ResetSksClusterField request
+	ResetSksClusterField(ctx context.Context, id string, field string) (*http.Response, error)
 
 	// ListSnapshots request
 	ListSnapshots(ctx context.Context) (*http.Response, error)
@@ -1030,8 +1082,113 @@ func (c *Client) GetAntiAffinityGroup(ctx context.Context, id string) (*http.Res
 	return c.Client.Do(req)
 }
 
+func (c *Client) ListElasticIps(ctx context.Context) (*http.Response, error) {
+	req, err := NewListElasticIpsRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if c.RequestEditor != nil {
+		err = c.RequestEditor(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CreateElasticIpWithBody(ctx context.Context, contentType string, body io.Reader) (*http.Response, error) {
+	req, err := NewCreateElasticIpRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if c.RequestEditor != nil {
+		err = c.RequestEditor(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CreateElasticIp(ctx context.Context, body CreateElasticIpJSONRequestBody) (*http.Response, error) {
+	req, err := NewCreateElasticIpRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if c.RequestEditor != nil {
+		err = c.RequestEditor(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) DeleteElasticIp(ctx context.Context, id string) (*http.Response, error) {
+	req, err := NewDeleteElasticIpRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if c.RequestEditor != nil {
+		err = c.RequestEditor(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return c.Client.Do(req)
+}
+
 func (c *Client) GetElasticIp(ctx context.Context, id string) (*http.Response, error) {
 	req, err := NewGetElasticIpRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if c.RequestEditor != nil {
+		err = c.RequestEditor(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateElasticIpWithBody(ctx context.Context, id string, contentType string, body io.Reader) (*http.Response, error) {
+	req, err := NewUpdateElasticIpRequestWithBody(c.Server, id, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if c.RequestEditor != nil {
+		err = c.RequestEditor(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateElasticIp(ctx context.Context, id string, body UpdateElasticIpJSONRequestBody) (*http.Response, error) {
+	req, err := NewUpdateElasticIpRequest(c.Server, id, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if c.RequestEditor != nil {
+		err = c.RequestEditor(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ResetElasticIpField(ctx context.Context, id string, field string) (*http.Response, error) {
+	req, err := NewResetElasticIpFieldRequest(c.Server, id, field)
 	if err != nil {
 		return nil, err
 	}
@@ -1195,8 +1352,8 @@ func (c *Client) UpdateInstancePool(ctx context.Context, id string, body UpdateI
 	return c.Client.Do(req)
 }
 
-func (c *Client) DeleteInstancePoolField(ctx context.Context, id string, field string) (*http.Response, error) {
-	req, err := NewDeleteInstancePoolFieldRequest(c.Server, id, field)
+func (c *Client) ResetInstancePoolField(ctx context.Context, id string, field string) (*http.Response, error) {
+	req, err := NewResetInstancePoolFieldRequest(c.Server, id, field)
 	if err != nil {
 		return nil, err
 	}
@@ -1660,21 +1817,6 @@ func (c *Client) UpdatePrivateNetwork(ctx context.Context, id string, body Updat
 	return c.Client.Do(req)
 }
 
-func (c *Client) DeletePrivateNetworkField(ctx context.Context, id string, field string) (*http.Response, error) {
-	req, err := NewDeletePrivateNetworkFieldRequest(c.Server, id, field)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if c.RequestEditor != nil {
-		err = c.RequestEditor(ctx, req)
-		if err != nil {
-			return nil, err
-		}
-	}
-	return c.Client.Do(req)
-}
-
 func (c *Client) ListSecurityGroups(ctx context.Context) (*http.Response, error) {
 	req, err := NewListSecurityGroupsRequest(c.Server)
 	if err != nil {
@@ -2035,8 +2177,8 @@ func (c *Client) UpdateSksNodepool(ctx context.Context, id string, sksNodepoolId
 	return c.Client.Do(req)
 }
 
-func (c *Client) DeleteSksNodepoolField(ctx context.Context, id string, sksNodepoolId string, field string) (*http.Response, error) {
-	req, err := NewDeleteSksNodepoolFieldRequest(c.Server, id, sksNodepoolId, field)
+func (c *Client) ResetSksNodepoolField(ctx context.Context, id string, sksNodepoolId string, field string) (*http.Response, error) {
+	req, err := NewResetSksNodepoolFieldRequest(c.Server, id, sksNodepoolId, field)
 	if err != nil {
 		return nil, err
 	}
@@ -2110,6 +2252,21 @@ func (c *Client) ScaleSksNodepool(ctx context.Context, id string, sksNodepoolId 
 	return c.Client.Do(req)
 }
 
+func (c *Client) RotateSksCcmCredentials(ctx context.Context, id string) (*http.Response, error) {
+	req, err := NewRotateSksCcmCredentialsRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if c.RequestEditor != nil {
+		err = c.RequestEditor(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return c.Client.Do(req)
+}
+
 func (c *Client) UpgradeSksClusterWithBody(ctx context.Context, id string, contentType string, body io.Reader) (*http.Response, error) {
 	req, err := NewUpgradeSksClusterRequestWithBody(c.Server, id, contentType, body)
 	if err != nil {
@@ -2140,8 +2297,8 @@ func (c *Client) UpgradeSksCluster(ctx context.Context, id string, body UpgradeS
 	return c.Client.Do(req)
 }
 
-func (c *Client) DeleteSksClusterField(ctx context.Context, id string, field string) (*http.Response, error) {
-	req, err := NewDeleteSksClusterFieldRequest(c.Server, id, field)
+func (c *Client) ResetSksClusterField(ctx context.Context, id string, field string) (*http.Response, error) {
+	req, err := NewResetSksClusterFieldRequest(c.Server, id, field)
 	if err != nil {
 		return nil, err
 	}
@@ -2499,6 +2656,106 @@ func NewGetAntiAffinityGroupRequest(server string, id string) (*http.Request, er
 	return req, nil
 }
 
+// NewListElasticIpsRequest generates requests for ListElasticIps
+func NewListElasticIpsRequest(server string) (*http.Request, error) {
+	var err error
+
+	queryUrl, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	basePath := fmt.Sprintf("/elastic-ip")
+	if basePath[0] == '/' {
+		basePath = basePath[1:]
+	}
+
+	queryUrl, err = queryUrl.Parse(basePath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryUrl.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewCreateElasticIpRequest calls the generic CreateElasticIp builder with application/json body
+func NewCreateElasticIpRequest(server string, body CreateElasticIpJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewCreateElasticIpRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewCreateElasticIpRequestWithBody generates requests for CreateElasticIp with any type of body
+func NewCreateElasticIpRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	queryUrl, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	basePath := fmt.Sprintf("/elastic-ip")
+	if basePath[0] == '/' {
+		basePath = basePath[1:]
+	}
+
+	queryUrl, err = queryUrl.Parse(basePath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryUrl.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+	return req, nil
+}
+
+// NewDeleteElasticIpRequest generates requests for DeleteElasticIp
+func NewDeleteElasticIpRequest(server string, id string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParam("simple", false, "id", id)
+	if err != nil {
+		return nil, err
+	}
+
+	queryUrl, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	basePath := fmt.Sprintf("/elastic-ip/%s", pathParam0)
+	if basePath[0] == '/' {
+		basePath = basePath[1:]
+	}
+
+	queryUrl, err = queryUrl.Parse(basePath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("DELETE", queryUrl.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewGetElasticIpRequest generates requests for GetElasticIp
 func NewGetElasticIpRequest(server string, id string) (*http.Request, error) {
 	var err error
@@ -2526,6 +2783,93 @@ func NewGetElasticIpRequest(server string, id string) (*http.Request, error) {
 	}
 
 	req, err := http.NewRequest("GET", queryUrl.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewUpdateElasticIpRequest calls the generic UpdateElasticIp builder with application/json body
+func NewUpdateElasticIpRequest(server string, id string, body UpdateElasticIpJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUpdateElasticIpRequestWithBody(server, id, "application/json", bodyReader)
+}
+
+// NewUpdateElasticIpRequestWithBody generates requests for UpdateElasticIp with any type of body
+func NewUpdateElasticIpRequestWithBody(server string, id string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParam("simple", false, "id", id)
+	if err != nil {
+		return nil, err
+	}
+
+	queryUrl, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	basePath := fmt.Sprintf("/elastic-ip/%s", pathParam0)
+	if basePath[0] == '/' {
+		basePath = basePath[1:]
+	}
+
+	queryUrl, err = queryUrl.Parse(basePath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PUT", queryUrl.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+	return req, nil
+}
+
+// NewResetElasticIpFieldRequest generates requests for ResetElasticIpField
+func NewResetElasticIpFieldRequest(server string, id string, field string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParam("simple", false, "id", id)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParam("simple", false, "field", field)
+	if err != nil {
+		return nil, err
+	}
+
+	queryUrl, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	basePath := fmt.Sprintf("/elastic-ip/%s/%s", pathParam0, pathParam1)
+	if basePath[0] == '/' {
+		basePath = basePath[1:]
+	}
+
+	queryUrl, err = queryUrl.Parse(basePath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("DELETE", queryUrl.String(), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -2835,8 +3179,8 @@ func NewUpdateInstancePoolRequestWithBody(server string, id string, contentType 
 	return req, nil
 }
 
-// NewDeleteInstancePoolFieldRequest generates requests for DeleteInstancePoolField
-func NewDeleteInstancePoolFieldRequest(server string, id string, field string) (*http.Request, error) {
+// NewResetInstancePoolFieldRequest generates requests for ResetInstancePoolField
+func NewResetInstancePoolFieldRequest(server string, id string, field string) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -3684,47 +4028,6 @@ func NewUpdatePrivateNetworkRequestWithBody(server string, id string, contentTyp
 	return req, nil
 }
 
-// NewDeletePrivateNetworkFieldRequest generates requests for DeletePrivateNetworkField
-func NewDeletePrivateNetworkFieldRequest(server string, id string, field string) (*http.Request, error) {
-	var err error
-
-	var pathParam0 string
-
-	pathParam0, err = runtime.StyleParam("simple", false, "id", id)
-	if err != nil {
-		return nil, err
-	}
-
-	var pathParam1 string
-
-	pathParam1, err = runtime.StyleParam("simple", false, "field", field)
-	if err != nil {
-		return nil, err
-	}
-
-	queryUrl, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	basePath := fmt.Sprintf("/private-network/%s/%s", pathParam0, pathParam1)
-	if basePath[0] == '/' {
-		basePath = basePath[1:]
-	}
-
-	queryUrl, err = queryUrl.Parse(basePath)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest("DELETE", queryUrl.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return req, nil
-}
-
 // NewListSecurityGroupsRequest generates requests for ListSecurityGroups
 func NewListSecurityGroupsRequest(server string) (*http.Request, error) {
 	var err error
@@ -4380,8 +4683,8 @@ func NewUpdateSksNodepoolRequestWithBody(server string, id string, sksNodepoolId
 	return req, nil
 }
 
-// NewDeleteSksNodepoolFieldRequest generates requests for DeleteSksNodepoolField
-func NewDeleteSksNodepoolFieldRequest(server string, id string, sksNodepoolId string, field string) (*http.Request, error) {
+// NewResetSksNodepoolFieldRequest generates requests for ResetSksNodepoolField
+func NewResetSksNodepoolFieldRequest(server string, id string, sksNodepoolId string, field string) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -4534,6 +4837,40 @@ func NewScaleSksNodepoolRequestWithBody(server string, id string, sksNodepoolId 
 	return req, nil
 }
 
+// NewRotateSksCcmCredentialsRequest generates requests for RotateSksCcmCredentials
+func NewRotateSksCcmCredentialsRequest(server string, id string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParam("simple", false, "id", id)
+	if err != nil {
+		return nil, err
+	}
+
+	queryUrl, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	basePath := fmt.Sprintf("/sks-cluster/%s/rotate-ccm-credentials", pathParam0)
+	if basePath[0] == '/' {
+		basePath = basePath[1:]
+	}
+
+	queryUrl, err = queryUrl.Parse(basePath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PUT", queryUrl.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewUpgradeSksClusterRequest calls the generic UpgradeSksCluster builder with application/json body
 func NewUpgradeSksClusterRequest(server string, id string, body UpgradeSksClusterJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
@@ -4580,8 +4917,8 @@ func NewUpgradeSksClusterRequestWithBody(server string, id string, contentType s
 	return req, nil
 }
 
-// NewDeleteSksClusterFieldRequest generates requests for DeleteSksClusterField
-func NewDeleteSksClusterFieldRequest(server string, id string, field string) (*http.Request, error) {
+// NewResetSksClusterFieldRequest generates requests for ResetSksClusterField
+func NewResetSksClusterFieldRequest(server string, id string, field string) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -5124,8 +5461,27 @@ type ClientWithResponsesInterface interface {
 	// GetAntiAffinityGroup request
 	GetAntiAffinityGroupWithResponse(ctx context.Context, id string) (*GetAntiAffinityGroupResponse, error)
 
+	// ListElasticIps request
+	ListElasticIpsWithResponse(ctx context.Context) (*ListElasticIpsResponse, error)
+
+	// CreateElasticIp request  with any body
+	CreateElasticIpWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader) (*CreateElasticIpResponse, error)
+
+	CreateElasticIpWithResponse(ctx context.Context, body CreateElasticIpJSONRequestBody) (*CreateElasticIpResponse, error)
+
+	// DeleteElasticIp request
+	DeleteElasticIpWithResponse(ctx context.Context, id string) (*DeleteElasticIpResponse, error)
+
 	// GetElasticIp request
 	GetElasticIpWithResponse(ctx context.Context, id string) (*GetElasticIpResponse, error)
+
+	// UpdateElasticIp request  with any body
+	UpdateElasticIpWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader) (*UpdateElasticIpResponse, error)
+
+	UpdateElasticIpWithResponse(ctx context.Context, id string, body UpdateElasticIpJSONRequestBody) (*UpdateElasticIpResponse, error)
+
+	// ResetElasticIpField request
+	ResetElasticIpFieldWithResponse(ctx context.Context, id string, field string) (*ResetElasticIpFieldResponse, error)
 
 	// ListEvents request
 	ListEventsWithResponse(ctx context.Context, params *ListEventsParams) (*ListEventsResponse, error)
@@ -5154,8 +5510,8 @@ type ClientWithResponsesInterface interface {
 
 	UpdateInstancePoolWithResponse(ctx context.Context, id string, body UpdateInstancePoolJSONRequestBody) (*UpdateInstancePoolResponse, error)
 
-	// DeleteInstancePoolField request
-	DeleteInstancePoolFieldWithResponse(ctx context.Context, id string, field string) (*DeleteInstancePoolFieldResponse, error)
+	// ResetInstancePoolField request
+	ResetInstancePoolFieldWithResponse(ctx context.Context, id string, field string) (*ResetInstancePoolFieldResponse, error)
 
 	// EvictInstancePoolMembers request  with any body
 	EvictInstancePoolMembersWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader) (*EvictInstancePoolMembersResponse, error)
@@ -5238,9 +5594,6 @@ type ClientWithResponsesInterface interface {
 
 	UpdatePrivateNetworkWithResponse(ctx context.Context, id string, body UpdatePrivateNetworkJSONRequestBody) (*UpdatePrivateNetworkResponse, error)
 
-	// DeletePrivateNetworkField request
-	DeletePrivateNetworkFieldWithResponse(ctx context.Context, id string, field string) (*DeletePrivateNetworkFieldResponse, error)
-
 	// ListSecurityGroups request
 	ListSecurityGroupsWithResponse(ctx context.Context) (*ListSecurityGroupsResponse, error)
 
@@ -5306,8 +5659,8 @@ type ClientWithResponsesInterface interface {
 
 	UpdateSksNodepoolWithResponse(ctx context.Context, id string, sksNodepoolId string, body UpdateSksNodepoolJSONRequestBody) (*UpdateSksNodepoolResponse, error)
 
-	// DeleteSksNodepoolField request
-	DeleteSksNodepoolFieldWithResponse(ctx context.Context, id string, sksNodepoolId string, field string) (*DeleteSksNodepoolFieldResponse, error)
+	// ResetSksNodepoolField request
+	ResetSksNodepoolFieldWithResponse(ctx context.Context, id string, sksNodepoolId string, field string) (*ResetSksNodepoolFieldResponse, error)
 
 	// EvictSksNodepoolMembers request  with any body
 	EvictSksNodepoolMembersWithBodyWithResponse(ctx context.Context, id string, sksNodepoolId string, contentType string, body io.Reader) (*EvictSksNodepoolMembersResponse, error)
@@ -5319,13 +5672,16 @@ type ClientWithResponsesInterface interface {
 
 	ScaleSksNodepoolWithResponse(ctx context.Context, id string, sksNodepoolId string, body ScaleSksNodepoolJSONRequestBody) (*ScaleSksNodepoolResponse, error)
 
+	// RotateSksCcmCredentials request
+	RotateSksCcmCredentialsWithResponse(ctx context.Context, id string) (*RotateSksCcmCredentialsResponse, error)
+
 	// UpgradeSksCluster request  with any body
 	UpgradeSksClusterWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader) (*UpgradeSksClusterResponse, error)
 
 	UpgradeSksClusterWithResponse(ctx context.Context, id string, body UpgradeSksClusterJSONRequestBody) (*UpgradeSksClusterResponse, error)
 
-	// DeleteSksClusterField request
-	DeleteSksClusterFieldWithResponse(ctx context.Context, id string, field string) (*DeleteSksClusterFieldResponse, error)
+	// ResetSksClusterField request
+	ResetSksClusterFieldWithResponse(ctx context.Context, id string, field string) (*ResetSksClusterFieldResponse, error)
 
 	// ListSnapshots request
 	ListSnapshotsWithResponse(ctx context.Context) (*ListSnapshotsResponse, error)
@@ -5458,6 +5814,74 @@ func (r GetAntiAffinityGroupResponse) StatusCode() int {
 	return 0
 }
 
+type ListElasticIpsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		ElasticIps *[]ElasticIp `json:"elastic-ips,omitempty"`
+	}
+}
+
+// Status returns HTTPResponse.Status
+func (r ListElasticIpsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListElasticIpsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type CreateElasticIpResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *Operation
+}
+
+// Status returns HTTPResponse.Status
+func (r CreateElasticIpResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CreateElasticIpResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type DeleteElasticIpResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *Operation
+}
+
+// Status returns HTTPResponse.Status
+func (r DeleteElasticIpResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DeleteElasticIpResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type GetElasticIpResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -5474,6 +5898,50 @@ func (r GetElasticIpResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r GetElasticIpResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UpdateElasticIpResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *Operation
+}
+
+// Status returns HTTPResponse.Status
+func (r UpdateElasticIpResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UpdateElasticIpResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type ResetElasticIpFieldResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *Operation
+}
+
+// Status returns HTTPResponse.Status
+func (r ResetElasticIpFieldResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ResetElasticIpFieldResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -5636,14 +6104,14 @@ func (r UpdateInstancePoolResponse) StatusCode() int {
 	return 0
 }
 
-type DeleteInstancePoolFieldResponse struct {
+type ResetInstancePoolFieldResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *Operation
 }
 
 // Status returns HTTPResponse.Status
-func (r DeleteInstancePoolFieldResponse) Status() string {
+func (r ResetInstancePoolFieldResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -5651,7 +6119,7 @@ func (r DeleteInstancePoolFieldResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r DeleteInstancePoolFieldResponse) StatusCode() int {
+func (r ResetInstancePoolFieldResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -6126,28 +6594,6 @@ func (r UpdatePrivateNetworkResponse) StatusCode() int {
 	return 0
 }
 
-type DeletePrivateNetworkFieldResponse struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	JSON200      *Operation
-}
-
-// Status returns HTTPResponse.Status
-func (r DeletePrivateNetworkFieldResponse) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r DeletePrivateNetworkFieldResponse) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
 type ListSecurityGroupsResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -6530,14 +6976,14 @@ func (r UpdateSksNodepoolResponse) StatusCode() int {
 	return 0
 }
 
-type DeleteSksNodepoolFieldResponse struct {
+type ResetSksNodepoolFieldResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *Operation
 }
 
 // Status returns HTTPResponse.Status
-func (r DeleteSksNodepoolFieldResponse) Status() string {
+func (r ResetSksNodepoolFieldResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -6545,7 +6991,7 @@ func (r DeleteSksNodepoolFieldResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r DeleteSksNodepoolFieldResponse) StatusCode() int {
+func (r ResetSksNodepoolFieldResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -6596,6 +7042,28 @@ func (r ScaleSksNodepoolResponse) StatusCode() int {
 	return 0
 }
 
+type RotateSksCcmCredentialsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *Operation
+}
+
+// Status returns HTTPResponse.Status
+func (r RotateSksCcmCredentialsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r RotateSksCcmCredentialsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type UpgradeSksClusterResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -6618,14 +7086,14 @@ func (r UpgradeSksClusterResponse) StatusCode() int {
 	return 0
 }
 
-type DeleteSksClusterFieldResponse struct {
+type ResetSksClusterFieldResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *Operation
 }
 
 // Status returns HTTPResponse.Status
-func (r DeleteSksClusterFieldResponse) Status() string {
+func (r ResetSksClusterFieldResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -6633,7 +7101,7 @@ func (r DeleteSksClusterFieldResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r DeleteSksClusterFieldResponse) StatusCode() int {
+func (r ResetSksClusterFieldResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -6956,6 +7424,41 @@ func (c *ClientWithResponses) GetAntiAffinityGroupWithResponse(ctx context.Conte
 	return ParseGetAntiAffinityGroupResponse(rsp)
 }
 
+// ListElasticIpsWithResponse request returning *ListElasticIpsResponse
+func (c *ClientWithResponses) ListElasticIpsWithResponse(ctx context.Context) (*ListElasticIpsResponse, error) {
+	rsp, err := c.ListElasticIps(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListElasticIpsResponse(rsp)
+}
+
+// CreateElasticIpWithBodyWithResponse request with arbitrary body returning *CreateElasticIpResponse
+func (c *ClientWithResponses) CreateElasticIpWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader) (*CreateElasticIpResponse, error) {
+	rsp, err := c.CreateElasticIpWithBody(ctx, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateElasticIpResponse(rsp)
+}
+
+func (c *ClientWithResponses) CreateElasticIpWithResponse(ctx context.Context, body CreateElasticIpJSONRequestBody) (*CreateElasticIpResponse, error) {
+	rsp, err := c.CreateElasticIp(ctx, body)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateElasticIpResponse(rsp)
+}
+
+// DeleteElasticIpWithResponse request returning *DeleteElasticIpResponse
+func (c *ClientWithResponses) DeleteElasticIpWithResponse(ctx context.Context, id string) (*DeleteElasticIpResponse, error) {
+	rsp, err := c.DeleteElasticIp(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDeleteElasticIpResponse(rsp)
+}
+
 // GetElasticIpWithResponse request returning *GetElasticIpResponse
 func (c *ClientWithResponses) GetElasticIpWithResponse(ctx context.Context, id string) (*GetElasticIpResponse, error) {
 	rsp, err := c.GetElasticIp(ctx, id)
@@ -6963,6 +7466,32 @@ func (c *ClientWithResponses) GetElasticIpWithResponse(ctx context.Context, id s
 		return nil, err
 	}
 	return ParseGetElasticIpResponse(rsp)
+}
+
+// UpdateElasticIpWithBodyWithResponse request with arbitrary body returning *UpdateElasticIpResponse
+func (c *ClientWithResponses) UpdateElasticIpWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader) (*UpdateElasticIpResponse, error) {
+	rsp, err := c.UpdateElasticIpWithBody(ctx, id, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateElasticIpResponse(rsp)
+}
+
+func (c *ClientWithResponses) UpdateElasticIpWithResponse(ctx context.Context, id string, body UpdateElasticIpJSONRequestBody) (*UpdateElasticIpResponse, error) {
+	rsp, err := c.UpdateElasticIp(ctx, id, body)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateElasticIpResponse(rsp)
+}
+
+// ResetElasticIpFieldWithResponse request returning *ResetElasticIpFieldResponse
+func (c *ClientWithResponses) ResetElasticIpFieldWithResponse(ctx context.Context, id string, field string) (*ResetElasticIpFieldResponse, error) {
+	rsp, err := c.ResetElasticIpField(ctx, id, field)
+	if err != nil {
+		return nil, err
+	}
+	return ParseResetElasticIpFieldResponse(rsp)
 }
 
 // ListEventsWithResponse request returning *ListEventsResponse
@@ -7052,13 +7581,13 @@ func (c *ClientWithResponses) UpdateInstancePoolWithResponse(ctx context.Context
 	return ParseUpdateInstancePoolResponse(rsp)
 }
 
-// DeleteInstancePoolFieldWithResponse request returning *DeleteInstancePoolFieldResponse
-func (c *ClientWithResponses) DeleteInstancePoolFieldWithResponse(ctx context.Context, id string, field string) (*DeleteInstancePoolFieldResponse, error) {
-	rsp, err := c.DeleteInstancePoolField(ctx, id, field)
+// ResetInstancePoolFieldWithResponse request returning *ResetInstancePoolFieldResponse
+func (c *ClientWithResponses) ResetInstancePoolFieldWithResponse(ctx context.Context, id string, field string) (*ResetInstancePoolFieldResponse, error) {
+	rsp, err := c.ResetInstancePoolField(ctx, id, field)
 	if err != nil {
 		return nil, err
 	}
-	return ParseDeleteInstancePoolFieldResponse(rsp)
+	return ParseResetInstancePoolFieldResponse(rsp)
 }
 
 // EvictInstancePoolMembersWithBodyWithResponse request with arbitrary body returning *EvictInstancePoolMembersResponse
@@ -7322,15 +7851,6 @@ func (c *ClientWithResponses) UpdatePrivateNetworkWithResponse(ctx context.Conte
 	return ParseUpdatePrivateNetworkResponse(rsp)
 }
 
-// DeletePrivateNetworkFieldWithResponse request returning *DeletePrivateNetworkFieldResponse
-func (c *ClientWithResponses) DeletePrivateNetworkFieldWithResponse(ctx context.Context, id string, field string) (*DeletePrivateNetworkFieldResponse, error) {
-	rsp, err := c.DeletePrivateNetworkField(ctx, id, field)
-	if err != nil {
-		return nil, err
-	}
-	return ParseDeletePrivateNetworkFieldResponse(rsp)
-}
-
 // ListSecurityGroupsWithResponse request returning *ListSecurityGroupsResponse
 func (c *ClientWithResponses) ListSecurityGroupsWithResponse(ctx context.Context) (*ListSecurityGroupsResponse, error) {
 	rsp, err := c.ListSecurityGroups(ctx)
@@ -7540,13 +8060,13 @@ func (c *ClientWithResponses) UpdateSksNodepoolWithResponse(ctx context.Context,
 	return ParseUpdateSksNodepoolResponse(rsp)
 }
 
-// DeleteSksNodepoolFieldWithResponse request returning *DeleteSksNodepoolFieldResponse
-func (c *ClientWithResponses) DeleteSksNodepoolFieldWithResponse(ctx context.Context, id string, sksNodepoolId string, field string) (*DeleteSksNodepoolFieldResponse, error) {
-	rsp, err := c.DeleteSksNodepoolField(ctx, id, sksNodepoolId, field)
+// ResetSksNodepoolFieldWithResponse request returning *ResetSksNodepoolFieldResponse
+func (c *ClientWithResponses) ResetSksNodepoolFieldWithResponse(ctx context.Context, id string, sksNodepoolId string, field string) (*ResetSksNodepoolFieldResponse, error) {
+	rsp, err := c.ResetSksNodepoolField(ctx, id, sksNodepoolId, field)
 	if err != nil {
 		return nil, err
 	}
-	return ParseDeleteSksNodepoolFieldResponse(rsp)
+	return ParseResetSksNodepoolFieldResponse(rsp)
 }
 
 // EvictSksNodepoolMembersWithBodyWithResponse request with arbitrary body returning *EvictSksNodepoolMembersResponse
@@ -7583,6 +8103,15 @@ func (c *ClientWithResponses) ScaleSksNodepoolWithResponse(ctx context.Context, 
 	return ParseScaleSksNodepoolResponse(rsp)
 }
 
+// RotateSksCcmCredentialsWithResponse request returning *RotateSksCcmCredentialsResponse
+func (c *ClientWithResponses) RotateSksCcmCredentialsWithResponse(ctx context.Context, id string) (*RotateSksCcmCredentialsResponse, error) {
+	rsp, err := c.RotateSksCcmCredentials(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	return ParseRotateSksCcmCredentialsResponse(rsp)
+}
+
 // UpgradeSksClusterWithBodyWithResponse request with arbitrary body returning *UpgradeSksClusterResponse
 func (c *ClientWithResponses) UpgradeSksClusterWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader) (*UpgradeSksClusterResponse, error) {
 	rsp, err := c.UpgradeSksClusterWithBody(ctx, id, contentType, body)
@@ -7600,13 +8129,13 @@ func (c *ClientWithResponses) UpgradeSksClusterWithResponse(ctx context.Context,
 	return ParseUpgradeSksClusterResponse(rsp)
 }
 
-// DeleteSksClusterFieldWithResponse request returning *DeleteSksClusterFieldResponse
-func (c *ClientWithResponses) DeleteSksClusterFieldWithResponse(ctx context.Context, id string, field string) (*DeleteSksClusterFieldResponse, error) {
-	rsp, err := c.DeleteSksClusterField(ctx, id, field)
+// ResetSksClusterFieldWithResponse request returning *ResetSksClusterFieldResponse
+func (c *ClientWithResponses) ResetSksClusterFieldWithResponse(ctx context.Context, id string, field string) (*ResetSksClusterFieldResponse, error) {
+	rsp, err := c.ResetSksClusterField(ctx, id, field)
 	if err != nil {
 		return nil, err
 	}
-	return ParseDeleteSksClusterFieldResponse(rsp)
+	return ParseResetSksClusterFieldResponse(rsp)
 }
 
 // ListSnapshotsWithResponse request returning *ListSnapshotsResponse
@@ -7839,6 +8368,86 @@ func ParseGetAntiAffinityGroupResponse(rsp *http.Response) (*GetAntiAffinityGrou
 	return response, nil
 }
 
+// ParseListElasticIpsResponse parses an HTTP response from a ListElasticIpsWithResponse call
+func ParseListElasticIpsResponse(rsp *http.Response) (*ListElasticIpsResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer rsp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListElasticIpsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			ElasticIps *[]ElasticIp `json:"elastic-ips,omitempty"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseCreateElasticIpResponse parses an HTTP response from a CreateElasticIpWithResponse call
+func ParseCreateElasticIpResponse(rsp *http.Response) (*CreateElasticIpResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer rsp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CreateElasticIpResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest Operation
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseDeleteElasticIpResponse parses an HTTP response from a DeleteElasticIpWithResponse call
+func ParseDeleteElasticIpResponse(rsp *http.Response) (*DeleteElasticIpResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer rsp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DeleteElasticIpResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest Operation
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
 // ParseGetElasticIpResponse parses an HTTP response from a GetElasticIpWithResponse call
 func ParseGetElasticIpResponse(rsp *http.Response) (*GetElasticIpResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
@@ -7855,6 +8464,58 @@ func ParseGetElasticIpResponse(rsp *http.Response) (*GetElasticIpResponse, error
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest ElasticIp
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUpdateElasticIpResponse parses an HTTP response from a UpdateElasticIpWithResponse call
+func ParseUpdateElasticIpResponse(rsp *http.Response) (*UpdateElasticIpResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer rsp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UpdateElasticIpResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest Operation
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseResetElasticIpFieldResponse parses an HTTP response from a ResetElasticIpFieldWithResponse call
+func ParseResetElasticIpFieldResponse(rsp *http.Response) (*ResetElasticIpFieldResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer rsp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ResetElasticIpFieldResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest Operation
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -8049,15 +8710,15 @@ func ParseUpdateInstancePoolResponse(rsp *http.Response) (*UpdateInstancePoolRes
 	return response, nil
 }
 
-// ParseDeleteInstancePoolFieldResponse parses an HTTP response from a DeleteInstancePoolFieldWithResponse call
-func ParseDeleteInstancePoolFieldResponse(rsp *http.Response) (*DeleteInstancePoolFieldResponse, error) {
+// ParseResetInstancePoolFieldResponse parses an HTTP response from a ResetInstancePoolFieldWithResponse call
+func ParseResetInstancePoolFieldResponse(rsp *http.Response) (*ResetInstancePoolFieldResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer rsp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &DeleteInstancePoolFieldResponse{
+	response := &ResetInstancePoolFieldResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -8627,32 +9288,6 @@ func ParseUpdatePrivateNetworkResponse(rsp *http.Response) (*UpdatePrivateNetwor
 	return response, nil
 }
 
-// ParseDeletePrivateNetworkFieldResponse parses an HTTP response from a DeletePrivateNetworkFieldWithResponse call
-func ParseDeletePrivateNetworkFieldResponse(rsp *http.Response) (*DeletePrivateNetworkFieldResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
-	defer rsp.Body.Close()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &DeletePrivateNetworkFieldResponse{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest Operation
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON200 = &dest
-
-	}
-
-	return response, nil
-}
-
 // ParseListSecurityGroupsResponse parses an HTTP response from a ListSecurityGroupsWithResponse call
 func ParseListSecurityGroupsResponse(rsp *http.Response) (*ListSecurityGroupsResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
@@ -9103,15 +9738,15 @@ func ParseUpdateSksNodepoolResponse(rsp *http.Response) (*UpdateSksNodepoolRespo
 	return response, nil
 }
 
-// ParseDeleteSksNodepoolFieldResponse parses an HTTP response from a DeleteSksNodepoolFieldWithResponse call
-func ParseDeleteSksNodepoolFieldResponse(rsp *http.Response) (*DeleteSksNodepoolFieldResponse, error) {
+// ParseResetSksNodepoolFieldResponse parses an HTTP response from a ResetSksNodepoolFieldWithResponse call
+func ParseResetSksNodepoolFieldResponse(rsp *http.Response) (*ResetSksNodepoolFieldResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer rsp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &DeleteSksNodepoolFieldResponse{
+	response := &ResetSksNodepoolFieldResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -9181,6 +9816,32 @@ func ParseScaleSksNodepoolResponse(rsp *http.Response) (*ScaleSksNodepoolRespons
 	return response, nil
 }
 
+// ParseRotateSksCcmCredentialsResponse parses an HTTP response from a RotateSksCcmCredentialsWithResponse call
+func ParseRotateSksCcmCredentialsResponse(rsp *http.Response) (*RotateSksCcmCredentialsResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer rsp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &RotateSksCcmCredentialsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest Operation
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
 // ParseUpgradeSksClusterResponse parses an HTTP response from a UpgradeSksClusterWithResponse call
 func ParseUpgradeSksClusterResponse(rsp *http.Response) (*UpgradeSksClusterResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
@@ -9207,15 +9868,15 @@ func ParseUpgradeSksClusterResponse(rsp *http.Response) (*UpgradeSksClusterRespo
 	return response, nil
 }
 
-// ParseDeleteSksClusterFieldResponse parses an HTTP response from a DeleteSksClusterFieldWithResponse call
-func ParseDeleteSksClusterFieldResponse(rsp *http.Response) (*DeleteSksClusterFieldResponse, error) {
+// ParseResetSksClusterFieldResponse parses an HTTP response from a ResetSksClusterFieldWithResponse call
+func ParseResetSksClusterFieldResponse(rsp *http.Response) (*ResetSksClusterFieldResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer rsp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &DeleteSksClusterFieldResponse{
+	response := &ResetSksClusterFieldResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}

--- a/vendor/github.com/exoscale/egoscale/v2/internal/public-api/public-api.go
+++ b/vendor/github.com/exoscale/egoscale/v2/internal/public-api/public-api.go
@@ -22,3 +22,12 @@ func OptionalInt64(v *int64) int64 {
 
 	return 0
 }
+
+// OptionalBool returns the dereferenced bool value of v if not nil, otherwise false.
+func OptionalBool(v *bool) bool {
+	if v != nil {
+		return *v
+	}
+
+	return false
+}

--- a/vendor/github.com/exoscale/egoscale/v2/private_network.go
+++ b/vendor/github.com/exoscale/egoscale/v2/private_network.go
@@ -1,0 +1,167 @@
+package v2
+
+import (
+	"context"
+	"net"
+
+	apiv2 "github.com/exoscale/egoscale/v2/api"
+	papi "github.com/exoscale/egoscale/v2/internal/public-api"
+)
+
+// PrivateNetwork represents a Private Network.
+type PrivateNetwork struct {
+	Description string
+	EndIP       net.IP
+	ID          string
+	Name        string
+	Netmask     net.IP
+	StartIP     net.IP
+}
+
+func privateNetworkFromAPI(p *papi.PrivateNetwork) *PrivateNetwork {
+	return &PrivateNetwork{
+		Description: papi.OptionalString(p.Description),
+		EndIP:       net.ParseIP(papi.OptionalString(p.EndIp)),
+		ID:          papi.OptionalString(p.Id),
+		Name:        papi.OptionalString(p.Name),
+		Netmask:     net.ParseIP(papi.OptionalString(p.Netmask)),
+		StartIP:     net.ParseIP(papi.OptionalString(p.StartIp)),
+	}
+}
+
+// CreatePrivateNetwork creates a Private Network in the specified zone.
+func (c *Client) CreatePrivateNetwork(ctx context.Context, zone string,
+	privateNetwork *PrivateNetwork) (*PrivateNetwork, error) {
+	resp, err := c.CreatePrivateNetworkWithResponse(
+		apiv2.WithZone(ctx, zone),
+		papi.CreatePrivateNetworkJSONRequestBody{
+			Description: &privateNetwork.Description,
+			EndIp: func() (ip *string) {
+				if privateNetwork.EndIP != nil {
+					v := privateNetwork.EndIP.String()
+					return &v
+				}
+				return
+			}(),
+			Name: privateNetwork.Name,
+			Netmask: func() (ip *string) {
+				if privateNetwork.Netmask != nil {
+					v := privateNetwork.Netmask.String()
+					return &v
+				}
+				return
+			}(),
+			StartIp: func() (ip *string) {
+				if privateNetwork.StartIP != nil {
+					v := privateNetwork.StartIP.String()
+					return &v
+				}
+				return
+			}(),
+		})
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := papi.NewPoller().
+		WithTimeout(c.timeout).
+		Poll(ctx, c.OperationPoller(zone, *resp.JSON200.Id))
+	if err != nil {
+		return nil, err
+	}
+
+	return c.GetPrivateNetwork(ctx, zone, *res.(*papi.Reference).Id)
+}
+
+// ListPrivateNetworks returns the list of existing Private Networks in the specified zone.
+func (c *Client) ListPrivateNetworks(ctx context.Context, zone string) ([]*PrivateNetwork, error) {
+	list := make([]*PrivateNetwork, 0)
+
+	resp, err := c.ListPrivateNetworksWithResponse(apiv2.WithZone(ctx, zone))
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.JSON200.PrivateNetworks != nil {
+		for i := range *resp.JSON200.PrivateNetworks {
+			cluster := privateNetworkFromAPI(&(*resp.JSON200.PrivateNetworks)[i])
+
+			list = append(list, cluster)
+		}
+	}
+
+	return list, nil
+}
+
+// GetPrivateNetwork returns the Private Network corresponding to the specified ID in the specified zone.
+func (c *Client) GetPrivateNetwork(ctx context.Context, zone, id string) (*PrivateNetwork, error) {
+	resp, err := c.GetPrivateNetworkWithResponse(apiv2.WithZone(ctx, zone), id)
+	if err != nil {
+		return nil, err
+	}
+
+	privateNetwork := privateNetworkFromAPI(resp.JSON200)
+
+	return privateNetwork, nil
+}
+
+// UpdatePrivateNetwork updates the specified Private Network in the specified zone.
+func (c *Client) UpdatePrivateNetwork(ctx context.Context, zone string, privateNetwork *PrivateNetwork) error {
+	resp, err := c.UpdatePrivateNetworkWithResponse(
+		apiv2.WithZone(ctx, zone),
+		privateNetwork.ID,
+		papi.UpdatePrivateNetworkJSONRequestBody{
+			Description: &privateNetwork.Description,
+			EndIp: func() (ip *string) {
+				if privateNetwork.EndIP != nil {
+					v := privateNetwork.EndIP.String()
+					return &v
+				}
+				return
+			}(),
+			Name: &privateNetwork.Name,
+			Netmask: func() (ip *string) {
+				if privateNetwork.Netmask != nil {
+					v := privateNetwork.Netmask.String()
+					return &v
+				}
+				return
+			}(),
+			StartIp: func() (ip *string) {
+				if privateNetwork.StartIP != nil {
+					v := privateNetwork.StartIP.String()
+					return &v
+				}
+				return
+			}(),
+		})
+	if err != nil {
+		return err
+	}
+
+	_, err = papi.NewPoller().
+		WithTimeout(c.timeout).
+		Poll(ctx, c.OperationPoller(zone, *resp.JSON200.Id))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// DeletePrivateNetwork deletes the specified Private Network in the specified zone.
+func (c *Client) DeletePrivateNetwork(ctx context.Context, zone, id string) error {
+	resp, err := c.DeletePrivateNetworkWithResponse(apiv2.WithZone(ctx, zone), id)
+	if err != nil {
+		return err
+	}
+
+	_, err = papi.NewPoller().
+		WithTimeout(c.timeout).
+		Poll(ctx, c.OperationPoller(zone, *resp.JSON200.Id))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/vendor/github.com/exoscale/egoscale/v2/security_group.go
+++ b/vendor/github.com/exoscale/egoscale/v2/security_group.go
@@ -1,0 +1,271 @@
+package v2
+
+import (
+	"context"
+	"errors"
+	"net"
+
+	apiv2 "github.com/exoscale/egoscale/v2/api"
+	papi "github.com/exoscale/egoscale/v2/internal/public-api"
+)
+
+// SecurityGroupRule represents a Security Group rule.
+type SecurityGroupRule struct {
+	Description     string
+	EndPort         uint16
+	FlowDirection   string
+	ICMPCode        uint8
+	ICMPType        uint8
+	ID              string
+	Network         *net.IPNet
+	Protocol        string
+	SecurityGroupID string
+	StartPort       uint16
+}
+
+func securityGroupRuleFromAPI(r *papi.SecurityGroupRule) *SecurityGroupRule {
+	return &SecurityGroupRule{
+		Description:   papi.OptionalString(r.Description),
+		EndPort:       uint16(papi.OptionalInt64(r.EndPort)),
+		FlowDirection: papi.OptionalString(r.FlowDirection),
+		ICMPCode: func() (v uint8) {
+			if r.Icmp != nil {
+				v = uint8(papi.OptionalInt64(r.Icmp.Code))
+			}
+			return
+		}(),
+		ICMPType: func() (v uint8) {
+			if r.Icmp != nil {
+				v = uint8(papi.OptionalInt64(r.Icmp.Type))
+			}
+			return
+		}(),
+		ID: papi.OptionalString(r.Id),
+		Network: func() (v *net.IPNet) {
+			if r.Network != nil {
+				_, v, _ = net.ParseCIDR(*r.Network)
+			}
+			return
+		}(),
+		Protocol: papi.OptionalString(r.Protocol),
+		SecurityGroupID: func() (v string) {
+			if r.SecurityGroup != nil {
+				v = papi.OptionalString(r.SecurityGroup.Id)
+			}
+			return
+		}(),
+		StartPort: uint16(papi.OptionalInt64(r.StartPort)),
+	}
+}
+
+// SecurityGroup represents a Security Group.
+type SecurityGroup struct {
+	Description string
+	ID          string
+	Name        string
+	Rules       []*SecurityGroupRule
+
+	zone string
+	c    *Client
+}
+
+func securityGroupFromAPI(s *papi.SecurityGroup) *SecurityGroup {
+	return &SecurityGroup{
+		Description: papi.OptionalString(s.Description),
+		ID:          papi.OptionalString(s.Id),
+		Name:        papi.OptionalString(s.Name),
+		Rules: func() (rules []*SecurityGroupRule) {
+			if s.Rules != nil {
+				rules = make([]*SecurityGroupRule, 0)
+				for _, rule := range *s.Rules {
+					rule := rule
+					rules = append(rules, securityGroupRuleFromAPI(&rule))
+				}
+			}
+			return rules
+		}(),
+	}
+}
+
+// AddRule adds a rule to the Security Group.
+func (s *SecurityGroup) AddRule(ctx context.Context, rule *SecurityGroupRule) (*SecurityGroupRule, error) {
+	var icmp *struct {
+		Code *int64 `json:"code,omitempty"`
+		Type *int64 `json:"type,omitempty"`
+	}
+
+	if rule.Protocol == "icmp" || rule.Protocol == "icmpv6" {
+		icmpCode := int64(rule.ICMPCode)
+		icmpType := int64(rule.ICMPType)
+
+		icmp = &struct {
+			Code *int64 `json:"code,omitempty"`
+			Type *int64 `json:"type,omitempty"`
+		}{
+			Code: &icmpCode,
+			Type: &icmpType,
+		}
+	}
+
+	// The API doesn't return the Security Group rule created directly, so in order to
+	// return a *SecurityGroupRule corresponding to the new rule we have to manually
+	// compare the list of rules in the SG before and after the rule creation, and
+	// identify the rule that wasn't there before.
+	// Note: in case of multiple rules creation in parallel this technique is subject
+	// to race condition as we could return an unrelated rule. To prevent this, we
+	// also compare the protocol/start port/end port parameters of the new rule to the
+	// ones specified in the input rule parameter.
+	rules := make(map[string]struct{})
+	for _, r := range s.Rules {
+		rules[r.ID] = struct{}{}
+	}
+
+	startPort := int64(rule.StartPort)
+	endPort := int64(rule.EndPort)
+
+	resp, err := s.c.AddRuleToSecurityGroupWithResponse(
+		apiv2.WithZone(ctx, s.zone),
+		s.ID,
+		papi.AddRuleToSecurityGroupJSONRequestBody{
+			Description:   &rule.Description,
+			EndPort:       &endPort,
+			FlowDirection: rule.FlowDirection,
+			Icmp:          icmp,
+			Network: func() (v *string) {
+				if rule.Network != nil {
+					ip := rule.Network.String()
+					v = &ip
+				}
+				return
+			}(),
+			Protocol: &rule.Protocol,
+			SecurityGroup: func() (v *papi.SecurityGroupResource) {
+				if rule.SecurityGroupID != "" {
+					v = &papi.SecurityGroupResource{Id: &rule.SecurityGroupID}
+				}
+				return
+			}(),
+			StartPort: &startPort,
+		})
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := papi.NewPoller().
+		WithTimeout(s.c.timeout).
+		Poll(ctx, s.c.OperationPoller(s.zone, *resp.JSON200.Id))
+	if err != nil {
+		return nil, err
+	}
+
+	sgUpdated, err := s.c.GetSecurityGroup(ctx, s.zone, *res.(*papi.Reference).Id)
+	if err != nil {
+		return nil, err
+	}
+
+	// Look for an unknown rule: if we find one we hope it's the one we've just created.
+	for _, r := range sgUpdated.Rules {
+		if _, ok := rules[r.ID]; !ok && (r.Protocol == rule.Protocol &&
+			r.StartPort == rule.StartPort &&
+			r.EndPort == rule.EndPort) {
+			return r, nil
+		}
+	}
+
+	return nil, errors.New("unable to identify the rule created")
+}
+
+// DeleteRule deletes the specified rule from the Security Group.
+func (s *SecurityGroup) DeleteRule(ctx context.Context, rule *SecurityGroupRule) error {
+	resp, err := s.c.DeleteRuleFromSecurityGroupWithResponse(
+		apiv2.WithZone(ctx, s.zone),
+		s.ID,
+		rule.ID,
+	)
+	if err != nil {
+		return err
+	}
+
+	_, err = papi.NewPoller().
+		WithTimeout(s.c.timeout).
+		Poll(ctx, s.c.OperationPoller(s.zone, *resp.JSON200.Id))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// CreateSecurityGroup creates a Security Group.
+func (c *Client) CreateSecurityGroup(ctx context.Context, zone string,
+	securityGroup *SecurityGroup) (*SecurityGroup, error) {
+	resp, err := c.CreateSecurityGroupWithResponse(ctx, papi.CreateSecurityGroupJSONRequestBody{
+		Description: &securityGroup.Description,
+		Name:        securityGroup.Name,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := papi.NewPoller().
+		WithTimeout(c.timeout).
+		Poll(ctx, c.OperationPoller(zone, *resp.JSON200.Id))
+	if err != nil {
+		return nil, err
+	}
+
+	return c.GetSecurityGroup(ctx, zone, *res.(*papi.Reference).Id)
+}
+
+// ListSecurityGroups returns the list of existing Security Groups.
+func (c *Client) ListSecurityGroups(ctx context.Context, zone string) ([]*SecurityGroup, error) {
+	list := make([]*SecurityGroup, 0)
+
+	resp, err := c.ListSecurityGroupsWithResponse(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.JSON200.SecurityGroups != nil {
+		for i := range *resp.JSON200.SecurityGroups {
+			securityGroup := securityGroupFromAPI(&(*resp.JSON200.SecurityGroups)[i])
+			securityGroup.c = c
+			securityGroup.zone = zone
+
+			list = append(list, securityGroup)
+		}
+	}
+
+	return list, nil
+}
+
+// GetSecurityGroup returns the Security Group corresponding to the specified ID in the specified zone.
+func (c *Client) GetSecurityGroup(ctx context.Context, zone, id string) (*SecurityGroup, error) {
+	resp, err := c.GetSecurityGroupWithResponse(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	securityGroup := securityGroupFromAPI(resp.JSON200)
+	securityGroup.c = c
+	securityGroup.zone = zone
+
+	return securityGroup, nil
+}
+
+// DeleteSecurityGroup deletes the specified Security Group in the specified zone.
+func (c *Client) DeleteSecurityGroup(ctx context.Context, zone, id string) error {
+	resp, err := c.DeleteSecurityGroupWithResponse(apiv2.WithZone(ctx, zone), id)
+	if err != nil {
+		return err
+	}
+
+	_, err = papi.NewPoller().
+		WithTimeout(c.timeout).
+		Poll(ctx, c.OperationPoller(zone, *resp.JSON200.Id))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/vendor/github.com/exoscale/egoscale/v2/test.go
+++ b/vendor/github.com/exoscale/egoscale/v2/test.go
@@ -1,3 +1,5 @@
 package v2
 
+const iso8601Format = "2006-01-02T15:04:05Z"
+
 var testZone = "ch-gva-2"

--- a/vendor/github.com/exoscale/egoscale/v2/v2.go
+++ b/vendor/github.com/exoscale/egoscale/v2/v2.go
@@ -1,3 +1,39 @@
 // Package v2 is the new Exoscale client API binding.
 // Reference: https://openapi-v2.exoscale.com/
 package v2
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// resetFieldName returns the value corresponding to the `reset:""` struct tag
+// in the struct res for the specified field, for example:
+//
+// type MyStruct struct {
+//     FieldA string
+//     FieldB int `reset:"field-b"`
+// }
+func resetFieldName(res, field interface{}) (string, error) {
+	fieldValue := reflect.ValueOf(field)
+	if fieldValue.Kind() != reflect.Ptr || fieldValue.IsNil() {
+		return "", fmt.Errorf("field must be a non-nil pointer value")
+	}
+
+	structValue := reflect.ValueOf(res).Elem()
+	for i := 0; i < structValue.NumField(); i++ {
+		structField := structValue.Type().Field(i)
+
+		if structValue.Field(i).UnsafeAddr() == fieldValue.Pointer() {
+			resetField, ok := structField.Tag.Lookup("reset")
+			if !ok {
+				return "", fmt.Errorf("struct field %s.%s is not resettable",
+					structValue.Type(), structField.Name)
+			}
+
+			return resetField, nil
+		}
+	}
+
+	return "", fmt.Errorf("field not found in struct %s", structValue.Type())
+}

--- a/vendor/github.com/exoscale/egoscale/version.go
+++ b/vendor/github.com/exoscale/egoscale/version.go
@@ -1,4 +1,4 @@
 package egoscale
 
 // Version of the library
-const Version = "0.43.1"
+const Version = "0.44.0"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -70,7 +70,7 @@ github.com/emirpasic/gods/lists/arraylist
 github.com/emirpasic/gods/trees
 github.com/emirpasic/gods/trees/binaryheap
 github.com/emirpasic/gods/utils
-# github.com/exoscale/egoscale v0.43.1
+# github.com/exoscale/egoscale v0.44.0
 github.com/exoscale/egoscale
 github.com/exoscale/egoscale/v2
 github.com/exoscale/egoscale/v2/api

--- a/website/docs/r/sks_cluster.html.markdown
+++ b/website/docs/r/sks_cluster.html.markdown
@@ -65,6 +65,6 @@ $ terraform import exoscale_sks_cluster.prod eb556678-ec59-4be6-8c54-0406ae0f6da
 
 [cni]: https://www.cni.dev/
 [r-sks_nodepool]: sks_nodepool.html
-[sks-doc]: #
+[sks-doc]: https://community.exoscale.com/documentation/sks/
 [zone]: https://www.exoscale.com/datacenters/
 


### PR DESCRIPTION
This change adds support for Security Groups and Anti-Affinity Groups
updating to the `sks_nodepool` resource.