### PR TITLE
Fix non-existence detection logic for NLB service/SKS Nodepool

### DIFF
--- a/exoscale/resource_exoscale_nlb_service.go
+++ b/exoscale/resource_exoscale_nlb_service.go
@@ -2,6 +2,7 @@ package exoscale
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"time"
@@ -203,6 +204,9 @@ func resourceNLBServiceExists(d *schema.ResourceData, meta interface{}) (bool, e
 
 	service, err := findNLBService(ctx, d, meta)
 	if err != nil {
+		if errors.Is(err, exoapi.ErrNotFound) {
+			return false, nil
+		}
 		return false, err
 	}
 

--- a/exoscale/resource_exoscale_sks_nodepool.go
+++ b/exoscale/resource_exoscale_sks_nodepool.go
@@ -205,6 +205,9 @@ func resourceSKSNodepoolExists(d *schema.ResourceData, meta interface{}) (bool, 
 
 	nodepool, err := findSKSNodepool(ctx, d, meta)
 	if err != nil {
+		if errors.Is(err, exoapi.ErrNotFound) {
+			return false, nil
+		}
 		return false, err
 	}
 


### PR DESCRIPTION
This change fixes a bug in the resource existence detection logic for
`exoscale_nlb_service` and `exoscale_sks_nodepool` resources, where
previously an error was returned if the parent resource (respectively
`exoscale_nlb` and `exoscale_sks_cluster`) was deleted outside of
Terraform instead of properly signal that the resource doesn't exist
anymore and prompt Terraform to re-create it.

Fixes #81.