### PR TITLE
Add exoscale_sks_kubeconfig resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Next release
+
+FEATURES:
+
+- **New Resource:** `exoscale_sks_kubeconfig`
+
+BUG FIXES:
+
+- `database`: fix cidr blocks filtering for `ip_filter` attributes.
+
 ## 0.32.0 (February 28, 2022)
 
 BUG FIXES:

--- a/docs/resources/sks_kubeconfig.md
+++ b/docs/resources/sks_kubeconfig.md
@@ -49,8 +49,8 @@ output "kubeconfig" {
 * `cluster_id` - (Required) The ID of the target SKS cluster.
 * `ttl_seconds` - The number of seconds after initial issuing that the Kubeconfig will become invalid.
 * `early_renewal_seconds` - If set, the resource will consider the Kubeconfig to have expired the given number of seconds before its actual ca certificate or client certificate expiry time. This can be useful to deploy an updated Kubeconfig in advance of the expiration of its internal current certificate. Note however that the old certificate remains valid until its true expiration time since this resource does not (and cannot) support certificate revocation. Note also that this advance update can only be performed should the Terraform configuration be applied during the early renewal period.
-* `user` - User name in the generated Kubeconfig. The certificate present in the Kubeconfig will also have this name set for the CN field.
-* `groups` - Group names in the generated Kubeconfig. The certificate present in the Kubeconfig will have these roles set in the Organization field.
+* `user` - (Required) User name in the generated Kubeconfig. The certificate present in the Kubeconfig will also have this name set for the CN field.
+* `groups` - (Required) Group names in the generated Kubeconfig. The certificate present in the Kubeconfig will have these roles set in the Organization field.
 
 ## Attributes Reference
 

--- a/docs/resources/sks_kubeconfig.md
+++ b/docs/resources/sks_kubeconfig.md
@@ -1,0 +1,70 @@
+---
+page_title: "Exoscale: exoscale_sks_kubeconfig"
+description: |-
+  Provides an Exoscale SKS cluster kubeconfig.
+---
+
+# exoscale\_sks\_kubeconfig
+
+Provides an Exoscale [SKS][sks-doc] Kubeconfig resource. This can be used to create a configuration file (Kubeconfig) to interact with SKS clusters.
+
+
+## Example Usage
+
+```hcl
+locals {
+  zone = "de-fra-1"
+}
+
+resource "exoscale_sks_cluster" "prod" {
+  zone    = local.zone
+  name    = "prod"
+  version = "1.20.2"
+
+  labels = {
+    env = "prod"
+  }
+}
+
+resource "exoscale_sks_kubeconfig" "prod_admin" {
+  zone = local.zone
+
+  ttl_seconds = 3600
+  early_renewal_seconds = 300
+  cluster_id = exoscale_sks_cluster.prod.id
+  user = "kubernetes-admin"
+  groups = ["system:masters"]
+}
+
+output "kubeconfig" {
+  value = exoscale_sks_kubeconfig.prod_admin.kubeconfig
+  sensitive = true
+}
+```
+
+
+## Arguments Reference
+
+* `zone` - (Required) The name of the [zone][zone] of the target SKS cluster.
+* `cluster_id` - (Required) The ID of the target SKS cluster.
+* `ttl_seconds` - The number of seconds after initial issuing that the Kubeconfig will become invalid.
+* `early_renewal_seconds` - If set, the resource will consider the Kubeconfig to have expired the given number of seconds before its actual ca certificate or client certificate expiry time. This can be useful to deploy an updated Kubeconfig in advance of the expiration of its internal current certificate. Note however that the old certificate remains valid until its true expiration time since this resource does not (and cannot) support certificate revocation. Note also that this advance update can only be performed should the Terraform configuration be applied during the early renewal period.
+* `user` - User name in the generated Kubeconfig. The certificate present in the Kubeconfig will also have this name set for the CN field.
+* `groups` - Group names in the generated Kubeconfig. The certificate present in the Kubeconfig will have these roles set in the Organization field.
+
+## Attributes Reference
+
+In addition to the arguments listed above, the following attributes are exported:
+
+* `kubeconfig` - The generated Kubeconfig for use to interact with the SKS cluster.
+
+## Automatic Renewal
+
+This resource considers its instances to have been deleted after either their validity period ends or the early renewal period is reached. At this time, applying the Terraform configuration will cause a new certificate to be generated for the instance.
+
+Therefore in a development environment with frequent deployments, it may be convenient to set a relatively-short expiration time and use early renewal to automatically provision a new certificate when the current one is about to expire.
+
+The creation of a new certificate may of course cause dependent resources to be updated or replaced, depending on the lifecycle rules applying to those resources.
+
+[sks-doc]: https://community.exoscale.com/documentation/sks/
+[zone]: https://www.exoscale.com/datacenters/

--- a/docs/resources/sks_kubeconfig.md
+++ b/docs/resources/sks_kubeconfig.md
@@ -1,7 +1,7 @@
 ---
 page_title: "Exoscale: exoscale_sks_kubeconfig"
 description: |-
-  Provides an Exoscale SKS cluster kubeconfig.
+  Provides an Exoscale SKS cluster Kubeconfig.
 ---
 
 # exoscale\_sks\_kubeconfig
@@ -47,8 +47,8 @@ output "kubeconfig" {
 
 * `zone` - (Required) The name of the [zone][zone] of the target SKS cluster.
 * `cluster_id` - (Required) The ID of the target SKS cluster.
-* `ttl_seconds` - The number of seconds after initial issuing that the Kubeconfig will become invalid.
-* `early_renewal_seconds` - If set, the resource will consider the Kubeconfig to have expired the given number of seconds before its actual ca certificate or client certificate expiry time. This can be useful to deploy an updated Kubeconfig in advance of the expiration of its internal current certificate. Note however that the old certificate remains valid until its true expiration time since this resource does not (and cannot) support certificate revocation. Note also that this advance update can only be performed should the Terraform configuration be applied during the early renewal period.
+* `ttl_seconds` - The number of seconds after initial issuing that the Kubeconfig will become invalid (default: 2592000 = 30 days).
+* `early_renewal_seconds` - If set, the resource will consider the Kubeconfig to have expired the given number of seconds before its actual ca certificate or client certificate expiry time. This can be useful to deploy an updated Kubeconfig in advance of the expiration of its internal current certificate. Note however that the old certificate remains valid until its true expiration time since this resource does not (and cannot) support certificate revocation. Note also that this advance update can only be performed should the Terraform configuration be applied during the early renewal period (default: 0).
 * `user` - (Required) User name in the generated Kubeconfig. The certificate present in the Kubeconfig will also have this name set for the CN field.
 * `groups` - (Required) Group names in the generated Kubeconfig. The certificate present in the Kubeconfig will have these roles set in the Organization field.
 
@@ -60,11 +60,11 @@ In addition to the arguments listed above, the following attributes are exported
 
 ## Automatic Renewal
 
-This resource considers its instances to have been deleted after either their validity period ends or the early renewal period is reached. At this time, applying the Terraform configuration will cause a new certificate to be generated for the instance.
+This resource considers its instances to have been deleted after either their validity period ends or the early renewal period is reached. At this time, applying the Terraform configuration will cause a new Kubeconfig to be generated for the instance.
 
-Therefore in a development environment with frequent deployments, it may be convenient to set a relatively-short expiration time and use early renewal to automatically provision a new certificate when the current one is about to expire.
+Therefore in a development environment with frequent deployments, it may be convenient to set a relatively-short expiration time and use early renewal to automatically provision a new Kubeconfig when the current one is about to expire.
 
-The creation of a new certificate may of course cause dependent resources to be updated or replaced, depending on the lifecycle rules applying to those resources.
+The creation of a new Kubeconfig may of course cause dependent resources to be updated or replaced, depending on the lifecycle rules applying to those resources.
 
 [sks-doc]: https://community.exoscale.com/documentation/sks/
 [zone]: https://www.exoscale.com/datacenters/

--- a/exoscale/provider.go
+++ b/exoscale/provider.go
@@ -183,6 +183,7 @@ func Provider() *schema.Provider {
 			"exoscale_security_group_rule":  resourceSecurityGroupRule(),
 			"exoscale_security_group_rules": resourceSecurityGroupRules(),
 			"exoscale_sks_cluster":          resourceSKSCluster(),
+			"exoscale_sks_kubeconfig":       resourceSKSKubeconfig(),
 			"exoscale_sks_nodepool":         resourceSKSNodepool(),
 			"exoscale_ssh_key":              resourceSSHKey(),
 			"exoscale_ssh_keypair":          resourceSSHKeypair(),

--- a/exoscale/resource_exoscale_sks_kubeconfig.go
+++ b/exoscale/resource_exoscale_sks_kubeconfig.go
@@ -1,0 +1,271 @@
+package exoscale
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	exoapi "github.com/exoscale/egoscale/v2/api"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	resSKSKubeconfigAttrClusterID       = "cluster_id"
+	resSKSKubeconfigAttrGroups          = "groups"
+	resSKSKubeconfigAttrKubeconfig      = "kubeconfig"
+	resSKSKubeconfigAttrReadyForRenewal = "ready_for_renewal"
+	resSKSKubeconfigAttrTTLSeconds      = "ttl_seconds"
+	resSKSKubeconfigAttrUser            = "user"
+	resSKSKubeconfigAttrZone            = "zone"
+)
+
+func resourceSKSKubeconfigIDString(d resourceIDStringer) string {
+	return resourceIDString(d, "exoscale_sks_kubeconfig")
+}
+
+func resourceSKSKubeconfig() *schema.Resource {
+	s := map[string]*schema.Schema{
+		resSKSKubeconfigAttrClusterID: {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+		resSKSKubeconfigAttrGroups: {
+			Type:     schema.TypeSet,
+			Optional: true,
+			ForceNew: true,
+			Set:      schema.HashString,
+			Elem:     &schema.Schema{Type: schema.TypeString},
+		},
+		resSKSKubeconfigAttrKubeconfig: {
+			Type:      schema.TypeString,
+			Computed:  true,
+			Sensitive: true,
+		},
+		resSKSKubeconfigAttrReadyForRenewal: {
+			Type:     schema.TypeBool,
+			Computed: true,
+		},
+		resSKSKubeconfigAttrTTLSeconds: {
+			Type:     schema.TypeFloat,
+			Optional: true,
+			ForceNew: true,
+			Default:  30 * 24 * 3600,
+		},
+		resSKSKubeconfigAttrUser: {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+		resSKSKubeconfigAttrZone: {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+	}
+
+	return &schema.Resource{
+		Schema: s,
+
+		CreateContext: resourceSKSKubeconfigCreate,
+		ReadContext:   resourceSKSKubeconfigRead,
+		DeleteContext: resourceSKSKubeconfigDelete,
+
+		CustomizeDiff: resourceSKSKubeconfigDiff,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(defaultTimeout),
+			Read:   schema.DefaultTimeout(defaultTimeout),
+			Update: schema.DefaultTimeout(defaultTimeout),
+			Delete: schema.DefaultTimeout(defaultTimeout),
+		},
+	}
+}
+
+func resourceSKSKubeconfigCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	log.Printf("[DEBUG] %s: beginning create", resourceSKSKubeconfigIDString(d))
+
+	zone := d.Get(resSKSKubeconfigAttrZone).(string)
+	ctx, cancel := context.WithTimeout(ctx, d.Timeout(schema.TimeoutCreate))
+	ctx = exoapi.WithEndpoint(ctx, exoapi.NewReqEndpoint(getEnvironment(meta), zone))
+	defer cancel()
+
+	client := GetComputeClient(meta)
+
+	cluster, err := client.GetSKSCluster(ctx, zone, d.Get(resSKSKubeconfigAttrClusterID).(string))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	user := d.Get(resSKSKubeconfigAttrUser).(string)
+	groups := []string{}
+	if set, ok := d.Get(resSKSKubeconfigAttrGroups).(*schema.Set); ok {
+		groups = schemaSetToStringArray(set)
+	}
+
+	duration := time.Duration(int64(d.Get(resSKSKubeconfigAttrTTLSeconds).(float64)) * int64(time.Second))
+
+	b64Kubeconfig, err := client.GetSKSClusterKubeconfig(ctx, zone, cluster, user, groups, duration)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	kubeconfig, err := base64.StdEncoding.DecodeString(b64Kubeconfig)
+	if err != nil {
+		return diag.Errorf("error decoding kubeconfig content: %s", err)
+	}
+
+	if err := d.Set(resSKSKubeconfigAttrReadyForRenewal, false); err != nil {
+		return diag.Errorf("error setting value on key '%s': %s", resSKSKubeconfigAttrReadyForRenewal, err)
+	}
+
+	if err := d.Set(resSKSKubeconfigAttrKubeconfig, string(kubeconfig)); err != nil {
+		return diag.Errorf("error setting value on key '%s': %s", resSKSKubeconfigAttrKubeconfig, err)
+	}
+
+	id, err := kubeconfigToID(string(kubeconfig))
+	if err != nil {
+		return diag.Errorf("error generating kubeconfig ID: %s", err)
+	}
+
+	d.SetId(*id)
+
+	log.Printf("[DEBUG] %s: create finished successfully", resourceSKSKubeconfigIDString(d))
+
+	return resourceSKSKubeconfigRead(ctx, d, meta)
+}
+
+func resourceSKSKubeconfigRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceSKSKubeconfigDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	log.Printf("[DEBUG] %s: beginning delete", resourceSKSKubeconfigIDString(d))
+
+	// no revocation: we rely on client certificate expiration
+	// So let's just remove the kubeconfig from the state.
+	d.SetId("")
+
+	log.Printf("[DEBUG] %s: delete finished successfully", resourceSKSKubeconfigIDString(d))
+	return nil
+}
+
+func resourceSKSKubeconfigDiff(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+	kubeconfig := d.Get(resSKSKubeconfigAttrKubeconfig).(string)
+
+	clusterCerts, clientCerts, err := kubeconfigExtractCertificates(kubeconfig)
+	if len(kubeconfig) != 0 && err != nil {
+		return err
+	}
+
+	readyForRenewal := len(kubeconfig) == 0
+
+	if !readyForRenewal {
+		now := time.Now()
+		for _, certificate := range append(clusterCerts, clientCerts...) {
+			if !certificate.NotAfter.After(now) {
+				readyForRenewal = true
+				break
+			}
+		}
+	}
+
+	if readyForRenewal {
+		if err := d.SetNew(resSKSKubeconfigAttrReadyForRenewal, true); err != nil {
+			return err
+		}
+
+		if err := d.ForceNew(resSKSKubeconfigAttrReadyForRenewal); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func kubeconfigExtractCertificates(kubeconfig string) ([]*x509.Certificate, []*x509.Certificate, error) {
+	if len(kubeconfig) == 0 {
+		return nil, nil, fmt.Errorf("kubeconfig is empty")
+	}
+
+	var kubeconfigData struct {
+		Clusters []struct {
+			Cluster struct {
+				CertificateAuthorityData string `yaml:"certificate-authority-data"`
+			} `yaml:"cluster"`
+		} `yaml:"clusters"`
+		Users []struct {
+			User struct {
+				ClientCertificateData string `yaml:"client-certificate-data"`
+			} `yaml:"user"`
+		} `yaml:"users"`
+	}
+
+	if err := yaml.Unmarshal([]byte(kubeconfig), &kubeconfigData); err != nil {
+		return nil, nil, fmt.Errorf("error decoding kubeconfig certificates: %w", err)
+	}
+
+	var clusterCertificates []*x509.Certificate
+	var clientCertificates []*x509.Certificate
+
+	for _, cluster := range kubeconfigData.Clusters {
+		pemData, err := base64.StdEncoding.DecodeString(cluster.Cluster.CertificateAuthorityData)
+		if err != nil {
+			return nil, nil, fmt.Errorf("error decoding kubeconfig content: %w", err)
+		}
+
+		certificate, _ := pem.Decode(pemData)
+		parsedCertificate, err := x509.ParseCertificate(certificate.Bytes)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		clusterCertificates = append(clusterCertificates, parsedCertificate)
+	}
+
+	for _, user := range kubeconfigData.Users {
+		pemData, err := base64.StdEncoding.DecodeString(user.User.ClientCertificateData)
+		if err != nil {
+			return nil, nil, fmt.Errorf("error decoding kubeconfig content: %w", err)
+		}
+
+		certificate, _ := pem.Decode(pemData)
+		parsedCertificate, err := x509.ParseCertificate(certificate.Bytes)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		clientCertificates = append(clientCertificates, parsedCertificate)
+	}
+
+	return clusterCertificates, clientCertificates, nil
+}
+
+func kubeconfigToID(kubeconfig string) (*string, error) {
+	log.Printf("[DEBUG] kubeconfigToID: kubeconfig= %s", kubeconfig)
+
+	clusterCertificates, clientCertificates, err := kubeconfigExtractCertificates(kubeconfig)
+	if err != nil {
+		return nil, err
+	}
+
+	certificateIDs := []string{}
+	for _, cert := range append(clusterCertificates, clientCertificates...) {
+		log.Printf("[DEBUG] kubeconfigToID: adding SN: %s", cert.SerialNumber.String())
+
+		certificateIDs = append(certificateIDs, cert.SerialNumber.String())
+	}
+
+	kubeconfigID := strings.Join(certificateIDs, ":")
+
+	log.Printf("[DEBUG] kubeconfigToID: %s", kubeconfigID)
+
+	return &kubeconfigID, nil
+}

--- a/exoscale/resource_exoscale_sks_kubeconfig.go
+++ b/exoscale/resource_exoscale_sks_kubeconfig.go
@@ -45,7 +45,7 @@ func resourceSKSKubeconfig() *schema.Resource {
 		},
 		resSKSKubeconfigAttrGroups: {
 			Type:     schema.TypeSet,
-			Optional: true,
+			Required: true,
 			ForceNew: true,
 			Set:      schema.HashString,
 			Elem:     &schema.Schema{Type: schema.TypeString},

--- a/exoscale/resource_exoscale_sks_kubeconfig_test.go
+++ b/exoscale/resource_exoscale_sks_kubeconfig_test.go
@@ -1,0 +1,118 @@
+package exoscale
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"testing"
+
+	egoscale "github.com/exoscale/egoscale/v2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	testAccResourceSKSKubeconfigAttrEarlyRenewalSeconds = int64(600)
+	testAccResourceSKSKubeconfigAttrGroup               = "kube-group"
+	testAccResourceSKSKubeconfigAttrTTLSeconds          = int64(3600)
+	testAccResourceSKSKubeconfigAttrUser                = "kube-user"
+
+	testAccResourceSKSKubeconfigConfigCreate = fmt.Sprintf(`
+locals {
+  zone = "%s"
+}
+
+resource "exoscale_sks_cluster" "test" {
+  zone = local.zone
+  name = "%s"
+
+  timeouts {
+    create = "10m"
+  }
+}
+
+resource "exoscale_sks_kubeconfig" "test_admin" {
+	zone = local.zone
+
+	ttl_seconds = %d
+	early_renewal_seconds = %d
+	cluster_id = exoscale_sks_cluster.test.id
+	user = "%s"
+	groups = ["%s"]
+}
+`,
+		testZoneName,
+		testAccResourceSKSClusterName,
+		testAccResourceSKSKubeconfigAttrTTLSeconds,
+		testAccResourceSKSKubeconfigAttrEarlyRenewalSeconds,
+		testAccResourceSKSKubeconfigAttrUser,
+		testAccResourceSKSKubeconfigAttrGroup,
+	)
+)
+
+func TestAccResourceSKSKubeconfig(t *testing.T) {
+	var (
+		r             = "exoscale_sks_kubeconfig.test_admin"
+		sksCluster    egoscale.SKSCluster
+		sksKubeconfig string
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceSKSKubeconfigConfigCreate,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckResourceSKSClusterExists("exoscale_sks_cluster.test", &sksCluster),
+					testAccCheckResourceSKSKubeconfigExists(r, &sksKubeconfig),
+					func(s *terraform.State) error {
+						a := require.New(t)
+
+						_, certificates, _ := KubeconfigExtractCertificates(sksKubeconfig)
+
+						a.Len(certificates, 1)
+						clientCertificate := *(certificates[0])
+
+						certificateTTL := int64(clientCertificate.NotAfter.Sub(clientCertificate.NotBefore).Seconds())
+
+						a.InDelta(testAccResourceSKSKubeconfigAttrTTLSeconds, certificateTTL, 10)
+						a.Equal(testAccResourceSKSKubeconfigAttrUser, clientCertificate.Subject.CommonName)
+						a.Equal(testAccResourceSKSKubeconfigAttrGroup, clientCertificate.Subject.Organization[0])
+
+						return nil
+					},
+					checkResourceState(r, checkResourceStateValidateAttributes(testAttrs{
+						resSKSKubeconfigAttrGroups + ".#":       validateString("1"),
+						resSKSKubeconfigAttrGroups + ".0":       validateString(testAccResourceSKSKubeconfigAttrGroup),
+						resSKSKubeconfigAttrTTLSeconds:          validateString(strconv.FormatInt(testAccResourceSKSKubeconfigAttrTTLSeconds, 10)),
+						resSKSKubeconfigAttrUser:                validateString(testAccResourceSKSKubeconfigAttrUser),
+						resSKSKubeconfigAttrEarlyRenewalSeconds: validateString(strconv.FormatInt(testAccResourceSKSKubeconfigAttrEarlyRenewalSeconds, 10)),
+					})),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckResourceSKSKubeconfigExists(r string, sksKubeconfig *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[r]
+		if !ok {
+			return errors.New("resource not found in the state")
+		}
+
+		if rs.Primary.ID == "" {
+			return errors.New("resource ID not set")
+		}
+
+		kubeconfig, ok := rs.Primary.Attributes[resSKSKubeconfigAttrKubeconfig]
+		if !ok {
+			return errors.New("attribute not found in the resource")
+		}
+
+		*sksKubeconfig = kubeconfig
+		return nil
+	}
+}

--- a/exoscale/util.go
+++ b/exoscale/util.go
@@ -1,5 +1,7 @@
 package exoscale
 
+import "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 // in returns true if v is found in list.
 func in(list []string, v string) bool {
 	for i := range list {
@@ -45,4 +47,13 @@ func nonEmptyStringPtr(s string) *string {
 	}
 
 	return nil
+}
+
+func schemaSetToStringArray(set *schema.Set) []string {
+	array := make([]string, set.Len())
+	for i, group := range set.List() {
+		array[i] = group.(string)
+	}
+
+	return array
 }

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	golang.org/x/tools v0.0.0-20201028111035-eafbe7b904eb // indirect
 	google.golang.org/api v0.34.0 // indirect
 	gopkg.in/ini.v1 v1.48.0
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 )
 
 go 1.16

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -325,4 +325,5 @@ google.golang.org/protobuf/types/known/timestamppb
 ## explicit
 gopkg.in/ini.v1
 # gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
+## explicit
 gopkg.in/yaml.v3


### PR DESCRIPTION
Implement a solution for https://github.com/exoscale/terraform-provider-exoscale/issues/131.

We decided to implement the Kubeconfig generation in a separate resource to let every SKS user the choice to use it or not:
- If you want to generate Kubeconfigs from Terraform, it gives lots of flexibility, allowing you to build multiple configuration embedding certificates with fine-grained control on the user (CN), groups (orgs), or TTL of the client certificate.
- If you want to keep secrets outside of your Terraform state, just continue using the provider as usual, without declaring any `exoscale_sks_kubeconfig`.