### PR TITLE
exoscale_security_group_rules: Fix for protocols without port numbers

### DIFF
--- a/exoscale/provider_test.go
+++ b/exoscale/provider_test.go
@@ -32,7 +32,7 @@ const (
 		    zoneid=85664334-0fd5-47bd-94a1-b4f40b1d2eb7 \
 		    name="Linux Ubuntu 20.04 LTS 64-bit"
 	*/
-	testInstanceTemplateID = "3ebca0c5-63f4-4055-b325-3cef0e68fa98"
+	testInstanceTemplateID = "67d62675-80fe-4932-88ac-5655b8ccca1b"
 
 	testInstanceTypeIDTiny   = "b6cd1ff5-3a2f-4e9d-a4d1-8988c1191fe8"
 	testInstanceTypeIDSmall  = "21624abb-764e-4def-81d7-9fc54b5957fb"

--- a/exoscale/resource_exoscale_database_kafka_test.go
+++ b/exoscale/resource_exoscale_database_kafka_test.go
@@ -14,7 +14,7 @@ import (
 
 var (
 	testAccResourceDatabaseKafkaIPFilter = []string{"1.2.3.4/32"}
-	testAccResourceDatabaseKafkaVersion  = "2.8"
+	testAccResourceDatabaseKafkaVersion  = "3.0"
 	testAccResourceDatabasePlanKafka     = "business-4"
 
 	testAccResourceDatabaseConfigCreateKafka = fmt.Sprintf(`

--- a/exoscale/resource_exoscale_security_group_rules.go
+++ b/exoscale/resource_exoscale_security_group_rules.go
@@ -668,14 +668,7 @@ func ruleToID(
 			name = *userSecurityGroup.Name
 		}
 
-		if protocol == "ah" || protocol == "esp" || protocol == "gre" || protocol == "ipip" {
-			id = fmt.Sprintf(
-				"%s_%s_%s",
-				*securityGroupRule.ID,
-				*securityGroupRule.Protocol,
-				name,
-			)
-		} else {
+		if protocol == "tcp" || protocol == "udp" {
 			id = fmt.Sprintf(
 				"%s_%s_%s_%d-%d",
 				*securityGroupRule.ID,
@@ -684,8 +677,14 @@ func ruleToID(
 				*securityGroupRule.StartPort,
 				*securityGroupRule.EndPort,
 			)
+		} else {
+			id = fmt.Sprintf(
+				"%s_%s_%s",
+				*securityGroupRule.ID,
+				*securityGroupRule.Protocol,
+				name,
+			)
 		}
-
 	}
 
 	return id, nil
@@ -750,10 +749,7 @@ func securityGroupRulesToAdd(
 		securityGroupRule.ICMPCode = &icmpCode
 		securityGroupRule.ICMPType = &icmpType
 		baseRules = append(baseRules, securityGroupRule)
-	} else if protocol == "ah" || protocol == "esp" || protocol == "gre" || protocol == "ipip" {
-		securityGroupRule.Protocol = &protocol
-		baseRules = append(baseRules, securityGroupRule)
-	} else {
+	} else if protocol == "tcp" || protocol == "udp" {
 		ports := preparePorts(rule[resSecurityGroupRulesAttrPorts].(*schema.Set))
 		for _, portRange := range ports {
 			portRange := portRange
@@ -762,6 +758,9 @@ func securityGroupRulesToAdd(
 			securityGroupRule.EndPort = &portRange[1]
 			baseRules = append(baseRules, securityGroupRule)
 		}
+	} else {
+		securityGroupRule.Protocol = &protocol
+		baseRules = append(baseRules, securityGroupRule)
 	}
 
 	expandedRules := make([]egoscale.SecurityGroupRule, 0)

--- a/exoscale/resource_exoscale_security_group_rules.go
+++ b/exoscale/resource_exoscale_security_group_rules.go
@@ -603,7 +603,7 @@ func readRules(
 				rule[resSecurityGroupRulesAttrProtocol] = strings.ReplaceAll(protocol, "V6", "v6")
 				rule[resSecurityGroupRulesAttrICMPCode] = int(*r.ICMPCode)
 				rule[resSecurityGroupRulesAttrICMPType] = int(*r.ICMPType)
-			} else {
+			} else if protocol == "TCP" || protocol == "UDP" {
 				var startPort, endPort uint16
 				if r.StartPort != nil {
 					startPort = *r.StartPort
@@ -668,14 +668,24 @@ func ruleToID(
 			name = *userSecurityGroup.Name
 		}
 
-		id = fmt.Sprintf(
-			"%s_%s_%s_%d-%d",
-			*securityGroupRule.ID,
-			*securityGroupRule.Protocol,
-			name,
-			*securityGroupRule.StartPort,
-			*securityGroupRule.EndPort,
-		)
+		if protocol == "ah" || protocol == "esp" || protocol == "gre" || protocol == "ipip" {
+			id = fmt.Sprintf(
+				"%s_%s_%s",
+				*securityGroupRule.ID,
+				*securityGroupRule.Protocol,
+				name,
+			)
+		} else {
+			id = fmt.Sprintf(
+				"%s_%s_%s_%d-%d",
+				*securityGroupRule.ID,
+				*securityGroupRule.Protocol,
+				name,
+				*securityGroupRule.StartPort,
+				*securityGroupRule.EndPort,
+			)
+		}
+
 	}
 
 	return id, nil
@@ -740,7 +750,7 @@ func securityGroupRulesToAdd(
 		securityGroupRule.ICMPCode = &icmpCode
 		securityGroupRule.ICMPType = &icmpType
 		baseRules = append(baseRules, securityGroupRule)
-	} else if protocol == "AH" || protocol == "ESP" || protocol == "GRE" || protocol == "IPIP" {
+	} else if protocol == "ah" || protocol == "esp" || protocol == "gre" || protocol == "ipip" {
 		securityGroupRule.Protocol = &protocol
 		baseRules = append(baseRules, securityGroupRule)
 	} else {

--- a/exoscale/resource_exoscale_security_group_rules_test.go
+++ b/exoscale/resource_exoscale_security_group_rules_test.go
@@ -59,6 +59,12 @@ resource "exoscale_security_group_rules" "rules" {
     user_security_group_list = [exoscale_security_group.test.name, data.exoscale_security_group.default.name]
   }
 
+  ingress {
+	protocol = "ESP"
+	cidr_list = ["192.168.0.0/24", "::/0"]
+	user_security_group_list = [data.exoscale_security_group.default.name]
+  }
+
   egress {
     protocol = "UDP"
     cidr_list = ["192.168.0.0/24", "::/0"]
@@ -101,6 +107,12 @@ resource "exoscale_security_group_rules" "rules" {
     cidr_list = ["10.0.0.0/24", "::/0"]
     ports = ["2222", "8000-8888"]
     user_security_group_list = [exoscale_security_group.test.name, data.exoscale_security_group.default.name]
+  }
+
+  ingress {
+	protocol = "ESP"
+	cidr_list = ["192.168.0.0/24", "::/0"]
+	user_security_group_list = [exoscale_security_group.test.name]
   }
 
   egress {
@@ -185,7 +197,7 @@ func TestAccResourceSecurityGroupRules(t *testing.T) {
 						require.NotNil(t, defaultSecurityGroup.ID)
 						return nil
 					},
-					testAccCheckSecurityGroupHasManyRules(16),
+					testAccCheckSecurityGroupHasManyRules(19),
 					testAccCheckSecurityGroupRuleExists(testSecurityGroup, &egoscale.SecurityGroupRule{
 						FlowDirection: nonEmptyStringPtr("ingress"),
 						Network:       mustParseCIDR(t, "0.0.0.0/0"),
@@ -255,6 +267,21 @@ func TestAccResourceSecurityGroupRules(t *testing.T) {
 						StartPort:       portValPtr(8000),
 						EndPort:         portValPtr(8888),
 						Protocol:        nonEmptyStringPtr("tcp"),
+					}),
+					testAccCheckSecurityGroupRuleExists(testSecurityGroup, &egoscale.SecurityGroupRule{
+						FlowDirection: nonEmptyStringPtr("ingress"),
+						Protocol:      nonEmptyStringPtr("esp"),
+						Network:       mustParseCIDR(t, "192.168.0.0/24"),
+					}),
+					testAccCheckSecurityGroupRuleExists(testSecurityGroup, &egoscale.SecurityGroupRule{
+						FlowDirection: nonEmptyStringPtr("ingress"),
+						Protocol:      nonEmptyStringPtr("esp"),
+						Network:       mustParseCIDR(t, "::/0"),
+					}),
+					testAccCheckSecurityGroupRuleExists(testSecurityGroup, &egoscale.SecurityGroupRule{
+						FlowDirection:   nonEmptyStringPtr("ingress"),
+						Protocol:        nonEmptyStringPtr("esp"),
+						SecurityGroupID: defaultSecurityGroup.ID,
 					}),
 					testAccCheckSecurityGroupRuleExists(testSecurityGroup, &egoscale.SecurityGroupRule{
 						FlowDirection: nonEmptyStringPtr("egress"),
@@ -331,6 +358,21 @@ func TestAccResourceSecurityGroupRules(t *testing.T) {
 						StartPort:       portValPtr(44),
 						EndPort:         portValPtr(44),
 						Protocol:        nonEmptyStringPtr("udp"),
+					}),
+					testAccCheckSecurityGroupRuleExists(testSecurityGroup, &egoscale.SecurityGroupRule{
+						FlowDirection: nonEmptyStringPtr("ingress"),
+						Protocol:      nonEmptyStringPtr("esp"),
+						Network:       mustParseCIDR(t, "192.168.0.0/24"),
+					}),
+					testAccCheckSecurityGroupRuleExists(testSecurityGroup, &egoscale.SecurityGroupRule{
+						FlowDirection: nonEmptyStringPtr("ingress"),
+						Protocol:      nonEmptyStringPtr("esp"),
+						Network:       mustParseCIDR(t, "::/0"),
+					}),
+					testAccCheckSecurityGroupRuleExists(testSecurityGroup, &egoscale.SecurityGroupRule{
+						FlowDirection:   nonEmptyStringPtr("ingress"),
+						Protocol:        nonEmptyStringPtr("esp"),
+						SecurityGroupID: testSecurityGroup.ID,
 					}),
 					testAccCheckSecurityGroupRuleExists(testSecurityGroup, &egoscale.SecurityGroupRule{
 						FlowDirection: nonEmptyStringPtr("egress"),


### PR DESCRIPTION
No port numbers for protocols `AH`, `ESP`, `IPIP` and `GRE`.

- Remove ports in the computed rule id for these protocols
- Update acceptance tests with ESP rules

(Fix #143)