### PR TITLE
Add new resource "exoscale_ssh_key'

### DIFF
--- a/exoscale/provider.go
+++ b/exoscale/provider.go
@@ -176,6 +176,7 @@ func Provider() *schema.Provider {
 			"exoscale_security_group_rules": resourceSecurityGroupRules(),
 			"exoscale_sks_cluster":          resourceSKSCluster(),
 			"exoscale_sks_nodepool":         resourceSKSNodepool(),
+			"exoscale_ssh_key":              resourceSSHKey(),
 			"exoscale_ssh_keypair":          resourceSSHKeypair(),
 		},
 

--- a/exoscale/resource_exoscale_ssh_key.go
+++ b/exoscale/resource_exoscale_ssh_key.go
@@ -1,0 +1,149 @@
+package exoscale
+
+import (
+	"context"
+	"errors"
+	"log"
+
+	egoscale "github.com/exoscale/egoscale/v2"
+	exoapi "github.com/exoscale/egoscale/v2/api"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+const (
+	resSSHKeyAttrFingerprint = "fingerprint"
+	resSSHKeyAttrName        = "name"
+	resSSHKeyAttrPublicKey   = "public_key"
+)
+
+func resourceSSHKeyIDString(d resourceIDStringer) string {
+	return resourceIDString(d, "exoscale_ssh_key")
+}
+
+func resourceSSHKey() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			resSSHKeyAttrFingerprint: {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			resSSHKeyAttrName: {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			resSSHKeyAttrPublicKey: {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+		},
+
+		CreateContext: resourceSSHKeyCreate,
+		ReadContext:   resourceSSHKeyRead,
+		DeleteContext: resourceSSHKeyDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(defaultTimeout),
+			Read:   schema.DefaultTimeout(defaultTimeout),
+			Delete: schema.DefaultTimeout(defaultTimeout),
+		},
+	}
+}
+
+func resourceSSHKeyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	log.Printf("[DEBUG] %s: beginning create", resourceSSHKeyIDString(d))
+
+	zone := defaultZone
+
+	ctx, cancel := context.WithTimeout(ctx, d.Timeout(schema.TimeoutCreate))
+	ctx = exoapi.WithEndpoint(ctx, exoapi.NewReqEndpoint(getEnvironment(meta), zone))
+	defer cancel()
+
+	client := GetComputeClient(meta)
+
+	publicKey, ok := d.GetOk(resSSHKeyAttrPublicKey)
+	if !ok {
+		return diag.Errorf("a value must be provided for attribute %q", resSSHKeyAttrPublicKey)
+	}
+
+	sshKey, err := client.RegisterSSHKey(
+		ctx,
+		zone,
+		d.Get(resSSHKeyAttrName).(string),
+		publicKey.(string),
+	)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(*sshKey.Name)
+
+	log.Printf("[DEBUG] %s: create finished successfully", resourceSSHKeyIDString(d))
+
+	return resourceSSHKeyRead(ctx, d, meta)
+}
+
+func resourceSSHKeyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	log.Printf("[DEBUG] %s: beginning read", resourceSSHKeyIDString(d))
+
+	zone := defaultZone
+
+	ctx, cancel := context.WithTimeout(ctx, d.Timeout(schema.TimeoutRead))
+	ctx = exoapi.WithEndpoint(ctx, exoapi.NewReqEndpoint(getEnvironment(meta), zone))
+	defer cancel()
+
+	client := GetComputeClient(meta)
+
+	securityGroup, err := client.GetSSHKey(ctx, zone, d.Id())
+	if err != nil {
+		if errors.Is(err, exoapi.ErrNotFound) {
+			// Resource doesn't exist anymore, signaling the core to remove it from the state.
+			d.SetId("")
+			return nil
+		}
+		return diag.FromErr(err)
+	}
+
+	log.Printf("[DEBUG] %s: read finished successfully", resourceSSHKeyIDString(d))
+
+	return diag.FromErr(resourceSSHKeyApply(ctx, d, securityGroup))
+}
+
+func resourceSSHKeyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	log.Printf("[DEBUG] %s: beginning delete", resourceSSHKeyIDString(d))
+
+	zone := defaultZone
+
+	ctx, cancel := context.WithTimeout(ctx, d.Timeout(schema.TimeoutDelete))
+	ctx = exoapi.WithEndpoint(ctx, exoapi.NewReqEndpoint(getEnvironment(meta), zone))
+	defer cancel()
+
+	client := GetComputeClient(meta)
+
+	if err := client.DeleteSSHKey(ctx, zone, &egoscale.SSHKey{Name: nonEmptyStringPtr(d.Id())}); err != nil {
+		return diag.FromErr(err)
+	}
+
+	log.Printf("[DEBUG] %s: delete finished successfully", resourceSSHKeyIDString(d))
+
+	return nil
+}
+
+func resourceSSHKeyApply(_ context.Context, d *schema.ResourceData, sshKey *egoscale.SSHKey) error {
+	if err := d.Set(resSSHKeyAttrName, *sshKey.Name); err != nil {
+		return err
+	}
+
+	if err := d.Set(resSSHKeyAttrFingerprint, *sshKey.Fingerprint); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/exoscale/resource_exoscale_ssh_key_test.go
+++ b/exoscale/resource_exoscale_ssh_key_test.go
@@ -1,0 +1,131 @@
+package exoscale
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"regexp"
+	"testing"
+
+	egoscale "github.com/exoscale/egoscale/v2"
+	exoapi "github.com/exoscale/egoscale/v2/api"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	testAccResourceSSHKeyName      = acctest.RandomWithPrefix(testPrefix)
+	testAccResourceSSHKeyPublicKey = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDN7L45b4vO2ytH68ZU" +
+		"C5PMS1b7JG78zGslwcJ0zolE5BuxsCYor248/FKGC5TXrME+yBu/uLqaAkioq4Wp1PzP6Zy5jEowWQDO" +
+		"deER7uu1GgZShcvly2Oaf/UKLqTdwL+U3tCknqHY63fOAi1lBwmNTUu1uZ24iNiogfhXwQn7HJLQK9vf" +
+		"oGwg+/qJIzeswR6XDa6qh0fuzdxWQ4JWHw2s8fv8WvGOlklmAg/uEi1kF5D6R7kJpOVaE20FLnT4sjA8" +
+		"1iErhMIH77OaZqQKiyVH3i5m/lkQI/2e25ml8aculaWzHOs4ctd7l+K1ZWFYje3qMBY1sar1gd787eaqk6RZ"
+
+	testAccResourceSSHKeyConfigCreate = fmt.Sprintf(`
+resource "exoscale_ssh_key" "test" {
+  name       = "%s"
+  public_key = "%s"
+}
+`,
+		testAccResourceSSHKeyName,
+		testAccResourceSSHKeyPublicKey,
+	)
+)
+
+func TestAccResourceSSHKey(t *testing.T) {
+	var (
+		r      = "exoscale_ssh_key.test"
+		sshKey egoscale.SSHKey
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckResourceSSHKeyDestroy(&sshKey),
+		Steps: []resource.TestStep{
+			{
+				// Create (missing public_key)
+				Config:      `resource "exoscale_ssh_key" "test" { name = "lolnope" }`,
+				ExpectError: regexp.MustCompile(`a value must be provided`),
+			},
+			{
+				// Create
+				Config: testAccResourceSSHKeyConfigCreate,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckResourceSSHKeyExists(r, &sshKey),
+					func(s *terraform.State) error {
+						a := assert.New(t)
+
+						a.Equal(testAccResourceSSHKeyName, *sshKey.Name)
+
+						return nil
+					},
+					checkResourceState(r, checkResourceStateValidateAttributes(testAttrs{
+						resSSHKeyAttrFingerprint: validation.ToDiagFunc(validation.NoZeroValues),
+						resSSHKeyAttrName:        validateString(testAccResourceSSHKeyName),
+					})),
+				),
+			},
+			{
+				// Import
+				ResourceName:            r,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{resSSHKeyAttrPublicKey},
+				ImportStateCheck: func(s []*terraform.InstanceState) error {
+					return checkResourceAttributes(
+						testAttrs{
+							resSSHKeyAttrFingerprint: validation.ToDiagFunc(validation.NoZeroValues),
+							resSSHKeyAttrName:        validateString(testAccResourceSSHKeyName),
+						},
+						s[0].Attributes)
+				},
+			},
+		},
+	})
+}
+
+func testAccCheckResourceSSHKeyExists(r string, sshKey *egoscale.SSHKey) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[r]
+		if !ok {
+			return errors.New("resource not found in the state")
+		}
+
+		if rs.Primary.ID == "" {
+			return errors.New("resource ID not set")
+		}
+
+		client := GetComputeClient(testAccProvider.Meta())
+
+		ctx := exoapi.WithEndpoint(context.Background(), exoapi.NewReqEndpoint(testEnvironment, testZoneName))
+		res, err := client.GetSSHKey(ctx, testZoneName, rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		*sshKey = *res
+		return nil
+	}
+}
+
+func testAccCheckResourceSSHKeyDestroy(sshKey *egoscale.SSHKey) resource.TestCheckFunc {
+	return func(_ *terraform.State) error {
+		client := GetComputeClient(testAccProvider.Meta())
+		ctx := exoapi.WithEndpoint(context.Background(), exoapi.NewReqEndpoint(testEnvironment, testZoneName))
+
+		_, err := client.GetSSHKey(ctx, testZoneName, *sshKey.Name)
+		if err != nil {
+			if errors.Is(err, exoapi.ErrNotFound) {
+				return nil
+			}
+
+			return err
+		}
+
+		return errors.New("SSH Key still exists")
+	}
+}

