### PR TITLE
sks_cluster: export kubeconfig string as a resource attribute

### DIFF
--- a/exoscale/resource_exoscale_sks_cluster.go
+++ b/exoscale/resource_exoscale_sks_cluster.go
@@ -82,8 +82,9 @@ func resourceSKSCluster() *schema.Resource {
 			Computed: true,
 		},
 		resSKSClusterAttrKubeconfig: {
-			Type:     schema.TypeString,
-			Computed: true,
+			Type:      schema.TypeString,
+			Computed:  true,
+			Sensitive: true,
 		},
 		resSKSClusterAttrExoscaleCCM: {
 			Type:     schema.TypeBool,


### PR DESCRIPTION
should close #131

---

simply gets the kubeconfig string from the exoscale api and sets it to the resource attribute