### PR TITLE
sks_cluster: expose addons as discrete parameters

### DIFF
--- a/exoscale/resource_exoscale_sks_cluster_test.go
+++ b/exoscale/resource_exoscale_sks_cluster_test.go
@@ -29,6 +29,8 @@ resource "exoscale_sks_cluster" "test" {
   zone = local.zone
   name = "%s"
   description = "%s"
+  exoscale_ccm = true
+  metrics_server = false
 
   timeouts {
     create = "10m"
@@ -61,6 +63,8 @@ locals {
 resource "exoscale_sks_cluster" "test" {
   zone = local.zone
   name = "%s"
+  exoscale_ccm = true
+  metrics_server = false
 
   timeouts {
     create = "10m"
@@ -136,12 +140,14 @@ func TestAccResourceSKSCluster(t *testing.T) {
 						return nil
 					},
 					testAccCheckResourceSKSClusterAttributes(testAttrs{
-						"addons.791607250": ValidateString(defaultSKSClusterAddOns[0]),
+						"addons.791607250": validation.NoZeroValues,
 						"cni":              ValidateString(defaultSKSClusterCNI),
 						"created_at":       validation.NoZeroValues,
 						"description":      ValidateString(testAccResourceSKSClusterDescription),
 						"endpoint":         validation.IsURLWithHTTPS,
+						"exoscale_ccm":     ValidateString("true"),
 						"id":               validation.IsUUID,
+						"metrics_server":   ValidateString("false"),
 						"name":             ValidateString(testAccResourceSKSClusterName),
 						"service_level":    ValidateString(defaultSKSClusterServiceLevel),
 						"state":            validation.NoZeroValues,
@@ -156,12 +162,14 @@ func TestAccResourceSKSCluster(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceSKSClusterExists("exoscale_sks_cluster.test", &sksCluster),
 					testAccCheckResourceSKSClusterAttributes(testAttrs{
-						"addons.791607250": ValidateString(defaultSKSClusterAddOns[0]),
+						"addons.791607250": validation.NoZeroValues,
 						"cni":              ValidateString(defaultSKSClusterCNI),
 						"created_at":       validation.NoZeroValues,
 						"description":      ValidateString(""),
 						"endpoint":         validation.IsURLWithHTTPS,
+						"exoscale_ccm":     ValidateString("true"),
 						"id":               validation.IsUUID,
+						"metrics_server":   ValidateString("false"),
 						"name":             ValidateString(testAccResourceSKSClusterNameUpdated),
 						"nodepools.#":      ValidateString("1"),
 						"service_level":    ValidateString(defaultSKSClusterServiceLevel),
@@ -180,12 +188,14 @@ func TestAccResourceSKSCluster(t *testing.T) {
 					testAccCheckResourceImportedAttributes(
 						"exoscale_sks_cluster",
 						testAttrs{
-							"addons.791607250": ValidateString(defaultSKSClusterAddOns[0]),
+							"addons.791607250": validation.NoZeroValues,
 							"cni":              ValidateString(defaultSKSClusterCNI),
 							"created_at":       validation.NoZeroValues,
 							"description":      ValidateString(""),
 							"endpoint":         validation.IsURLWithHTTPS,
+							"exoscale_ccm":     ValidateString("true"),
 							"id":               validation.IsUUID,
+							"metrics_server":   ValidateString("false"),
 							"name":             ValidateString(testAccResourceSKSClusterNameUpdated),
 							"nodepools.#":      ValidateString("1"),
 							"service_level":    ValidateString(defaultSKSClusterServiceLevel),

--- a/exoscale/util.go
+++ b/exoscale/util.go
@@ -1,0 +1,12 @@
+package exoscale
+
+// in returns true if v is found in list.
+func in(list []string, v string) bool {
+	for i := range list {
+		if list[i] == v {
+			return true
+		}
+	}
+
+	return false
+}

--- a/exoscale/util_test.go
+++ b/exoscale/util_test.go
@@ -1,0 +1,60 @@
+package exoscale
+
+import "testing"
+
+func Test_in(t *testing.T) {
+	type args struct {
+		list []string
+		v    string
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			args: args{
+				list: []string{"a", "b", "c"},
+				v:    "a",
+			},
+			want: true,
+		},
+		{
+			args: args{
+				list: []string{"a", "b", "c"},
+				v:    "z",
+			},
+			want: false,
+		},
+		{
+			args: args{
+				list: []string{"a", "b", "c"},
+				v:    "",
+			},
+			want: false,
+		},
+		{
+			args: args{
+				list: nil,
+				v:    "a",
+			},
+			want: false,
+		},
+		{
+			args: args{
+				list: nil,
+				v:    "",
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := in(tt.args.list, tt.args.v); got != tt.want {
+				t.Errorf("in() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/website/docs/r/sks_cluster.html.markdown
+++ b/website/docs/r/sks_cluster.html.markdown
@@ -38,7 +38,9 @@ output "sks_endpoint" {
 * `service_level` - The service level of the SKS cluster control plane (default: `"pro"`).
 * `version` - The Kubernetes version of the SKS cluster control plane (default: latest version available from the API).
 * `cni` - The Kubernetes [CNI][cni] plugin to be deployed in the SKS cluster control plane (default: `"calico"`).
-* `addons` - A list of optional add-ons to be deployed in the SKS cluster control plane (default: `["exoscale-cloud-controller"]`).
+* `exoscale_ccm` - Deploy the Exoscale [Cloud Controller Manager][exo-ccm] in the SKS cluster control plane (default: `true`).
+* `metrics_server` - Deploy the [Kubernetes Metrics Server][k8s-ms] in the SKS cluster control plane (default: `true`).
+* `addons` - A list of optional add-ons to be deployed in the SKS cluster control plane (default: `[]`).
 
 
 ## Attributes Reference
@@ -64,6 +66,8 @@ $ terraform import exoscale_sks_cluster.prod eb556678-ec59-4be6-8c54-0406ae0f6da
 
 
 [cni]: https://www.cni.dev/
+[exo-ccm]: https://github.com/exoscale/exoscale-cloud-controller-manager
+[k8s-ms]: https://github.com/kubernetes-sigs/metrics-server
 [r-sks_nodepool]: sks_nodepool.html
 [sks-doc]: https://community.exoscale.com/documentation/sks/
 [zone]: https://www.exoscale.com/datacenters/


### PR DESCRIPTION
This change introduces new `exoscale_ccm`/`metrics_server` parameters to
the `exoscale_sks_cluster` resource to replace manual `addons` parameter
value setting.