### PR TITLE
Switch exoscale_security_group* resources to public API

### DIFF
--- a/exoscale/datasource_exoscale_security_group_test.go
+++ b/exoscale/datasource_exoscale_security_group_test.go
@@ -36,8 +36,8 @@ data "exoscale_security_group" "by-id" {
 }`, testAccDataSourceSecurityGroupName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccDataSourceSecurityGroupAttributes("data.exoscale_security_group.by-id", testAttrs{
-						"id":   validation.ToDiagFunc(validation.IsUUID),
-						"name": validateString(testAccDataSourceSecurityGroupName),
+						dsSecurityGroupAttrID:   validation.ToDiagFunc(validation.IsUUID),
+						dsSecurityGroupAttrName: validateString(testAccDataSourceSecurityGroupName),
 					}),
 				),
 			},
@@ -52,8 +52,8 @@ data "exoscale_security_group" "by-name" {
 }`, testAccDataSourceSecurityGroupName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccDataSourceSecurityGroupAttributes("data.exoscale_security_group.by-name", testAttrs{
-						"id":   validation.ToDiagFunc(validation.IsUUID),
-						"name": validateString(testAccDataSourceSecurityGroupName),
+						dsSecurityGroupAttrID:   validation.ToDiagFunc(validation.IsUUID),
+						dsSecurityGroupAttrName: validateString(testAccDataSourceSecurityGroupName),
 					}),
 				),
 			},

