### PR TITLE
Update security_group and security_group_rules schema

### DIFF
--- a/exoscale/resource_exoscale_instance_pool.go
+++ b/exoscale/resource_exoscale_instance_pool.go
@@ -123,13 +123,7 @@ func resourceInstancePool() *schema.Resource {
 			Computed:      true,
 			Deprecated:    `This attribute has been replaced by "instance_type".`,
 			ConflictsWith: []string{resInstancePoolAttrInstanceType},
-			ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
-				v := val.(string)
-				if strings.ContainsAny(v, "ABCDEFGHIJKLMNOPQRSTUVWXYZ") {
-					errs = append(errs, fmt.Errorf("%q must be lowercase, got: %q", key, v))
-				}
-				return
-			},
+			ValidateFunc:  validateLowercaseString,
 		},
 		resInstancePoolAttrSize: {
 			Type:         schema.TypeInt,

--- a/exoscale/resource_exoscale_security_group.go
+++ b/exoscale/resource_exoscale_security_group.go
@@ -47,10 +47,7 @@ func resourceSecurityGroupSchema() map[string]*schema.Schema {
 			// with uppercase letters with provider < v0.31.
 			// Let's ignore case of the name, assuming that anyway, it will be converted to lowercase.
 			DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-				if strings.ToLower(old) == strings.ToLower(new) {
-					return true
-				}
-				return false
+				return strings.EqualFold(old, new)
 			},
 		},
 	}

--- a/exoscale/resource_exoscale_security_group_rule.go
+++ b/exoscale/resource_exoscale_security_group_rule.go
@@ -58,7 +58,7 @@ func resourceSecurityGroupRule() *schema.Resource {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.IntBetween(0, 65535),
+				ValidateFunc: validation.IntBetween(1, 65535),
 				ConflictsWith: []string{
 					resSecurityGroupRuleAttrICMPCode,
 					resSecurityGroupRuleAttrICMPType,
@@ -125,7 +125,7 @@ func resourceSecurityGroupRule() *schema.Resource {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.IntBetween(0, 65535),
+				ValidateFunc: validation.IntBetween(1, 65535),
 				ConflictsWith: []string{
 					resSecurityGroupRuleAttrICMPCode,
 					resSecurityGroupRuleAttrICMPType,

--- a/exoscale/resource_exoscale_security_group_rules.go
+++ b/exoscale/resource_exoscale_security_group_rules.go
@@ -244,6 +244,7 @@ func resourceSecurityGroupRulesStateUpgradeV0(_ context.Context, rawState map[st
 
 					rules[idx] = rule
 					rawState[direction] = rules
+					patchRules = false
 				}
 			}
 		} else {

--- a/exoscale/resource_exoscale_security_group_test.go
+++ b/exoscale/resource_exoscale_security_group_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -159,4 +160,26 @@ func testAccCheckResourceSecurityGroupDestroy(securityGroup *egoscale.SecurityGr
 
 		return errors.New("Security Group still exists")
 	}
+}
+
+func TestAccCheckSecurityGroupMigrationSucceed(t *testing.T) {
+	legacyState := testAccCheckSecurityGroupMigrationStateDataV0()
+	expectedState := testAccCheckSecurityGroupMigrationStateDataV1()
+
+	migratedState, err := resourceSecurityGroupStateUpgradeV0(context.Background(), legacyState, nil)
+	if err != nil {
+		t.Fatalf("error migrating state: %s", err)
+	}
+
+	if !reflect.DeepEqual(expectedState, migratedState) {
+		t.Fatalf("migration error: expected: '%#v' \ngot: '%#v'", expectedState, migratedState)
+	}
+}
+
+func testAccCheckSecurityGroupMigrationStateDataV0() map[string]interface{} {
+	return map[string]interface{}{"name": "MiXeD-CASE-NOT-wanted"}
+}
+
+func testAccCheckSecurityGroupMigrationStateDataV1() map[string]interface{} {
+	return map[string]interface{}{"name": "mixed-case-not-wanted"}
 }

--- a/exoscale/validation.go
+++ b/exoscale/validation.go
@@ -29,6 +29,15 @@ func validateString(str string) schema.SchemaValidateDiagFunc {
 	})
 }
 
+// validateLowercaseString validates that the given fields contains only lowercase characters
+func validateLowercaseString(val interface{}, key string) (warns []string, errs []error) {
+	v := val.(string)
+	if strings.ContainsAny(v, "ABCDEFGHIJKLMNOPQRSTUVWXYZ") {
+		errs = append(errs, fmt.Errorf("%q must be lowercase, got: %q", key, v))
+	}
+	return
+}
+
 // validatePortRange validates that the given field contains a port range.
 func validatePortRange(i interface{}, k string) (s []string, es []error) {
 	value, ok := i.(string)
@@ -48,6 +57,11 @@ func validatePortRange(i interface{}, k string) (s []string, es []error) {
 		p, err := strconv.ParseUint(port, 10, 16)
 		if err != nil {
 			es = append(es, err)
+			return
+		}
+
+		if p == 0 {
+			es = append(es, fmt.Errorf("port expected to be between 1 and 65535, got %d", p))
 			return
 		}
 

--- a/exoscale/validation_test.go
+++ b/exoscale/validation_test.go
@@ -84,7 +84,11 @@ func Test_validatePortRange(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			args: args{i: "0", k: "ports"},
+			args:    args{i: "0", k: "ports"},
+			wantErr: true,
+		},
+		{
+			args: args{i: "1", k: "ports"},
 		},
 		{
 			args: args{i: "22", k: "ports"},


### PR DESCRIPTION
This change address the following issues:
- avoid to re-create `security_group`s because of case-sensitiveness of the name (this solve #139)
- fix a security_group_rules incompatibility with previous versions of the provider
