### PR TITLE
SKS

### DIFF
--- a/exoscale/resource_exoscale_database_kafka.go
+++ b/exoscale/resource_exoscale_database_kafka.go
@@ -376,11 +376,7 @@ func resourceDatabaseUpdateKafka(
 	return nil
 }
 
-func resourceDatabaseApplyKafka(
-	ctx context.Context,
-	d *schema.ResourceData,
-	client *egoscale.Client,
-) error {
+func resourceDatabaseApplyKafka(ctx context.Context, d *schema.ResourceData, client *egoscale.Client) error {
 	res, err := client.GetDbaasServiceKafkaWithResponse(ctx, oapi.DbaasServiceName(d.Id()))
 	if err != nil {
 		return err

--- a/exoscale/resource_exoscale_database_mysql.go
+++ b/exoscale/resource_exoscale_database_mysql.go
@@ -265,11 +265,7 @@ func resourceDatabaseUpdateMysql(
 	return nil
 }
 
-func resourceDatabaseApplyMysql(
-	ctx context.Context,
-	d *schema.ResourceData,
-	client *egoscale.Client,
-) error {
+func resourceDatabaseApplyMysql(ctx context.Context, d *schema.ResourceData, client *egoscale.Client) error {
 	res, err := client.GetDbaasServiceMysqlWithResponse(ctx, oapi.DbaasServiceName(d.Id()))
 	if err != nil {
 		return err

--- a/exoscale/resource_exoscale_database_pg.go
+++ b/exoscale/resource_exoscale_database_pg.go
@@ -317,11 +317,7 @@ func resourceDatabaseUpdatePg(
 	return nil
 }
 
-func resourceDatabaseApplyPg(
-	ctx context.Context,
-	d *schema.ResourceData,
-	client *egoscale.Client,
-) error {
+func resourceDatabaseApplyPg(ctx context.Context, d *schema.ResourceData, client *egoscale.Client) error {
 	res, err := client.GetDbaasServicePgWithResponse(ctx, oapi.DbaasServiceName(d.Id()))
 	if err != nil {
 		return err

--- a/exoscale/resource_exoscale_database_redis.go
+++ b/exoscale/resource_exoscale_database_redis.go
@@ -193,11 +193,7 @@ func resourceDatabaseUpdateRedis(
 	return nil
 }
 
-func resourceDatabaseApplyRedis(
-	ctx context.Context,
-	d *schema.ResourceData,
-	client *egoscale.Client,
-) error {
+func resourceDatabaseApplyRedis(ctx context.Context, d *schema.ResourceData, client *egoscale.Client) error {
 	res, err := client.GetDbaasServiceRedisWithResponse(ctx, oapi.DbaasServiceName(d.Id()))
 	if err != nil {
 		return err

--- a/exoscale/resource_exoscale_nlb.go
+++ b/exoscale/resource_exoscale_nlb.go
@@ -152,7 +152,7 @@ func resourceNLBRead(ctx context.Context, d *schema.ResourceData, meta interface
 
 	log.Printf("[DEBUG] %s: read finished successfully", resourceNLBIDString(d))
 
-	return resourceNLBApply(ctx, d, nlb)
+	return diag.FromErr(resourceNLBApply(ctx, d, nlb))
 }
 
 func resourceNLBUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -227,25 +227,25 @@ func resourceNLBDelete(ctx context.Context, d *schema.ResourceData, meta interfa
 	return nil
 }
 
-func resourceNLBApply(_ context.Context, d *schema.ResourceData, nlb *egoscale.NetworkLoadBalancer) diag.Diagnostics {
+func resourceNLBApply(_ context.Context, d *schema.ResourceData, nlb *egoscale.NetworkLoadBalancer) error {
 	if err := d.Set(resNLBAttrCreatedAt, nlb.CreatedAt.String()); err != nil {
-		return diag.FromErr(err)
+		return err
 	}
 
 	if err := d.Set(resNLBAttrDescription, defaultString(nlb.Description, "")); err != nil {
-		return diag.FromErr(err)
+		return err
 	}
 
 	if err := d.Set(resNLBAttrIPAddress, nlb.IPAddress.String()); err != nil {
-		return diag.FromErr(err)
+		return err
 	}
 
 	if err := d.Set(resNLBAttrLabels, nlb.Labels); err != nil {
-		return diag.FromErr(err)
+		return err
 	}
 
 	if err := d.Set(resNLBAttrName, *nlb.Name); err != nil {
-		return diag.FromErr(err)
+		return err
 	}
 
 	services := make([]string, len(nlb.Services))
@@ -253,11 +253,11 @@ func resourceNLBApply(_ context.Context, d *schema.ResourceData, nlb *egoscale.N
 		services[i] = *service.ID
 	}
 	if err := d.Set(resNLBAttrServices, services); err != nil {
-		return diag.FromErr(err)
+		return err
 	}
 
 	if err := d.Set(resNLBAttrState, *nlb.State); err != nil {
-		return diag.FromErr(err)
+		return err
 	}
 
 	return nil

--- a/exoscale/resource_exoscale_nlb_service.go
+++ b/exoscale/resource_exoscale_nlb_service.go
@@ -294,7 +294,7 @@ func resourceNLBServiceRead(ctx context.Context, d *schema.ResourceData, meta in
 
 	log.Printf("[DEBUG] %s: read finished successfully", resourceNLBServiceIDString(d))
 
-	return resourceNLBServiceApply(ctx, d, nlbService)
+	return diag.FromErr(resourceNLBServiceApply(ctx, d, nlbService))
 }
 
 func resourceNLBServiceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -438,9 +438,13 @@ func resourceNLBServiceDelete(ctx context.Context, d *schema.ResourceData, meta 
 	return nil
 }
 
-func resourceNLBServiceApply(_ context.Context, d *schema.ResourceData, nlbService *egoscale.NetworkLoadBalancerService) diag.Diagnostics {
+func resourceNLBServiceApply(
+	_ context.Context,
+	d *schema.ResourceData,
+	nlbService *egoscale.NetworkLoadBalancerService,
+) error {
 	if err := d.Set(resNLBServiceAttrDescription, defaultString(nlbService.Description, "")); err != nil {
-		return diag.FromErr(err)
+		return err
 	}
 
 	healthcheck := d.Get(resNLBServiceAttrHealthcheck).(*schema.Set)
@@ -455,35 +459,35 @@ func resourceNLBServiceApply(_ context.Context, d *schema.ResourceData, nlbServi
 			resNLBServiceAttrHealthcheckURI:      defaultString(nlbService.Healthcheck.URI, ""),
 		},
 	})); err != nil {
-		return diag.FromErr(err)
+		return err
 	}
 
 	if err := d.Set(resNLBServiceAttrInstancePoolID, *nlbService.InstancePoolID); err != nil {
-		return diag.FromErr(err)
+		return err
 	}
 
 	if err := d.Set(resNLBServiceAttrName, *nlbService.Name); err != nil {
-		return diag.FromErr(err)
+		return err
 	}
 
 	if err := d.Set(resNLBServiceAttrPort, *nlbService.Port); err != nil {
-		return diag.FromErr(err)
+		return err
 	}
 
 	if err := d.Set(resNLBServiceAttrProtocol, *nlbService.Protocol); err != nil {
-		return diag.FromErr(err)
+		return err
 	}
 
 	if err := d.Set(resNLBServiceAttrState, *nlbService.State); err != nil {
-		return diag.FromErr(err)
+		return err
 	}
 
 	if err := d.Set(resNLBServiceAttrStrategy, *nlbService.Strategy); err != nil {
-		return diag.FromErr(err)
+		return err
 	}
 
 	if err := d.Set(resNLBServiceAttrTargetPort, *nlbService.TargetPort); err != nil {
-		return diag.FromErr(err)
+		return err
 	}
 
 	return nil

--- a/exoscale/resource_exoscale_sks_cluster.go
+++ b/exoscale/resource_exoscale_sks_cluster.go
@@ -128,7 +128,8 @@ func resourceSKSCluster() *schema.Resource {
 						Required: true,
 					},
 					resSKSClusterAttrOIDCRequiredClaim: {
-						Type:     schema.TypeString,
+						Type:     schema.TypeMap,
+						Elem:     &schema.Schema{Type: schema.TypeString},
 						Optional: true,
 					},
 					resSKSClusterAttrOIDCUsernameClaim: {
@@ -280,8 +281,12 @@ func resourceSKSClusterCreate(ctx context.Context, d *schema.ResourceData, meta 
 			sksClusterOIDCConfig.IssuerURL = nonEmptyStringPtr(v.(string))
 		}
 
-		if v, ok := d.GetOk(resSKSClusterAttrOIDC(resSKSClusterAttrOIDCRequiredClaim)); ok {
-			sksClusterOIDCConfig.RequiredClaim = nonEmptyStringPtr(v.(string))
+		if c, ok := d.GetOk(resSKSClusterAttrOIDC(resSKSClusterAttrOIDCRequiredClaim)); ok {
+			claims := make(map[string]string)
+			for k, v := range c.(map[string]interface{}) {
+				claims[k] = v.(string)
+			}
+			sksClusterOIDCConfig.RequiredClaim = &claims
 		}
 
 		if v, ok := d.GetOk(resSKSClusterAttrOIDC(resSKSClusterAttrOIDCUsernameClaim)); ok {

--- a/exoscale/resource_exoscale_sks_cluster.go
+++ b/exoscale/resource_exoscale_sks_cluster.go
@@ -335,7 +335,7 @@ func resourceSKSClusterRead(ctx context.Context, d *schema.ResourceData, meta in
 
 	log.Printf("[DEBUG] %s: read finished successfully", resourceSKSClusterIDString(d))
 
-	return resourceSKSClusterApply(ctx, d, sksCluster)
+	return diag.FromErr(resourceSKSClusterApply(ctx, d, sksCluster))
 }
 
 func resourceSKSClusterUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -416,47 +416,47 @@ func resourceSKSClusterDelete(ctx context.Context, d *schema.ResourceData, meta 
 	return nil
 }
 
-func resourceSKSClusterApply(_ context.Context, d *schema.ResourceData, sksCluster *egoscale.SKSCluster) diag.Diagnostics {
+func resourceSKSClusterApply(_ context.Context, d *schema.ResourceData, sksCluster *egoscale.SKSCluster) error {
 	if sksCluster.AddOns != nil {
 		if err := d.Set(resSKSClusterAttrAddons, *sksCluster.AddOns); err != nil {
-			return diag.FromErr(err)
+			return err
 		}
 
 		if err := d.Set(resSKSClusterAttrExoscaleCCM, in(*sksCluster.AddOns, sksClusterAddonExoscaleCCM)); err != nil {
-			return diag.FromErr(err)
+			return err
 		}
 
 		if err := d.Set(resSKSClusterAttrMetricsServer, in(*sksCluster.AddOns, sksClusterAddonMS)); err != nil {
-			return diag.FromErr(err)
+			return err
 		}
 	}
 
 	if err := d.Set(resSKSClusterAttrAutoUpgrade, defaultBool(sksCluster.AutoUpgrade, false)); err != nil {
-		return diag.FromErr(err)
+		return err
 	}
 
 	if err := d.Set(resSKSClusterAttrCNI, defaultString(sksCluster.CNI, "")); err != nil {
-		return diag.FromErr(err)
+		return err
 	}
 
 	if err := d.Set(resSKSClusterAttrCreatedAt, sksCluster.CreatedAt.String()); err != nil {
-		return diag.FromErr(err)
+		return err
 	}
 
 	if err := d.Set(resSKSClusterAttrDescription, defaultString(sksCluster.Description, "")); err != nil {
-		return diag.FromErr(err)
+		return err
 	}
 
 	if err := d.Set(resSKSClusterAttrEndpoint, *sksCluster.Endpoint); err != nil {
-		return diag.FromErr(err)
+		return err
 	}
 
 	if err := d.Set(resSKSClusterAttrLabels, sksCluster.Labels); err != nil {
-		return diag.FromErr(err)
+		return err
 	}
 
 	if err := d.Set(resSKSClusterAttrName, *sksCluster.Name); err != nil {
-		return diag.FromErr(err)
+		return err
 	}
 
 	nodepools := make([]string, len(sksCluster.Nodepools))
@@ -464,19 +464,19 @@ func resourceSKSClusterApply(_ context.Context, d *schema.ResourceData, sksClust
 		nodepools[i] = *nodepool.ID
 	}
 	if err := d.Set(resSKSClusterAttrNodepools, nodepools); err != nil {
-		return diag.FromErr(err)
+		return err
 	}
 
 	if err := d.Set(resSKSClusterAttrServiceLevel, *sksCluster.ServiceLevel); err != nil {
-		return diag.FromErr(err)
+		return err
 	}
 
 	if err := d.Set(resSKSClusterAttrState, *sksCluster.State); err != nil {
-		return diag.FromErr(err)
+		return err
 	}
 
 	if err := d.Set(resSKSClusterAttrVersion, *sksCluster.Version); err != nil {
-		return diag.FromErr(err)
+		return err
 	}
 
 	return nil

--- a/exoscale/resource_exoscale_sks_cluster_test.go
+++ b/exoscale/resource_exoscale_sks_cluster_test.go
@@ -17,19 +17,19 @@ import (
 )
 
 var (
-	testAccResourceSKSClusterLabelValue         = acctest.RandomWithPrefix(testPrefix)
-	testAccResourceSKSClusterLabelValueUpdated  = testAccResourceSKSClusterLabelValue + "-updated"
-	testAccResourceSKSClusterName               = acctest.RandomWithPrefix(testPrefix)
-	testAccResourceSKSClusterNameUpdated        = testAccResourceSKSClusterName + "-updated"
-	testAccResourceSKSClusterOIDCClientID       = acctest.RandString(10)
-	testAccResourceSKSClusterOIDCGroupsClaim    = acctest.RandString(10)
-	testAccResourceSKSClusterOIDCGroupsPrefix   = acctest.RandString(10)
-	testAccResourceSKSClusterOIDCIssuerURL      = "https://id.example.net"
-	testAccResourceSKSClusterOIDCRequiredClaim  = acctest.RandString(10)
-	testAccResourceSKSClusterOIDCUsernameClaim  = acctest.RandString(10)
-	testAccResourceSKSClusterOIDCUsernamePrefix = acctest.RandString(10)
-	testAccResourceSKSClusterDescription        = acctest.RandString(10)
-	testAccResourceSKSClusterDescriptionUpdated = testAccResourceSKSClusterDescription + "-updated"
+	testAccResourceSKSClusterLabelValue             = acctest.RandomWithPrefix(testPrefix)
+	testAccResourceSKSClusterLabelValueUpdated      = testAccResourceSKSClusterLabelValue + "-updated"
+	testAccResourceSKSClusterName                   = acctest.RandomWithPrefix(testPrefix)
+	testAccResourceSKSClusterNameUpdated            = testAccResourceSKSClusterName + "-updated"
+	testAccResourceSKSClusterOIDCClientID           = acctest.RandString(10)
+	testAccResourceSKSClusterOIDCGroupsClaim        = acctest.RandString(10)
+	testAccResourceSKSClusterOIDCGroupsPrefix       = acctest.RandString(10)
+	testAccResourceSKSClusterOIDCIssuerURL          = "https://id.example.net"
+	testAccResourceSKSClusterOIDCRequiredClaimValue = acctest.RandString(10)
+	testAccResourceSKSClusterOIDCUsernameClaim      = acctest.RandString(10)
+	testAccResourceSKSClusterOIDCUsernamePrefix     = acctest.RandString(10)
+	testAccResourceSKSClusterDescription            = acctest.RandString(10)
+	testAccResourceSKSClusterDescriptionUpdated     = testAccResourceSKSClusterDescription + "-updated"
 
 	testAccResourceSKSClusterConfigCreate = fmt.Sprintf(`
 locals {
@@ -52,7 +52,7 @@ resource "exoscale_sks_cluster" "test" {
 	groups_claim = "%s"
 	groups_prefix = "%s"
     issuer_url = "%s"
-	required_claim = "test=%s"
+	required_claim = { test = "%s" }
 	username_claim = "%s"
 	username_prefix = "%s"
   }
@@ -83,7 +83,7 @@ resource "exoscale_sks_nodepool" "test" {
 		testAccResourceSKSClusterOIDCGroupsClaim,
 		testAccResourceSKSClusterOIDCGroupsPrefix,
 		testAccResourceSKSClusterOIDCIssuerURL,
-		testAccResourceSKSClusterOIDCRequiredClaim,
+		testAccResourceSKSClusterOIDCRequiredClaimValue,
 		testAccResourceSKSClusterOIDCUsernameClaim,
 		testAccResourceSKSClusterOIDCUsernamePrefix,
 	)
@@ -136,10 +136,7 @@ func TestAccResourceSKSCluster(t *testing.T) {
 	)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-		},
-
+		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckResourceSKSClusterDestroy(&sksCluster),
 		Steps: []resource.TestStep{

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/exoscale/terraform-provider-exoscale
 require (
 	github.com/apparentlymart/go-cidr v1.1.0 // indirect
 	github.com/aws/aws-sdk-go v1.37.0 // indirect
-	github.com/exoscale/egoscale v0.83.0
+	github.com/exoscale/egoscale v0.84.1
 	github.com/gofrs/uuid v4.0.0+incompatible // indirect
 	github.com/gopherjs/gopherjs v0.0.0-20190430165422-3e4dfb77656c // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2

--- a/go.sum
+++ b/go.sum
@@ -93,8 +93,8 @@ github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymF
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/exoscale/egoscale v0.83.0 h1:mo+eKegti0ALe6bHYfdeDb74w89tjcBPOTYn2rQ+Iss=
-github.com/exoscale/egoscale v0.83.0/go.mod h1:C1e4bJE8Ml1GylP14hOMGdCfgDDf9hMLsbny1QWsemw=
+github.com/exoscale/egoscale v0.84.1 h1:3ddejtFgHvX+3w7olUDhMFzwiChS8wByAcZ95V3KSHM=
+github.com/exoscale/egoscale v0.84.1/go.mod h1:C1e4bJE8Ml1GylP14hOMGdCfgDDf9hMLsbny1QWsemw=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=

--- a/vendor/github.com/exoscale/egoscale/.golangci.yml
+++ b/vendor/github.com/exoscale/egoscale/.golangci.yml
@@ -2,8 +2,6 @@ run:
   timeout: 10m
 
 linters-settings:
-  gocyclo:
-    min-complexity: 28
   goimports:
     local-prefixes: github.com
 
@@ -13,7 +11,6 @@ linters:
     - errcheck
     - exportloopref
     - gocritic
-    - gocyclo
     - goimports
     - gosimple
     - govet

--- a/vendor/github.com/exoscale/egoscale/CHANGELOG.md
+++ b/vendor/github.com/exoscale/egoscale/CHANGELOG.md
@@ -1,6 +1,26 @@
 Changelog
 =========
 
+0.84.1
+------
+
+- fix: v2: fix `CreateSecurityGroupRule()` method (#547)
+
+0.84.0
+------
+
+- change: v2: `SKSClusterOIDCConfig` struct field `RequiredClaim` now is a `map[string]string` type instead of a string
+
+0.83.2
+------
+
+- change: v2: refresh code generated from public API spec
+
+0.83.1
+------
+
+- change: v2: refresh code generated from public API spec
+
 0.83.0
 ------
 

--- a/vendor/github.com/exoscale/egoscale/v2/oapi/oapi.gen.go
+++ b/vendor/github.com/exoscale/egoscale/v2/oapi/oapi.gen.go
@@ -205,6 +205,13 @@ const (
 	EnumServiceStateRunning EnumServiceState = "running"
 )
 
+// Defines values for EnumSortOrder.
+const (
+	EnumSortOrderAsc EnumSortOrder = "asc"
+
+	EnumSortOrderDesc EnumSortOrder = "desc"
+)
+
 // Defines values for InstanceState.
 const (
 	InstanceStateDestroyed InstanceState = "destroyed"
@@ -629,6 +636,36 @@ type DbaasBackupConfig struct {
 
 // DbaasIntegration defines model for dbaas-integration.
 type DbaasIntegration struct {
+	// Description of the integration
+	Description *string `json:"description,omitempty"`
+
+	// Destination service name
+	Dest *string `json:"dest,omitempty"`
+
+	// Integration id
+	Id *string `json:"id,omitempty"`
+
+	// Whether the integration is active or not
+	IsActive *bool `json:"is-active,omitempty"`
+
+	// Whether the integration is enabled or not
+	IsEnabled *bool `json:"is-enabled,omitempty"`
+
+	// Integration settings
+	Settings *map[string]interface{} `json:"settings,omitempty"`
+
+	// Source service name
+	Source *string `json:"source,omitempty"`
+
+	// Integration status
+	Status *string `json:"status,omitempty"`
+
+	// Integration type
+	Type *string `json:"type,omitempty"`
+}
+
+// DbaasIntegrationType defines model for dbaas-integration-type.
+type DbaasIntegrationType struct {
 	// The description of the destination service types.
 	DestDescription *string `json:"dest-description,omitempty"`
 
@@ -744,8 +781,11 @@ type DbaasServiceCommon struct {
 	CreatedAt *time.Time `json:"created-at,omitempty"`
 
 	// TODO UNIT disk space for data storage
-	DiskSize *int64           `json:"disk-size,omitempty"`
-	Name     DbaasServiceName `json:"name"`
+	DiskSize *int64 `json:"disk-size,omitempty"`
+
+	// Service integrations
+	Integrations *[]DbaasIntegration `json:"integrations,omitempty"`
+	Name         DbaasServiceName    `json:"name"`
 
 	// Number of service nodes in the active plan
 	NodeCount *int64 `json:"node-count,omitempty"`
@@ -872,6 +912,9 @@ type DbaasServiceKafka struct {
 	// TODO UNIT disk space for data storage
 	DiskSize *int64 `json:"disk-size,omitempty"`
 
+	// Service integrations
+	Integrations *[]DbaasIntegration `json:"integrations,omitempty"`
+
 	// Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'
 	IpFilter *[]string `json:"ip-filter,omitempty"`
 
@@ -946,6 +989,18 @@ type DbaasServiceKafka struct {
 	Version *string `json:"version,omitempty"`
 }
 
+// DbaasServiceLogs defines model for dbaas-service-logs.
+type DbaasServiceLogs struct {
+	FirstLogOffset *string `json:"first-log-offset,omitempty"`
+	Logs           *[]struct {
+		Message *string `json:"message,omitempty"`
+		Node    *string `json:"node,omitempty"`
+		Time    *string `json:"time,omitempty"`
+		Unit    *string `json:"unit,omitempty"`
+	} `json:"logs,omitempty"`
+	Offset *string `json:"offset,omitempty"`
+}
+
 // Automatic maintenance settings
 type DbaasServiceMaintenance struct {
 	// Day of week for installing updates
@@ -1003,6 +1058,9 @@ type DbaasServiceMysql struct {
 
 	// TODO UNIT disk space for data storage
 	DiskSize *int64 `json:"disk-size,omitempty"`
+
+	// Service integrations
+	Integrations *[]DbaasIntegration `json:"integrations,omitempty"`
 
 	// Allowed CIDR address blocks for incoming connections
 	IpFilter *[]string `json:"ip-filter,omitempty"`
@@ -1145,6 +1203,9 @@ type DbaasServicePg struct {
 	// TODO UNIT disk space for data storage
 	DiskSize *int64 `json:"disk-size,omitempty"`
 
+	// Service integrations
+	Integrations *[]DbaasIntegration `json:"integrations,omitempty"`
+
 	// Allowed CIDR address blocks for incoming connections
 	IpFilter *[]string `json:"ip-filter,omitempty"`
 
@@ -1253,6 +1314,9 @@ type DbaasServiceRedis struct {
 
 	// TODO UNIT disk space for data storage
 	DiskSize *int64 `json:"disk-size,omitempty"`
+
+	// Service integrations
+	Integrations *[]DbaasIntegration `json:"integrations,omitempty"`
 
 	// Allowed CIDR address blocks for incoming connections
 	IpFilter *[]string `json:"ip-filter,omitempty"`
@@ -1478,6 +1542,9 @@ type EnumPgVariant string
 
 // EnumServiceState defines model for enum-service-state.
 type EnumServiceState string
+
+// EnumSortOrder defines model for enum-sort-order.
+type EnumSortOrder string
 
 // A notable event which happened on the infrastructure
 type Event struct {
@@ -2080,14 +2147,19 @@ type SksOidc struct {
 	// OpenID provider URL
 	IssuerUrl string `json:"issuer-url"`
 
-	// A key=value pair that describes a required claim in the ID Token
-	RequiredClaim *string `json:"required-claim,omitempty"`
+	// A key value map that describes a required claim in the ID Token
+	RequiredClaim *SksOidc_RequiredClaim `json:"required-claim,omitempty"`
 
 	// JWT claim to use as the user name
 	UsernameClaim *string `json:"username-claim,omitempty"`
 
 	// Prefix prepended to username claims
 	UsernamePrefix *string `json:"username-prefix,omitempty"`
+}
+
+// A key value map that describes a required claim in the ID Token
+type SksOidc_RequiredClaim struct {
+	AdditionalProperties map[string]string `json:"-"`
 }
 
 // Snapshot
@@ -2219,6 +2291,27 @@ type CreateAntiAffinityGroupJSONBody struct {
 
 	// Anti-affinity Group name
 	Name string `json:"name"`
+}
+
+// CreateDbaasIntegrationJSONBody defines parameters for CreateDbaasIntegration.
+type CreateDbaasIntegrationJSONBody struct {
+	// A destination service
+	DestService string `json:"dest-service"`
+
+	// Integration type
+	IntegrationType string `json:"integration-type"`
+
+	// Integration settings
+	Settings *map[string]interface{} `json:"settings,omitempty"`
+
+	// A source service
+	SourceService string `json:"source-service"`
+}
+
+// UpdateDbaasIntegrationJSONBody defines parameters for UpdateDbaasIntegration.
+type UpdateDbaasIntegrationJSONBody struct {
+	// Integration settings
+	Settings map[string]interface{} `json:"settings"`
 }
 
 // CreateDbaasServiceKafkaJSONBody defines parameters for CreateDbaasServiceKafka.
@@ -2648,6 +2741,25 @@ type CreateDbaasServiceJSONBody struct {
 
 // CreateDbaasServiceJSONBodyMaintenanceDow defines parameters for CreateDbaasService.
 type CreateDbaasServiceJSONBodyMaintenanceDow string
+
+// GetDbaasServiceLogsJSONBody defines parameters for GetDbaasServiceLogs.
+type GetDbaasServiceLogsJSONBody struct {
+	// How many log entries to receive at most, up to 500 (default: 100)
+	Limit *int64 `json:"limit,omitempty"`
+
+	// Opaque offset identifier
+	Offset    *string        `json:"offset,omitempty"`
+	SortOrder *EnumSortOrder `json:"sort-order,omitempty"`
+}
+
+// GetDbaasServiceMetricsJSONBody defines parameters for GetDbaasServiceMetrics.
+type GetDbaasServiceMetricsJSONBody struct {
+	// Metrics time period (default: hour)
+	Period *GetDbaasServiceMetricsJSONBodyPeriod `json:"period,omitempty"`
+}
+
+// GetDbaasServiceMetricsJSONBodyPeriod defines parameters for GetDbaasServiceMetrics.
+type GetDbaasServiceMetricsJSONBodyPeriod string
 
 // UpdateDbaasServiceJSONBody defines parameters for UpdateDbaasService.
 type UpdateDbaasServiceJSONBody struct {
@@ -3383,6 +3495,12 @@ type CreateAccessKeyJSONRequestBody CreateAccessKeyJSONBody
 // CreateAntiAffinityGroupJSONRequestBody defines body for CreateAntiAffinityGroup for application/json ContentType.
 type CreateAntiAffinityGroupJSONRequestBody CreateAntiAffinityGroupJSONBody
 
+// CreateDbaasIntegrationJSONRequestBody defines body for CreateDbaasIntegration for application/json ContentType.
+type CreateDbaasIntegrationJSONRequestBody CreateDbaasIntegrationJSONBody
+
+// UpdateDbaasIntegrationJSONRequestBody defines body for UpdateDbaasIntegration for application/json ContentType.
+type UpdateDbaasIntegrationJSONRequestBody UpdateDbaasIntegrationJSONBody
+
 // CreateDbaasServiceKafkaJSONRequestBody defines body for CreateDbaasServiceKafka for application/json ContentType.
 type CreateDbaasServiceKafkaJSONRequestBody CreateDbaasServiceKafkaJSONBody
 
@@ -3409,6 +3527,12 @@ type UpdateDbaasServiceRedisJSONRequestBody UpdateDbaasServiceRedisJSONBody
 
 // CreateDbaasServiceJSONRequestBody defines body for CreateDbaasService for application/json ContentType.
 type CreateDbaasServiceJSONRequestBody CreateDbaasServiceJSONBody
+
+// GetDbaasServiceLogsJSONRequestBody defines body for GetDbaasServiceLogs for application/json ContentType.
+type GetDbaasServiceLogsJSONRequestBody GetDbaasServiceLogsJSONBody
+
+// GetDbaasServiceMetricsJSONRequestBody defines body for GetDbaasServiceMetrics for application/json ContentType.
+type GetDbaasServiceMetricsJSONRequestBody GetDbaasServiceMetricsJSONBody
 
 // UpdateDbaasServiceJSONRequestBody defines body for UpdateDbaasService for application/json ContentType.
 type UpdateDbaasServiceJSONRequestBody UpdateDbaasServiceJSONBody
@@ -3648,6 +3772,59 @@ func (a SksNodepoolTaints) MarshalJSON() ([]byte, error) {
 	return json.Marshal(object)
 }
 
+// Getter for additional properties for SksOidc_RequiredClaim. Returns the specified
+// element and whether it was found
+func (a SksOidc_RequiredClaim) Get(fieldName string) (value string, found bool) {
+	if a.AdditionalProperties != nil {
+		value, found = a.AdditionalProperties[fieldName]
+	}
+	return
+}
+
+// Setter for additional properties for SksOidc_RequiredClaim
+func (a *SksOidc_RequiredClaim) Set(fieldName string, value string) {
+	if a.AdditionalProperties == nil {
+		a.AdditionalProperties = make(map[string]string)
+	}
+	a.AdditionalProperties[fieldName] = value
+}
+
+// Override default JSON handling for SksOidc_RequiredClaim to handle AdditionalProperties
+func (a *SksOidc_RequiredClaim) UnmarshalJSON(b []byte) error {
+	object := make(map[string]json.RawMessage)
+	err := json.Unmarshal(b, &object)
+	if err != nil {
+		return err
+	}
+
+	if len(object) != 0 {
+		a.AdditionalProperties = make(map[string]string)
+		for fieldName, fieldBuf := range object {
+			var fieldVal string
+			err := json.Unmarshal(fieldBuf, &fieldVal)
+			if err != nil {
+				return fmt.Errorf("error unmarshaling field %s: %w", fieldName, err)
+			}
+			a.AdditionalProperties[fieldName] = fieldVal
+		}
+	}
+	return nil
+}
+
+// Override default JSON handling for SksOidc_RequiredClaim to handle AdditionalProperties
+func (a SksOidc_RequiredClaim) MarshalJSON() ([]byte, error) {
+	var err error
+	object := make(map[string]json.RawMessage)
+
+	for fieldName, field := range a.AdditionalProperties {
+		object[fieldName], err = json.Marshal(field)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling '%s': %w", fieldName, err)
+		}
+	}
+	return json.Marshal(object)
+}
+
 // RequestEditorFn  is the function signature for the RequestEditor callback function
 type RequestEditorFn func(ctx context.Context, req *http.Request) error
 
@@ -3758,11 +3935,27 @@ type ClientInterface interface {
 	// GetDbaasCaCertificate request
 	GetDbaasCaCertificate(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// CreateDbaasIntegration request with any body
+	CreateDbaasIntegrationWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	CreateDbaasIntegration(ctx context.Context, body CreateDbaasIntegrationJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// ListDbaasIntegrationSettings request
 	ListDbaasIntegrationSettings(ctx context.Context, integrationType string, sourceType string, destType string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ListDbaasIntegrationTypes request
 	ListDbaasIntegrationTypes(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// DeleteDbaasIntegration request
+	DeleteDbaasIntegration(ctx context.Context, integrationUuid string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetDbaasIntegration request
+	GetDbaasIntegration(ctx context.Context, integrationUuid string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UpdateDbaasIntegration request with any body
+	UpdateDbaasIntegrationWithBody(ctx context.Context, integrationUuid string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UpdateDbaasIntegration(ctx context.Context, integrationUuid string, body UpdateDbaasIntegrationJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetDbaasServiceKafka request
 	GetDbaasServiceKafka(ctx context.Context, name DbaasServiceName, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -3823,6 +4016,16 @@ type ClientInterface interface {
 	CreateDbaasServiceWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	CreateDbaasService(ctx context.Context, body CreateDbaasServiceJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetDbaasServiceLogs request with any body
+	GetDbaasServiceLogsWithBody(ctx context.Context, serviceName string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	GetDbaasServiceLogs(ctx context.Context, serviceName string, body GetDbaasServiceLogsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetDbaasServiceMetrics request with any body
+	GetDbaasServiceMetricsWithBody(ctx context.Context, serviceName string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	GetDbaasServiceMetrics(ctx context.Context, serviceName string, body GetDbaasServiceMetricsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ListDbaasServiceTypes request
 	ListDbaasServiceTypes(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -4420,6 +4623,30 @@ func (c *Client) GetDbaasCaCertificate(ctx context.Context, reqEditors ...Reques
 	return c.Client.Do(req)
 }
 
+func (c *Client) CreateDbaasIntegrationWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateDbaasIntegrationRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CreateDbaasIntegration(ctx context.Context, body CreateDbaasIntegrationJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateDbaasIntegrationRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
 func (c *Client) ListDbaasIntegrationSettings(ctx context.Context, integrationType string, sourceType string, destType string, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewListDbaasIntegrationSettingsRequest(c.Server, integrationType, sourceType, destType)
 	if err != nil {
@@ -4434,6 +4661,54 @@ func (c *Client) ListDbaasIntegrationSettings(ctx context.Context, integrationTy
 
 func (c *Client) ListDbaasIntegrationTypes(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewListDbaasIntegrationTypesRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) DeleteDbaasIntegration(ctx context.Context, integrationUuid string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeleteDbaasIntegrationRequest(c.Server, integrationUuid)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetDbaasIntegration(ctx context.Context, integrationUuid string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetDbaasIntegrationRequest(c.Server, integrationUuid)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateDbaasIntegrationWithBody(ctx context.Context, integrationUuid string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateDbaasIntegrationRequestWithBody(c.Server, integrationUuid, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateDbaasIntegration(ctx context.Context, integrationUuid string, body UpdateDbaasIntegrationJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateDbaasIntegrationRequest(c.Server, integrationUuid, body)
 	if err != nil {
 		return nil, err
 	}
@@ -4710,6 +4985,54 @@ func (c *Client) CreateDbaasServiceWithBody(ctx context.Context, contentType str
 
 func (c *Client) CreateDbaasService(ctx context.Context, body CreateDbaasServiceJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewCreateDbaasServiceRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetDbaasServiceLogsWithBody(ctx context.Context, serviceName string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetDbaasServiceLogsRequestWithBody(c.Server, serviceName, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetDbaasServiceLogs(ctx context.Context, serviceName string, body GetDbaasServiceLogsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetDbaasServiceLogsRequest(c.Server, serviceName, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetDbaasServiceMetricsWithBody(ctx context.Context, serviceName string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetDbaasServiceMetricsRequestWithBody(c.Server, serviceName, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetDbaasServiceMetrics(ctx context.Context, serviceName string, body GetDbaasServiceMetricsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetDbaasServiceMetricsRequest(c.Server, serviceName, body)
 	if err != nil {
 		return nil, err
 	}
@@ -7003,6 +7326,46 @@ func NewGetDbaasCaCertificateRequest(server string) (*http.Request, error) {
 	return req, nil
 }
 
+// NewCreateDbaasIntegrationRequest calls the generic CreateDbaasIntegration builder with application/json body
+func NewCreateDbaasIntegrationRequest(server string, body CreateDbaasIntegrationJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewCreateDbaasIntegrationRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewCreateDbaasIntegrationRequestWithBody generates requests for CreateDbaasIntegration with any type of body
+func NewCreateDbaasIntegrationRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/dbaas-integration")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
 // NewListDbaasIntegrationSettingsRequest generates requests for ListDbaasIntegrationSettings
 func NewListDbaasIntegrationSettingsRequest(server string, integrationType string, sourceType string, destType string) (*http.Request, error) {
 	var err error
@@ -7074,6 +7437,121 @@ func NewListDbaasIntegrationTypesRequest(server string) (*http.Request, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	return req, nil
+}
+
+// NewDeleteDbaasIntegrationRequest generates requests for DeleteDbaasIntegration
+func NewDeleteDbaasIntegrationRequest(server string, integrationUuid string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "integration-uuid", runtime.ParamLocationPath, integrationUuid)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/dbaas-integration/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("DELETE", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetDbaasIntegrationRequest generates requests for GetDbaasIntegration
+func NewGetDbaasIntegrationRequest(server string, integrationUuid string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "integration-uuid", runtime.ParamLocationPath, integrationUuid)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/dbaas-integration/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewUpdateDbaasIntegrationRequest calls the generic UpdateDbaasIntegration builder with application/json body
+func NewUpdateDbaasIntegrationRequest(server string, integrationUuid string, body UpdateDbaasIntegrationJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUpdateDbaasIntegrationRequestWithBody(server, integrationUuid, "application/json", bodyReader)
+}
+
+// NewUpdateDbaasIntegrationRequestWithBody generates requests for UpdateDbaasIntegration with any type of body
+func NewUpdateDbaasIntegrationRequestWithBody(server string, integrationUuid string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "integration-uuid", runtime.ParamLocationPath, integrationUuid)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/dbaas-integration/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PUT", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
 
 	return req, nil
 }
@@ -7638,6 +8116,100 @@ func NewCreateDbaasServiceRequestWithBody(server string, contentType string, bod
 	}
 
 	operationPath := fmt.Sprintf("/dbaas-service")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewGetDbaasServiceLogsRequest calls the generic GetDbaasServiceLogs builder with application/json body
+func NewGetDbaasServiceLogsRequest(server string, serviceName string, body GetDbaasServiceLogsJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewGetDbaasServiceLogsRequestWithBody(server, serviceName, "application/json", bodyReader)
+}
+
+// NewGetDbaasServiceLogsRequestWithBody generates requests for GetDbaasServiceLogs with any type of body
+func NewGetDbaasServiceLogsRequestWithBody(server string, serviceName string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "service-name", runtime.ParamLocationPath, serviceName)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/dbaas-service-logs/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewGetDbaasServiceMetricsRequest calls the generic GetDbaasServiceMetrics builder with application/json body
+func NewGetDbaasServiceMetricsRequest(server string, serviceName string, body GetDbaasServiceMetricsJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewGetDbaasServiceMetricsRequestWithBody(server, serviceName, "application/json", bodyReader)
+}
+
+// NewGetDbaasServiceMetricsRequestWithBody generates requests for GetDbaasServiceMetrics with any type of body
+func NewGetDbaasServiceMetricsRequestWithBody(server string, serviceName string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "service-name", runtime.ParamLocationPath, serviceName)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/dbaas-service-metrics/%s", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -12365,11 +12937,27 @@ type ClientWithResponsesInterface interface {
 	// GetDbaasCaCertificate request
 	GetDbaasCaCertificateWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetDbaasCaCertificateResponse, error)
 
+	// CreateDbaasIntegration request with any body
+	CreateDbaasIntegrationWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateDbaasIntegrationResponse, error)
+
+	CreateDbaasIntegrationWithResponse(ctx context.Context, body CreateDbaasIntegrationJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateDbaasIntegrationResponse, error)
+
 	// ListDbaasIntegrationSettings request
 	ListDbaasIntegrationSettingsWithResponse(ctx context.Context, integrationType string, sourceType string, destType string, reqEditors ...RequestEditorFn) (*ListDbaasIntegrationSettingsResponse, error)
 
 	// ListDbaasIntegrationTypes request
 	ListDbaasIntegrationTypesWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListDbaasIntegrationTypesResponse, error)
+
+	// DeleteDbaasIntegration request
+	DeleteDbaasIntegrationWithResponse(ctx context.Context, integrationUuid string, reqEditors ...RequestEditorFn) (*DeleteDbaasIntegrationResponse, error)
+
+	// GetDbaasIntegration request
+	GetDbaasIntegrationWithResponse(ctx context.Context, integrationUuid string, reqEditors ...RequestEditorFn) (*GetDbaasIntegrationResponse, error)
+
+	// UpdateDbaasIntegration request with any body
+	UpdateDbaasIntegrationWithBodyWithResponse(ctx context.Context, integrationUuid string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateDbaasIntegrationResponse, error)
+
+	UpdateDbaasIntegrationWithResponse(ctx context.Context, integrationUuid string, body UpdateDbaasIntegrationJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateDbaasIntegrationResponse, error)
 
 	// GetDbaasServiceKafka request
 	GetDbaasServiceKafkaWithResponse(ctx context.Context, name DbaasServiceName, reqEditors ...RequestEditorFn) (*GetDbaasServiceKafkaResponse, error)
@@ -12430,6 +13018,16 @@ type ClientWithResponsesInterface interface {
 	CreateDbaasServiceWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateDbaasServiceResponse, error)
 
 	CreateDbaasServiceWithResponse(ctx context.Context, body CreateDbaasServiceJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateDbaasServiceResponse, error)
+
+	// GetDbaasServiceLogs request with any body
+	GetDbaasServiceLogsWithBodyWithResponse(ctx context.Context, serviceName string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*GetDbaasServiceLogsResponse, error)
+
+	GetDbaasServiceLogsWithResponse(ctx context.Context, serviceName string, body GetDbaasServiceLogsJSONRequestBody, reqEditors ...RequestEditorFn) (*GetDbaasServiceLogsResponse, error)
+
+	// GetDbaasServiceMetrics request with any body
+	GetDbaasServiceMetricsWithBodyWithResponse(ctx context.Context, serviceName string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*GetDbaasServiceMetricsResponse, error)
+
+	GetDbaasServiceMetricsWithResponse(ctx context.Context, serviceName string, body GetDbaasServiceMetricsJSONRequestBody, reqEditors ...RequestEditorFn) (*GetDbaasServiceMetricsResponse, error)
 
 	// ListDbaasServiceTypes request
 	ListDbaasServiceTypesWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListDbaasServiceTypesResponse, error)
@@ -13123,6 +13721,28 @@ func (r GetDbaasCaCertificateResponse) StatusCode() int {
 	return 0
 }
 
+type CreateDbaasIntegrationResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *DbaasIntegration
+}
+
+// Status returns HTTPResponse.Status
+func (r CreateDbaasIntegrationResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CreateDbaasIntegrationResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type ListDbaasIntegrationSettingsResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -13157,7 +13777,7 @@ type ListDbaasIntegrationTypesResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *struct {
-		DbaasIntegrations *[]DbaasIntegration `json:"dbaas-integrations,omitempty"`
+		DbaasIntegrationTypes *[]DbaasIntegrationType `json:"dbaas-integration-types,omitempty"`
 	}
 }
 
@@ -13171,6 +13791,72 @@ func (r ListDbaasIntegrationTypesResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r ListDbaasIntegrationTypesResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type DeleteDbaasIntegrationResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *DbaasIntegration
+}
+
+// Status returns HTTPResponse.Status
+func (r DeleteDbaasIntegrationResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DeleteDbaasIntegrationResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetDbaasIntegrationResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *DbaasIntegration
+}
+
+// Status returns HTTPResponse.Status
+func (r GetDbaasIntegrationResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetDbaasIntegrationResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UpdateDbaasIntegrationResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *DbaasIntegration
+}
+
+// Status returns HTTPResponse.Status
+func (r UpdateDbaasIntegrationResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UpdateDbaasIntegrationResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -13481,6 +14167,52 @@ func (r CreateDbaasServiceResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r CreateDbaasServiceResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetDbaasServiceLogsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *DbaasServiceLogs
+}
+
+// Status returns HTTPResponse.Status
+func (r GetDbaasServiceLogsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetDbaasServiceLogsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetDbaasServiceMetricsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		Metrics *map[string]interface{} `json:"metrics,omitempty"`
+	}
+}
+
+// Status returns HTTPResponse.Status
+func (r GetDbaasServiceMetricsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetDbaasServiceMetricsResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -16306,6 +17038,23 @@ func (c *ClientWithResponses) GetDbaasCaCertificateWithResponse(ctx context.Cont
 	return ParseGetDbaasCaCertificateResponse(rsp)
 }
 
+// CreateDbaasIntegrationWithBodyWithResponse request with arbitrary body returning *CreateDbaasIntegrationResponse
+func (c *ClientWithResponses) CreateDbaasIntegrationWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateDbaasIntegrationResponse, error) {
+	rsp, err := c.CreateDbaasIntegrationWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateDbaasIntegrationResponse(rsp)
+}
+
+func (c *ClientWithResponses) CreateDbaasIntegrationWithResponse(ctx context.Context, body CreateDbaasIntegrationJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateDbaasIntegrationResponse, error) {
+	rsp, err := c.CreateDbaasIntegration(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateDbaasIntegrationResponse(rsp)
+}
+
 // ListDbaasIntegrationSettingsWithResponse request returning *ListDbaasIntegrationSettingsResponse
 func (c *ClientWithResponses) ListDbaasIntegrationSettingsWithResponse(ctx context.Context, integrationType string, sourceType string, destType string, reqEditors ...RequestEditorFn) (*ListDbaasIntegrationSettingsResponse, error) {
 	rsp, err := c.ListDbaasIntegrationSettings(ctx, integrationType, sourceType, destType, reqEditors...)
@@ -16322,6 +17071,41 @@ func (c *ClientWithResponses) ListDbaasIntegrationTypesWithResponse(ctx context.
 		return nil, err
 	}
 	return ParseListDbaasIntegrationTypesResponse(rsp)
+}
+
+// DeleteDbaasIntegrationWithResponse request returning *DeleteDbaasIntegrationResponse
+func (c *ClientWithResponses) DeleteDbaasIntegrationWithResponse(ctx context.Context, integrationUuid string, reqEditors ...RequestEditorFn) (*DeleteDbaasIntegrationResponse, error) {
+	rsp, err := c.DeleteDbaasIntegration(ctx, integrationUuid, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDeleteDbaasIntegrationResponse(rsp)
+}
+
+// GetDbaasIntegrationWithResponse request returning *GetDbaasIntegrationResponse
+func (c *ClientWithResponses) GetDbaasIntegrationWithResponse(ctx context.Context, integrationUuid string, reqEditors ...RequestEditorFn) (*GetDbaasIntegrationResponse, error) {
+	rsp, err := c.GetDbaasIntegration(ctx, integrationUuid, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetDbaasIntegrationResponse(rsp)
+}
+
+// UpdateDbaasIntegrationWithBodyWithResponse request with arbitrary body returning *UpdateDbaasIntegrationResponse
+func (c *ClientWithResponses) UpdateDbaasIntegrationWithBodyWithResponse(ctx context.Context, integrationUuid string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateDbaasIntegrationResponse, error) {
+	rsp, err := c.UpdateDbaasIntegrationWithBody(ctx, integrationUuid, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateDbaasIntegrationResponse(rsp)
+}
+
+func (c *ClientWithResponses) UpdateDbaasIntegrationWithResponse(ctx context.Context, integrationUuid string, body UpdateDbaasIntegrationJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateDbaasIntegrationResponse, error) {
+	rsp, err := c.UpdateDbaasIntegration(ctx, integrationUuid, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateDbaasIntegrationResponse(rsp)
 }
 
 // GetDbaasServiceKafkaWithResponse request returning *GetDbaasServiceKafkaResponse
@@ -16520,6 +17304,40 @@ func (c *ClientWithResponses) CreateDbaasServiceWithResponse(ctx context.Context
 		return nil, err
 	}
 	return ParseCreateDbaasServiceResponse(rsp)
+}
+
+// GetDbaasServiceLogsWithBodyWithResponse request with arbitrary body returning *GetDbaasServiceLogsResponse
+func (c *ClientWithResponses) GetDbaasServiceLogsWithBodyWithResponse(ctx context.Context, serviceName string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*GetDbaasServiceLogsResponse, error) {
+	rsp, err := c.GetDbaasServiceLogsWithBody(ctx, serviceName, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetDbaasServiceLogsResponse(rsp)
+}
+
+func (c *ClientWithResponses) GetDbaasServiceLogsWithResponse(ctx context.Context, serviceName string, body GetDbaasServiceLogsJSONRequestBody, reqEditors ...RequestEditorFn) (*GetDbaasServiceLogsResponse, error) {
+	rsp, err := c.GetDbaasServiceLogs(ctx, serviceName, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetDbaasServiceLogsResponse(rsp)
+}
+
+// GetDbaasServiceMetricsWithBodyWithResponse request with arbitrary body returning *GetDbaasServiceMetricsResponse
+func (c *ClientWithResponses) GetDbaasServiceMetricsWithBodyWithResponse(ctx context.Context, serviceName string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*GetDbaasServiceMetricsResponse, error) {
+	rsp, err := c.GetDbaasServiceMetricsWithBody(ctx, serviceName, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetDbaasServiceMetricsResponse(rsp)
+}
+
+func (c *ClientWithResponses) GetDbaasServiceMetricsWithResponse(ctx context.Context, serviceName string, body GetDbaasServiceMetricsJSONRequestBody, reqEditors ...RequestEditorFn) (*GetDbaasServiceMetricsResponse, error) {
+	rsp, err := c.GetDbaasServiceMetrics(ctx, serviceName, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetDbaasServiceMetricsResponse(rsp)
 }
 
 // ListDbaasServiceTypesWithResponse request returning *ListDbaasServiceTypesResponse
@@ -18223,6 +19041,32 @@ func ParseGetDbaasCaCertificateResponse(rsp *http.Response) (*GetDbaasCaCertific
 	return response, nil
 }
 
+// ParseCreateDbaasIntegrationResponse parses an HTTP response from a CreateDbaasIntegrationWithResponse call
+func ParseCreateDbaasIntegrationResponse(rsp *http.Response) (*CreateDbaasIntegrationResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CreateDbaasIntegrationResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest DbaasIntegration
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
 // ParseListDbaasIntegrationSettingsResponse parses an HTTP response from a ListDbaasIntegrationSettingsWithResponse call
 func ParseListDbaasIntegrationSettingsResponse(rsp *http.Response) (*ListDbaasIntegrationSettingsResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
@@ -18273,8 +19117,86 @@ func ParseListDbaasIntegrationTypesResponse(rsp *http.Response) (*ListDbaasInteg
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest struct {
-			DbaasIntegrations *[]DbaasIntegration `json:"dbaas-integrations,omitempty"`
+			DbaasIntegrationTypes *[]DbaasIntegrationType `json:"dbaas-integration-types,omitempty"`
 		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseDeleteDbaasIntegrationResponse parses an HTTP response from a DeleteDbaasIntegrationWithResponse call
+func ParseDeleteDbaasIntegrationResponse(rsp *http.Response) (*DeleteDbaasIntegrationResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DeleteDbaasIntegrationResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest DbaasIntegration
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetDbaasIntegrationResponse parses an HTTP response from a GetDbaasIntegrationWithResponse call
+func ParseGetDbaasIntegrationResponse(rsp *http.Response) (*GetDbaasIntegrationResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetDbaasIntegrationResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest DbaasIntegration
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUpdateDbaasIntegrationResponse parses an HTTP response from a UpdateDbaasIntegrationWithResponse call
+func ParseUpdateDbaasIntegrationResponse(rsp *http.Response) (*UpdateDbaasIntegrationResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UpdateDbaasIntegrationResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest DbaasIntegration
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -18641,6 +19563,60 @@ func ParseCreateDbaasServiceResponse(rsp *http.Response) (*CreateDbaasServiceRes
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest DbaasServiceCommon
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetDbaasServiceLogsResponse parses an HTTP response from a GetDbaasServiceLogsWithResponse call
+func ParseGetDbaasServiceLogsResponse(rsp *http.Response) (*GetDbaasServiceLogsResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetDbaasServiceLogsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest DbaasServiceLogs
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetDbaasServiceMetricsResponse parses an HTTP response from a GetDbaasServiceMetricsWithResponse call
+func ParseGetDbaasServiceMetricsResponse(rsp *http.Response) (*GetDbaasServiceMetricsResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetDbaasServiceMetricsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			Metrics *map[string]interface{} `json:"metrics,omitempty"`
+		}
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/vendor/github.com/exoscale/egoscale/v2/sks_cluster.go
+++ b/vendor/github.com/exoscale/egoscale/v2/sks_cluster.go
@@ -15,7 +15,7 @@ type SKSClusterOIDCConfig struct {
 	GroupsClaim    *string
 	GroupsPrefix   *string
 	IssuerURL      *string `req-for:"create"`
-	RequiredClaim  *string
+	RequiredClaim  *map[string]string
 	UsernameClaim  *string
 	UsernamePrefix *string
 }
@@ -32,11 +32,16 @@ func CreateSKSClusterWithOIDC(v *SKSClusterOIDCConfig) CreateSKSClusterOpt {
 
 		if v != nil {
 			b.Oidc = &oapi.SksOidc{
-				ClientId:       *v.ClientID,
-				GroupsClaim:    v.GroupsClaim,
-				GroupsPrefix:   v.GroupsPrefix,
-				IssuerUrl:      *v.IssuerURL,
-				RequiredClaim:  v.RequiredClaim,
+				ClientId:     *v.ClientID,
+				GroupsClaim:  v.GroupsClaim,
+				GroupsPrefix: v.GroupsPrefix,
+				IssuerUrl:    *v.IssuerURL,
+				RequiredClaim: func() *oapi.SksOidc_RequiredClaim {
+					if v.RequiredClaim != nil {
+						return &oapi.SksOidc_RequiredClaim{AdditionalProperties: *v.RequiredClaim}
+					}
+					return nil
+				}(),
 				UsernameClaim:  v.UsernameClaim,
 				UsernamePrefix: v.UsernamePrefix,
 			}

--- a/vendor/github.com/exoscale/egoscale/version/version.go
+++ b/vendor/github.com/exoscale/egoscale/version/version.go
@@ -2,4 +2,4 @@
 package version
 
 // Version represents the current egoscale version.
-const Version = "0.83.0"
+const Version = "0.84.1"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -75,7 +75,7 @@ github.com/davecgh/go-spew/spew
 # github.com/deepmap/oapi-codegen v1.6.1
 github.com/deepmap/oapi-codegen/pkg/runtime
 github.com/deepmap/oapi-codegen/pkg/types
-# github.com/exoscale/egoscale v0.83.0
+# github.com/exoscale/egoscale v0.84.1
 ## explicit
 github.com/exoscale/egoscale
 github.com/exoscale/egoscale/v2

--- a/website/docs/r/instance_pool.html.markdown
+++ b/website/docs/r/instance_pool.html.markdown
@@ -47,7 +47,7 @@ resource "exoscale_instance_pool" "webapp" {
   name = "my-web-app"
   size = 3
   template_id = data.exoscale_compute_template.webapp.id
-  instance_type = "medium"
+  instance_type = "standard.medium"
   disk_size = 50
   key_pair = exoscale_ssh_keypair.webapp.name
   instance_prefix = "my-web-app"

--- a/website/docs/r/sks_cluster.html.markdown
+++ b/website/docs/r/sks_cluster.html.markdown
@@ -54,7 +54,7 @@ The `oidc` block supports:
 * `issuer_url` - (Required) The OpenID provider URL.
 * `groups_claim` - An OpenID JWT claim to use as the user's group.
 * `groups_prefix` - An OpenID prefix prepended to group claims.
-* `required_claim` - A `KEY=VALUE` pair that describes a required claim in the OpenID Token.
+* `required_claim` - A map of key/value pairs that describes a required claim in the OpenID Token.
 * `username_claim` - An OpenID JWT claim to use as the user name.
 * `username_prefix` - An OpenID prefix prepended to username claims.
 

--- a/website/docs/r/sks_nodepool.html.markdown
+++ b/website/docs/r/sks_nodepool.html.markdown
@@ -64,6 +64,10 @@ resource "exoscale_sks_nodepool" "ci-builders" {
   labels = {
     role = "ci-builders"
   }
+
+  taints = {
+    ci = "ci:NoSchedule"
+  }
 }
 ```
 
@@ -83,6 +87,7 @@ resource "exoscale_sks_nodepool" "ci-builders" {
 * `description` - The description of the SKS Nodepool.
 * `deploy_target_id` - A Deploy Target ID to deploy managed Compute instances to.
 * `labels` - A map of key/value labels.
+* `taints` - A map of key/value [Kubernetes taints][k8s-taints] (value format: `VALUE:EFFECT`).
 
 
 ## Attributes Reference
@@ -106,6 +111,7 @@ $ terraform import exoscale_sks_nodepool.ci-builders eb556678-ec59-4be6-8c54-040
 ```
 
 
+[k8s-taints]: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
 [r-sks_cluster]: sks_cluster.html
 [sks-doc]: https://community.exoscale.com/documentation/sks/
 [type]: https://www.exoscale.com/pricing/#/compute/


### PR DESCRIPTION
## sks_cluster: change OIDC required_claim attribute type

This change updates the `exoscale_sks_cluster.oidc.required_claim`
attribute to be a map type instead of a string, following recent
Exoscale API change.

## sks_nodepool: add support for K8s taints

This change adds support for Kubernetes taints to the
`exoscale_sks_nodepool` resource.