### PR TITLE
fix: add dbaas cidr filtering function

### DIFF
--- a/exoscale/resource_exoscale_database_kafka.go
+++ b/exoscale/resource_exoscale_database_kafka.go
@@ -10,6 +10,7 @@ import (
 	"github.com/exoscale/egoscale/v2/oapi"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 const (
@@ -60,9 +61,12 @@ var resDatabaseKafkaSchema = &schema.Schema{
 				Optional: true,
 			},
 			resDatabaseAttrKafkaIPFilter: {
-				Type:     schema.TypeSet,
-				Set:      schema.HashString,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Type: schema.TypeSet,
+				Set:  schema.HashString,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validation.IsCIDRNetwork(0, 128),
+				},
 				Optional: true,
 				Computed: true,
 			},

--- a/exoscale/resource_exoscale_database_mysql.go
+++ b/exoscale/resource_exoscale_database_mysql.go
@@ -10,6 +10,7 @@ import (
 	"github.com/exoscale/egoscale/v2/oapi"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 const (
@@ -44,9 +45,12 @@ var resDatabaseMysqlSchema = &schema.Schema{
 				Computed: true,
 			},
 			resDatabaseAttrMysqlIPFilter: {
-				Type:     schema.TypeSet,
-				Set:      schema.HashString,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Type: schema.TypeSet,
+				Set:  schema.HashString,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validation.IsCIDRNetwork(0, 128),
+				},
 				Optional: true,
 				Computed: true,
 			},

--- a/exoscale/resource_exoscale_database_pg.go
+++ b/exoscale/resource_exoscale_database_pg.go
@@ -10,6 +10,7 @@ import (
 	"github.com/exoscale/egoscale/v2/oapi"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 const (
@@ -46,9 +47,12 @@ var resDatabasePgSchema = &schema.Schema{
 				Computed: true,
 			},
 			resDatabaseAttrPgIPFilter: {
-				Type:     schema.TypeSet,
-				Set:      schema.HashString,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Type: schema.TypeSet,
+				Set:  schema.HashString,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validation.IsCIDRNetwork(0, 128),
+				},
 				Optional: true,
 				Computed: true,
 			},

--- a/exoscale/resource_exoscale_database_redis.go
+++ b/exoscale/resource_exoscale_database_redis.go
@@ -10,6 +10,7 @@ import (
 	"github.com/exoscale/egoscale/v2/oapi"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 const (
@@ -24,9 +25,12 @@ var resDatabaseRedisSchema = &schema.Schema{
 	Elem: &schema.Resource{
 		Schema: map[string]*schema.Schema{
 			resDatabaseAttrRedisIPFilter: {
-				Type:     schema.TypeSet,
-				Set:      schema.HashString,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Type: schema.TypeSet,
+				Set:  schema.HashString,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validation.IsCIDRNetwork(0, 128),
+				},
 				Optional: true,
 				Computed: true,
 			},


### PR DESCRIPTION
Fix CIDR filtering missing validate function.

Given this configuration:
```terraform
locals {
  nodeips = [
    "1.1.1.1"
  ]
}

resource "exoscale_database" "test" {
  zone = "ch-dk-2"
  name = "test"
  type = "redis"
  plan = "hobbyist-2"

  maintenance_dow  = "sunday"
  maintenance_time = "23:00:00"

  termination_protection = false

  redis {
    ip_filter = local.nodeips
  }
}
```

Before this fix, the configuration is accepted but triggers a modification on every run:
```
Terraform detected the following changes made outside of Terraform since the last "terraform apply":

  # exoscale_database.test has changed
  ~ resource "exoscale_database" "test" {
        id                     = "test"
        name                   = "test"
        # (14 unchanged attributes hidden)

      ~ redis {
          ~ ip_filter      = [
              - "1.1.1.1",
              + "1.1.1.1/32",
            ]
            # (1 unchanged attribute hidden)
        }
    }


Unless you have made equivalent changes to your configuration, or ignored the relevant attributes using ignore_changes, the following plan
may include actions to undo or respond to these changes.

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # exoscale_database.test will be updated in-place
  ~ resource "exoscale_database" "test" {
        id                     = "test"
        name                   = "test"
        # (14 unchanged attributes hidden)

      ~ redis {
          ~ ip_filter      = [
              + "1.1.1.1",
              - "1.1.1.1/32",
            ]
            # (1 unchanged attribute hidden)
        }
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

After:
```
╷
│ Error: expected redis.0.ip_filter.0 to contain a valid Value, got: 1.1.1.1 with err: invalid CIDR address: 1.1.1.1
│ 
│   with exoscale_database.test,
│   on main.tf line 28, in resource "exoscale_database" "test":
│   28:     ip_filter = local.nodeips
│ 
╵
```

As a side task, this PR also updates the documentation to move deprecated data sources to the "Deprecated" subcategory.