### PR TITLE
instance_pool: add "instance_type" attribute

### DIFF
--- a/examples/instance-pool/main.tf
+++ b/examples/instance-pool/main.tf
@@ -15,7 +15,7 @@ resource "exoscale_instance_pool" "instancepool-test" {
   name = "terraforminstancepool"
   description = "test"
   template_id = data.exoscale_compute_template.instancepool.id
-  service_offering = "medium"
+  instance_type = "standard.medium"
   size = 5
   disk_size = 50
   user_data = "#cloud-config\npackage_upgrade: true\n"

--- a/examples/nlb/main.tf
+++ b/examples/nlb/main.tf
@@ -15,7 +15,7 @@ resource "exoscale_instance_pool" "website" {
   name = "instancepool-website"
   description = "test"
   template_id = data.exoscale_compute_template.website.id
-  service_offering = "medium"
+  instance_type = "standard.medium"
   size = 3
   zone = var.zone
 }

--- a/exoscale/resource_exoscale_instance_pool_test.go
+++ b/exoscale/resource_exoscale_instance_pool_test.go
@@ -18,21 +18,21 @@ import (
 )
 
 var (
-	testAccResourceInstancePoolAntiAffinityGroupName        = acctest.RandomWithPrefix(testPrefix)
-	testAccResourceInstancePoolDescription                  = acctest.RandString(10)
-	testAccResourceInstancePoolDiskSize               int64 = 10
-	testAccResourceInstancePoolDiskSizeUpdated              = testAccResourceInstancePoolDiskSize * 2
-	testAccResourceInstancePoolKeyPair                      = acctest.RandomWithPrefix(testPrefix)
-	testAccResourceInstancePoolName                         = acctest.RandomWithPrefix(testPrefix)
-	testAccResourceInstancePoolNameUpdated                  = testAccResourceInstancePoolName + "-updated"
-	testAccResourceInstancePoolInstancePrefix               = "test"
-	testAccResourceInstancePoolNetwork                      = acctest.RandomWithPrefix(testPrefix)
-	testAccResourceInstancePoolServiceOffering              = "tiny"
-	testAccResourceInstancePoolServiceOfferingUpdated       = "small"
-	testAccResourceInstancePoolSize                   int64 = 1
-	testAccResourceInstancePoolSizeUpdated                  = testAccResourceInstancePoolSize * 2
-	testAccResourceInstancePoolUserData                     = acctest.RandString(10)
-	testAccResourceInstancePoolUserDataUpdated              = testAccResourceInstancePoolUserData + "-updated"
+	testAccResourceInstancePoolAntiAffinityGroupName       = acctest.RandomWithPrefix(testPrefix)
+	testAccResourceInstancePoolDescription                 = acctest.RandString(10)
+	testAccResourceInstancePoolDiskSize              int64 = 10
+	testAccResourceInstancePoolDiskSizeUpdated             = testAccResourceInstancePoolDiskSize * 2
+	testAccResourceInstancePoolKeyPair                     = acctest.RandomWithPrefix(testPrefix)
+	testAccResourceInstancePoolName                        = acctest.RandomWithPrefix(testPrefix)
+	testAccResourceInstancePoolNameUpdated                 = testAccResourceInstancePoolName + "-updated"
+	testAccResourceInstancePoolInstancePrefix              = "test"
+	testAccResourceInstancePoolNetwork                     = acctest.RandomWithPrefix(testPrefix)
+	testAccResourceInstancePoolInstanceType                = "standard.tiny"
+	testAccResourceInstancePoolInstanceTypeUpdated         = "standard.small"
+	testAccResourceInstancePoolSize                  int64 = 1
+	testAccResourceInstancePoolSizeUpdated                 = testAccResourceInstancePoolSize * 2
+	testAccResourceInstancePoolUserData                    = acctest.RandString(10)
+	testAccResourceInstancePoolUserDataUpdated             = testAccResourceInstancePoolUserData + "-updated"
 
 	testAccResourceInstancePoolConfigCreate = fmt.Sprintf(`
 locals {
@@ -57,7 +57,7 @@ resource "exoscale_instance_pool" "test" {
   name = "%s"
   description = "%s"
   template_id = data.exoscale_compute_template.ubuntu.id
-  service_offering = "%s"
+  instance_type = "%s"
   size = %d
   disk_size = %d
   ipv6 = true
@@ -75,7 +75,7 @@ resource "exoscale_instance_pool" "test" {
 		testAccResourceInstancePoolAntiAffinityGroupName,
 		testAccResourceInstancePoolName,
 		testAccResourceInstancePoolDescription,
-		testAccResourceInstancePoolServiceOffering,
+		testAccResourceInstancePoolInstanceType,
 		testAccResourceInstancePoolSize,
 		testAccResourceInstancePoolDiskSize,
 		testAccResourceInstancePoolInstancePrefix,
@@ -114,7 +114,7 @@ resource "exoscale_instance_pool" "test" {
   name = "%s"
   description = ""
   template_id = data.exoscale_compute_template.debian.id
-  service_offering = "%s"
+  instance_type = "%s"
   size = %d
   disk_size = %d
   ipv6 = false
@@ -134,7 +134,7 @@ resource "exoscale_instance_pool" "test" {
 		testAccResourceInstancePoolKeyPair,
 		testAccResourceInstancePoolAntiAffinityGroupName,
 		testAccResourceInstancePoolNameUpdated,
-		testAccResourceInstancePoolServiceOfferingUpdated,
+		testAccResourceInstancePoolInstanceTypeUpdated,
 		testAccResourceInstancePoolSizeUpdated,
 		testAccResourceInstancePoolDiskSizeUpdated,
 		testAccResourceInstancePoolUserDataUpdated,
@@ -186,11 +186,11 @@ func TestAccResourceInstancePool(t *testing.T) {
 						resInstancePoolAttrAffinityGroupIDs + ".#": ValidateString("1"),
 						resInstancePoolAttrDescription:             ValidateString(testAccResourceInstancePoolDescription),
 						resInstancePoolAttrDiskSize:                ValidateString(fmt.Sprint(testAccResourceInstancePoolDiskSize)),
-						resInstancePoolAttrInstancePrefix:          ValidateString(testAccResourceInstancePoolInstancePrefix),
 						resInstancePoolAttrIPv6:                    ValidateString("true"),
+						resInstancePoolAttrInstancePrefix:          ValidateString(testAccResourceInstancePoolInstancePrefix),
+						resInstancePoolAttrInstanceType:            ValidateString(testAccResourceInstancePoolInstanceType),
 						resInstancePoolAttrName:                    ValidateString(testAccResourceInstancePoolName),
 						resInstancePoolAttrSecurityGroupIDs + ".#": ValidateString("1"),
-						resInstancePoolAttrServiceOffering:         ValidateString(testAccResourceInstancePoolServiceOffering),
 						resInstancePoolAttrSize:                    ValidateString(fmt.Sprint(testAccResourceInstancePoolSize)),
 						resInstancePoolAttrState:                   validation.ToDiagFunc(validation.NoZeroValues),
 						resInstancePoolAttrTemplateID:              validation.ToDiagFunc(validation.IsUUID),
@@ -238,11 +238,11 @@ func TestAccResourceInstancePool(t *testing.T) {
 						resInstancePoolAttrDiskSize:                ValidateString(fmt.Sprint(testAccResourceInstancePoolDiskSizeUpdated)),
 						resInstancePoolAttrElasticIPIDs + ".#":     ValidateString("1"),
 						resInstancePoolAttrInstancePrefix:          ValidateString(defaultInstancePoolInstancePrefix),
+						resInstancePoolAttrInstanceType:            ValidateString(testAccResourceInstancePoolInstanceTypeUpdated),
 						resInstancePoolAttrIPv6:                    ValidateString("false"),
 						resInstancePoolAttrKeyPair:                 ValidateString(testAccResourceInstancePoolKeyPair),
 						resInstancePoolAttrName:                    ValidateString(testAccResourceInstancePoolNameUpdated),
 						resInstancePoolAttrNetworkIDs + ".#":       ValidateString("1"),
-						resInstancePoolAttrServiceOffering:         ValidateString(testAccResourceInstancePoolServiceOfferingUpdated),
 						resInstancePoolAttrSize:                    ValidateString(fmt.Sprint(testAccResourceInstancePoolSizeUpdated)),
 						resInstancePoolAttrState:                   validation.ToDiagFunc(validation.NoZeroValues),
 						resInstancePoolAttrUserData:                ValidateString(testAccResourceInstancePoolUserDataUpdated),
@@ -268,11 +268,11 @@ func TestAccResourceInstancePool(t *testing.T) {
 							resInstancePoolAttrDiskSize:                ValidateString(fmt.Sprint(testAccResourceInstancePoolDiskSizeUpdated)),
 							resInstancePoolAttrElasticIPIDs + ".#":     ValidateString("1"),
 							resInstancePoolAttrInstancePrefix:          ValidateString(defaultInstancePoolInstancePrefix),
+							resInstancePoolAttrInstanceType:            ValidateString(testAccResourceInstancePoolInstanceTypeUpdated),
 							resInstancePoolAttrIPv6:                    ValidateString("false"),
 							resInstancePoolAttrKeyPair:                 ValidateString(testAccResourceInstancePoolKeyPair),
 							resInstancePoolAttrName:                    ValidateString(testAccResourceInstancePoolNameUpdated),
 							resInstancePoolAttrNetworkIDs + ".#":       ValidateString("1"),
-							resInstancePoolAttrServiceOffering:         ValidateString(testAccResourceInstancePoolServiceOfferingUpdated),
 							resInstancePoolAttrSize:                    ValidateString(fmt.Sprint(testAccResourceInstancePoolSizeUpdated)),
 							resInstancePoolAttrState:                   validation.ToDiagFunc(validation.NoZeroValues),
 							resInstancePoolAttrUserData:                ValidateString(testAccResourceInstancePoolUserDataUpdated),

--- a/website/docs/r/instance_pool.html.markdown
+++ b/website/docs/r/instance_pool.html.markdown
@@ -45,16 +45,16 @@ data "exoscale_compute_template" "webapp" {
 resource "exoscale_instance_pool" "webapp" {
   zone = var.zone
   name = "my-web-app"
-  template_id = data.exoscale_compute_template.webapp.id
   size = 3
-  service_offering = "medium"
+  template_id = data.exoscale_compute_template.webapp.id
+  instance_type = "medium"
   disk_size = 50
-  user_data = "#cloud-config\npackage_upgrade: true\n"
   key_pair = exoscale_ssh_keypair.webapp.name
   instance_prefix = "my-web-app"
   security_group_ids = [exoscale_security_group.webapp.id]
   network_ids = [exoscale_network.webapp.id]
   elastic_ip_ids = [exoscale_ipaddress.webapp.id]
+  user_data = "#cloud-config\npackage_upgrade: true\n"
 
   timeouts {
     delete = "10m"
@@ -69,7 +69,8 @@ resource "exoscale_instance_pool" "webapp" {
 * `name` - (Required) The name of the Instance Pool.
 * `template_id` - (Required) The ID of the instance [template][template] to use when creating Compute instances. Usage of the [`compute_template`][d-compute_template] data source is recommended.
 * `size` - (Required) The number of Compute instance members the Instance Pool manages.
-* `service_offering` - (Required) The managed Compute instances [size][size], e.g. `tiny`, `small`, `medium`, `large` etc.
+* `instance_type` -  (Required) The managed Compute instances [type][type] (format: `FAMILY.SIZE`, e.g. `standard.medium`, `memory.small`).
+* `service_offering` -  **Deprecated** The managed Compute instances [size][size], e.g. `tiny`, `small`, `medium`, `large` etc.
 * `disk_size` - The managed Compute instances disk size.
 * `description` - The description of the Instance Pool.
 * `user_data` - A [cloud-init][cloudinit] configuration to apply when creating Compute instances. Whenever possible don't base64-encode neither gzip it yourself, as this will be automatically taken care of on your behalf by the provider.
@@ -105,7 +106,7 @@ $ terraform import exoscale_instance_pool.example eb556678-ec59-4be6-8c54-0406ae
 [privnet-doc]: https://community.exoscale.com/documentation/compute/private-networks/
 [r-affinity]: affinity.html
 [r-security_group]: security_group.html
-[size]: https://www.exoscale.com/pricing/#/compute/
 [sshkeypair]: https://community.exoscale.com/documentation/compute/ssh-keypairs/
 [template]: https://www.exoscale.com/templates/
+[type]: https://www.exoscale.com/pricing/#/compute/
 [zone]: https://www.exoscale.com/datacenters/


### PR DESCRIPTION
This change deprecates the `exoscale_instance_pool.service_offering`
attribute and replaces it with a new `instance_type` attribute.