### PR TITLE
ipaddress: add support for reverse DNS

### DIFF
--- a/exoscale/resource_exoscale_sks_cluster_test.go
+++ b/exoscale/resource_exoscale_sks_cluster_test.go
@@ -38,7 +38,7 @@ resource "exoscale_sks_nodepool" "test" {
   zone = local.zone
   cluster_id = exoscale_sks_cluster.test.id
   name = "test"
-  instance_type = "micro"
+  instance_type = "small"
   disk_size = 20
   size = 1
 
@@ -71,7 +71,7 @@ resource "exoscale_sks_nodepool" "test" {
   zone = local.zone
   cluster_id = exoscale_sks_cluster.test.id
   name = "test"
-  instance_type = "micro"
+  instance_type = "small"
   disk_size = 20
   size = 1
 

--- a/website/docs/r/ipaddress.html.markdown
+++ b/website/docs/r/ipaddress.html.markdown
@@ -38,6 +38,7 @@ resource "exoscale_ipaddress" "myip" {
   healthcheck_strikes_ok   = 2
   healthcheck_strikes_fail = 3
   healthcheck_tls_sni      = "example.net"
+  reverse_dns              = "lb.example.net"
 }
 ```
 
@@ -55,6 +56,7 @@ resource "exoscale_ipaddress" "myip" {
 * `healthcheck_strikes_fail` - The number of unsuccessful healthcheck probes before considering the target unhealthy (must be between `1` and `20`).
 * `healthcheck_tls_sni` - The healthcheck TLS server name to specify in `https` mode. Note: this parameter can only be changed to a non-empty value, it cannot be reset to its default empty value later on (requires a resource re-creation).
 * `healthcheck_tls_skip_verify` - Disable TLS certificate validation in `https` mode. Note: this parameter can only be changed to `true`, it cannot be reset to `false` later on (requires a resource re-creation).
+* `reverse_dns` - A reverse DNS record to set for the Elastic IP.
 * `tags` - A dictionary of tags (key/value). To remove all tags, set `tags = {}`.
 
 


### PR DESCRIPTION
This change adds support for reverse DNS management on
`exoscale_ipaddress` resources.