--- a/exoscale/provider.go
+++ b/exoscale/provider.go
@@ -24,6 +24,13 @@ import (
 const (
 	legacyAPIVersion = "compute"
 	apiVersion       = "v1"
+
+	// FIXME: defaultZone is used for global resources management, as at the
+	//  time of this implementation the Exoscale public API V2 doesn't
+	//  expose a global endpoint – only zone-local endpoints.
+	//  This should be removed once the Exoscale public API V2 exposes a
+	//  global endpoint.
+	defaultZone = "ch-gva-2"
 )
 
 func init() {

--- a/exoscale/resource_exoscale_compute_test.go
+++ b/exoscale/resource_exoscale_compute_test.go
@@ -133,7 +133,6 @@ EOF
 )
 
 func TestAccResourceCompute(t *testing.T) {
-	sg := new(egoscale.SecurityGroup)
 	vm := new(egoscale.VirtualMachine)
 
 	resource.Test(t, resource.TestCase{
@@ -182,7 +181,6 @@ func TestAccResourceCompute(t *testing.T) {
 			{
 				Config: testAccResourceComputeConfigUpdate,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckResourceSecurityGroupExists("exoscale_security_group.sg", sg),
 					testAccCheckResourceComputeExists("exoscale_compute.vm", vm),
 					testAccCheckResourceCompute(vm),
 					testAccCheckResourceComputeAttributes(testAttrs{

--- a/exoscale/resource_exoscale_security_group.go
+++ b/exoscale/resource_exoscale_security_group.go
@@ -2,10 +2,21 @@ package exoscale
 
 import (
 	"context"
+	"errors"
 	"log"
+	"strings"
 
-	"github.com/exoscale/egoscale"
+	egoscale "github.com/exoscale/egoscale/v2"
+	exoapi "github.com/exoscale/egoscale/v2/api"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+const (
+	resSecurityGroupAttrDescription     = "description"
+	resSecurityGroupAttrExternalSources = "external_sources"
+	resSecurityGroupAttrName            = "name"
 )
 
 func resourceSecurityGroupIDString(d resourceIDStringer) string {
@@ -15,22 +26,30 @@ func resourceSecurityGroupIDString(d resourceIDStringer) string {
 func resourceSecurityGroup() *schema.Resource {
 	return &schema.Resource{
 		Schema: map[string]*schema.Schema{
-			"name": {
+			resSecurityGroupAttrDescription: {
 				Type:     schema.TypeString,
-				ForceNew: true,
-				Required: true,
-			},
-			"description": {
-				Type:     schema.TypeString,
-				ForceNew: true,
 				Optional: true,
+				ForceNew: true,
+			},
+			resSecurityGroupAttrExternalSources: {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validation.IsCIDRNetwork(0, 128),
+				},
+			},
+			resSecurityGroupAttrName: {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
 			},
 		},
 
-		Create: resourceSecurityGroupCreate,
-		Read:   resourceSecurityGroupRead,
-		Delete: resourceSecurityGroupDelete,
-		Exists: resourceSecurityGroupExists,
+		CreateContext: resourceSecurityGroupCreate,
+		ReadContext:   resourceSecurityGroupRead,
+		UpdateContext: resourceSecurityGroupUpdate,
+		DeleteContext: resourceSecurityGroupDelete,
 
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceSecurityGroupImport,
@@ -44,99 +63,135 @@ func resourceSecurityGroup() *schema.Resource {
 	}
 }
 
-func resourceSecurityGroupCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceSecurityGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	log.Printf("[DEBUG] %s: beginning create", resourceSecurityGroupIDString(d))
 
-	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutCreate))
+	zone := defaultZone
+
+	ctx, cancel := context.WithTimeout(ctx, d.Timeout(schema.TimeoutCreate))
+	ctx = exoapi.WithEndpoint(ctx, exoapi.NewReqEndpoint(getEnvironment(meta), zone))
 	defer cancel()
 
 	client := GetComputeClient(meta)
 
-	resp, err := client.RequestWithContext(ctx, &egoscale.CreateSecurityGroup{
-		Name:        d.Get("name").(string),
-		Description: d.Get("description").(string),
+	securityGroup, err := client.CreateSecurityGroup(ctx, zone, &egoscale.SecurityGroup{
+		Name:        nonEmptyStringPtr(d.Get(resSecurityGroupAttrName).(string)),
+		Description: nonEmptyStringPtr(d.Get(resSecurityGroupAttrDescription).(string)),
 	})
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
-	sg := resp.(*egoscale.SecurityGroup)
+	if externalSourcesSet, ok := d.GetOk(resSecurityGroupAttrExternalSources); ok {
+		for _, cidr := range externalSourcesSet.(*schema.Set).List() {
+			if err := client.AddExternalSourceToSecurityGroup(ctx, zone, securityGroup, cidr.(string)); err != nil {
+				return diag.FromErr(err)
+			}
+		}
+	}
 
-	d.SetId(sg.ID.String())
+	d.SetId(*securityGroup.ID)
 
 	log.Printf("[DEBUG] %s: create finished successfully", resourceSecurityGroupIDString(d))
 
-	return resourceSecurityGroupRead(d, meta)
+	return resourceSecurityGroupRead(ctx, d, meta)
 }
 
-func resourceSecurityGroupExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutRead))
-	defer cancel()
-
-	client := GetComputeClient(meta)
-
-	id, err := egoscale.ParseUUID(d.Id())
-	if err != nil {
-		return false, err
-	}
-
-	sg := &egoscale.SecurityGroup{
-		ID: id,
-	}
-
-	_, err = client.GetWithContext(ctx, sg)
-	if err != nil {
-		e := handleNotFound(d, err)
-		return d.Id() != "", e
-	}
-
-	return true, nil
-}
-
-func resourceSecurityGroupRead(d *schema.ResourceData, meta interface{}) error {
+func resourceSecurityGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	log.Printf("[DEBUG] %s: beginning read", resourceSecurityGroupIDString(d))
 
-	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutRead))
+	zone := defaultZone
+
+	ctx, cancel := context.WithTimeout(ctx, d.Timeout(schema.TimeoutRead))
+	ctx = exoapi.WithEndpoint(ctx, exoapi.NewReqEndpoint(getEnvironment(meta), zone))
 	defer cancel()
 
 	client := GetComputeClient(meta)
 
-	id, err := egoscale.ParseUUID(d.Id())
+	securityGroup, err := client.GetSecurityGroup(ctx, zone, d.Id())
 	if err != nil {
-		return err
+		if errors.Is(err, exoapi.ErrNotFound) {
+			// Resource doesn't exist anymore, signaling the core to remove it from the state.
+			d.SetId("")
+			return nil
+		}
+		return diag.FromErr(err)
 	}
-
-	resp, err := client.GetWithContext(ctx, &egoscale.SecurityGroup{
-		ID: id,
-	})
-	if err != nil {
-		return handleNotFound(d, err)
-	}
-
-	sg := resp.(*egoscale.SecurityGroup)
 
 	log.Printf("[DEBUG] %s: read finished successfully", resourceSecurityGroupIDString(d))
 
-	return resourceSecurityGroupApply(d, sg)
+	return diag.FromErr(resourceSecurityGroupApply(ctx, d, securityGroup))
 }
 
-func resourceSecurityGroupDelete(d *schema.ResourceData, meta interface{}) error {
-	log.Printf("[DEBUG] %s: beginning delete", resourceSecurityGroupIDString(d))
+func resourceSecurityGroupUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	log.Printf("[DEBUG] %s: beginning update", resourceSecurityGroupIDString(d))
 
-	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutDelete))
+	zone := defaultZone
+
+	ctx, cancel := context.WithTimeout(ctx, d.Timeout(schema.TimeoutDelete))
+	ctx = exoapi.WithEndpoint(ctx, exoapi.NewReqEndpoint(getEnvironment(meta), zone))
 	defer cancel()
 
 	client := GetComputeClient(meta)
 
-	id, err := egoscale.ParseUUID(d.Id())
+	securityGroup, err := client.GetSecurityGroup(ctx, zone, d.Id())
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
-	sg := &egoscale.DeleteSecurityGroup{ID: id}
+	if d.HasChange(resSecurityGroupAttrExternalSources) {
+		o, n := d.GetChange(resSecurityGroupAttrExternalSources)
+		old := o.(*schema.Set)
+		cur := n.(*schema.Set)
 
-	if err := client.BooleanRequestWithContext(ctx, sg); err != nil {
-		return err
+		added := cur.Difference(old)
+		if added.Len() > 0 {
+			for _, cidr := range added.List() {
+				if err := client.AddExternalSourceToSecurityGroup(
+					ctx,
+					zone,
+					securityGroup,
+					cidr.(string),
+				); err != nil {
+					return diag.FromErr(err)
+				}
+			}
+		}
+
+		removed := old.Difference(cur)
+		if removed.Len() > 0 {
+			for _, cidr := range removed.List() {
+				if err := client.RemoveExternalSourceFromSecurityGroup(
+					ctx,
+					zone,
+					securityGroup,
+					cidr.(string),
+				); err != nil {
+					return diag.FromErr(err)
+				}
+			}
+		}
+	}
+
+	log.Printf("[DEBUG] %s: update finished successfully", resourceSecurityGroupIDString(d))
+
+	return resourceSecurityGroupRead(ctx, d, meta)
+}
+
+func resourceSecurityGroupDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	log.Printf("[DEBUG] %s: beginning delete", resourceSecurityGroupIDString(d))
+
+	zone := defaultZone
+
+	ctx, cancel := context.WithTimeout(ctx, d.Timeout(schema.TimeoutDelete))
+	ctx = exoapi.WithEndpoint(ctx, exoapi.NewReqEndpoint(getEnvironment(meta), zone))
+	defer cancel()
+
+	client := GetComputeClient(meta)
+
+	securityGroupID := d.Id()
+	if err := client.DeleteSecurityGroup(ctx, zone, &egoscale.SecurityGroup{ID: &securityGroupID}); err != nil {
+		return diag.FromErr(err)
 	}
 
 	log.Printf("[DEBUG] %s: delete finished successfully", resourceSecurityGroupIDString(d))
@@ -144,70 +199,68 @@ func resourceSecurityGroupDelete(d *schema.ResourceData, meta interface{}) error
 	return nil
 }
 
-func resourceSecurityGroupImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceSecurityGroupImport(
+	ctx context.Context,
+	d *schema.ResourceData,
+	meta interface{},
+) ([]*schema.ResourceData, error) {
+	zone := defaultZone
+
 	ctx, cancel := context.WithTimeout(ctx, d.Timeout(schema.TimeoutRead))
+	ctx = exoapi.WithEndpoint(ctx, exoapi.NewReqEndpoint(getEnvironment(meta), zone))
 	defer cancel()
 
 	client := GetComputeClient(meta)
 
-	securityGroup := &egoscale.SecurityGroup{}
-
-	id, err := egoscale.ParseUUID(d.Id())
-	if err != nil {
-		securityGroup.Name = d.Id()
-	} else {
-		securityGroup.ID = id
-	}
-
-	resp, err := client.GetWithContext(ctx, securityGroup)
+	securityGroup, err := client.FindSecurityGroup(ctx, zone, d.Id())
 	if err != nil {
 		return nil, err
 	}
 
-	sg := resp.(*egoscale.SecurityGroup)
-	if err := resourceSecurityGroupApply(d, sg); err != nil {
+	if err := resourceSecurityGroupApply(ctx, d, securityGroup); err != nil {
 		return nil, err
 	}
 
-	ruleLength := len(sg.EgressRule) + len(sg.IngressRule)
-	resources := make([]*schema.ResourceData, 0, 1+ruleLength)
+	resources := make([]*schema.ResourceData, 0)
 	resources = append(resources, d)
 
-	for _, rule := range sg.EgressRule {
+	for _, securityGroupRule := range securityGroup.Rules {
 		resource := resourceSecurityGroupRule()
-		d := resource.Data(nil)
-		d.SetType("exoscale_security_group_rule")
-		d.Set("type", "EGRESS") // nolint: errcheck
-		err := resourceSecurityGroupRuleApply(d, sg, rule)
-		if err != nil {
+		rd := resource.Data(nil)
+		rd.SetType("exoscale_security_group_rule")
+
+		if err := rd.Set("type", strings.ToUpper(*securityGroupRule.FlowDirection)); err != nil {
 			return nil, err
 		}
 
-		resources = append(resources, d)
-	}
-	for _, rule := range sg.IngressRule {
-		resource := resourceSecurityGroupRule()
-		d := resource.Data(nil)
-		d.SetType("exoscale_security_group_rule")
-		d.Set("type", "INGRESS") // nolint: errcheck
-		err := resourceSecurityGroupRuleApply(d, sg, (egoscale.EgressRule)(rule))
-		if err != nil {
+		if err := resourceSecurityGroupRuleApply(ctx, rd, meta, securityGroup, securityGroupRule); err != nil {
 			return nil, err
 		}
 
-		resources = append(resources, d)
+		resources = append(resources, rd)
 	}
 
 	return resources, nil
 }
 
-func resourceSecurityGroupApply(d *schema.ResourceData, securityGroup *egoscale.SecurityGroup) error {
-	d.SetId(securityGroup.ID.String())
-	if err := d.Set("name", securityGroup.Name); err != nil {
+func resourceSecurityGroupApply(
+	_ context.Context,
+	d *schema.ResourceData,
+	securityGroup *egoscale.SecurityGroup,
+) error {
+	if err := d.Set(resSecurityGroupAttrName, *securityGroup.Name); err != nil {
 		return err
 	}
-	if err := d.Set("description", securityGroup.Description); err != nil {
+
+	if securityGroup.ExternalSources != nil {
+		if err := d.Set(resSecurityGroupAttrExternalSources, *securityGroup.ExternalSources); err != nil {
+			return err
+		}
+	}
+
+	if err := d.Set(resSecurityGroupAttrDescription, defaultString(securityGroup.Description, "")); err != nil {
 		return err
 	}
+
 	return nil
 }

--- a/website/docs/r/security_group.html.markdown
+++ b/website/docs/r/security_group.html.markdown
@@ -15,8 +15,9 @@ Provides an Exoscale [Security Group][sg-doc] resource. This can be used to crea
 
 ```hcl
 resource "exoscale_security_group" "web" {
-  name        = "web"
-  description = "Webservers"
+  name             = "web"
+  description      = "Webservers"
+  external_sources = ["1.2.3.4/32", "5.6.7.8/32"]
 }
 ```
 
@@ -26,7 +27,8 @@ resource "exoscale_security_group" "web" {
 In addition to the arguments listed above, the following attributes are exported:
 
 * `name` - (Required) The name of the Security Group.
-* `description` - A free-form text describing the Anti-Affinity Group purpose.
+* `description` - A free-form text describing the Security Group purpose.
+* `external_sources` - A list of external network sources in [CIDR][cidr] notation.
 
 
 ## Attributes Reference
@@ -38,18 +40,15 @@ In addition to the arguments listed above, the following attributes are exported
 
 ## Import
 
-An existing Security Group can be imported as a resource by name or ID:
+An existing Security Group can be imported as a resource by its ID:
 
 ```console
-# By name
-$ terraform import exoscale_security_group.http http
-
-# By ID
 $ terraform import exoscale_security_group.http eb556678-ec59-4be6-8c54-0406ae0f6da6
 ```
 
 ~> **NOTE:** Importing a `exoscale_security_group` resource also imports related [`exoscale_security_group_rule`][r-security_group_rule] resources.
 
 
+[cidr]: https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing#CIDR_notatio
 [r-security_group_rule]: security_group_rule.html
 [sg-doc]: https://community.exoscale.com/documentation/compute/security-groups/

--- a/website/docs/r/security_group_rule.html.markdown
+++ b/website/docs/r/security_group_rule.html.markdown
@@ -47,12 +47,18 @@ resource "exoscale_security_group_rule" "http" {
 
 In addition to the arguments listed above, the following attributes are exported:
 
-* n/a
+* `id` - The ID of the Security Group rule.
 
 
 ## Import
 
-This resource is automatically imported when importing an `exoscale_security_group` resource.
+An existing Security Group rule can be imported as a resource by `<SECURITY-GROUP-ID>/<SECURITY-GROUP-RULE-ID>`:
+
+```console
+$ terraform import exoscale_security_group_rule.http eb556678-ec59-4be6-8c54-0406ae0f6da6/846831cb-a0fc-454b-9abd-cb526559fcf9
+```
+
+~> **NOTE:** This resource is automatically imported when importing an `exoscale_security_group` resource.
 
 
 [cidr]: https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing#CIDR_notation


### PR DESCRIPTION
This changes overhauls the `exoscale_security_group*` resources and
`exoscale_security_group` data source to use the new Exoscale public API
(aka V2).