--- a/exoscale/resource_exoscale_ssh_keypair.go
+++ b/exoscale/resource_exoscale_ssh_keypair.go
@@ -50,6 +50,8 @@ func resourceSSHKeypair() *schema.Resource {
 			Read:   schema.DefaultTimeout(defaultTimeout),
 			Delete: schema.DefaultTimeout(defaultTimeout),
 		},
+
+		DeprecationMessage: "replaced by exoscale_ssh_key",
 	}
 }
 

--- a/website/docs/r/ssh_key.html.markdown
+++ b/website/docs/r/ssh_key.html.markdown
@@ -1,0 +1,46 @@
+---
+layout: "exoscale"
+page_title: "Exoscale: exoscale_ssh_key"
+sidebar_current: "docs-exoscale-ssh-key"
+description: |-
+  Provides an Exoscale SSH Key.
+---
+
+# exoscale\_ssh\_key
+
+Provides an Exoscale [SSH Key][ssh-keys-doc] resource. This can be used to create and delete SSH Keys.
+
+
+## Example Usage
+
+```hcl
+resource "exoscale_ssh_key" "example" {
+  name       = "admin"
+  public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDGRY..."
+}
+```
+
+
+## Arguments Reference
+
+* `name` - (Required) The name of the SSH Key.
+* `public_key` - (Required) A SSH public key that will be copied into the instances at **first** boot.
+
+
+## Attributes Reference
+
+In addition to the arguments listed above, the following attributes are exported:
+
+* `fingerprint` - The unique identifier of the SSH Key.
+
+
+## Import
+
+An existing SSH Key can be imported as a resource by name:
+
+```console
+$ terraform import exoscale_ssh_key.my-key my-key
+```
+
+
+[ssh-keys-doc]: https://community.exoscale.com/documentation/compute/ssh-keys/

--- a/website/docs/r/ssh_keypair.html.markdown
+++ b/website/docs/r/ssh_keypair.html.markdown
@@ -10,6 +10,7 @@ description: |-
 
 Provides an Exoscale [SSH Keypair][ssh-keypairs-doc] resource. This can be used to create and delete SSH Keypairs.
 
+!> **WARNING:** This resource is deprecated and will be removed in the next major version.
 
 ## Example Usage
 


### PR DESCRIPTION
This change introduces a new resource `exoscale_ssh_key` using the new
Exoscale public API; this deprecates the `exoscale_ssh_keypair`
resource.