### PR TITLE
compute_instance/instance_pool/sks_nodepool/security_group_rule - ignore case differences for instance-type and protocol

### DIFF
--- a/exoscale/resource_exoscale_compute_instance.go
+++ b/exoscale/resource_exoscale_compute_instance.go
@@ -119,6 +119,8 @@ func resourceComputeInstance() *schema.Resource {
 			Type:             schema.TypeString,
 			Required:         true,
 			ValidateDiagFunc: validateComputeInstanceType,
+			// Ignore case differences
+			DiffSuppressFunc: suppressCaseDiff,
 		},
 		resComputeInstanceAttrUserData: {
 			Type:     schema.TypeString,

--- a/exoscale/resource_exoscale_instance_pool.go
+++ b/exoscale/resource_exoscale_instance_pool.go
@@ -86,6 +86,8 @@ func resourceInstancePool() *schema.Resource {
 			Computed:         true,
 			ConflictsWith:    []string{resInstancePoolAttrServiceOffering},
 			ValidateDiagFunc: validateComputeInstanceType,
+			// Ignore case differences
+			DiffSuppressFunc: suppressCaseDiff,
 		},
 		resInstancePoolAttrIPv6: {
 			Type:     schema.TypeBool,

--- a/exoscale/resource_exoscale_security_group_rule.go
+++ b/exoscale/resource_exoscale_security_group_rule.go
@@ -106,6 +106,8 @@ func resourceSecurityGroupRule() *schema.Resource {
 				ForceNew:     true,
 				Default:      "TCP",
 				ValidateFunc: validation.StringInSlice(securityGroupRuleProtocols, true),
+				// Ignore case differences
+				DiffSuppressFunc: suppressCaseDiff,
 			},
 			resSecurityGroupRuleAttrSecurityGroupID: {
 				Type:          schema.TypeString,

--- a/exoscale/resource_exoscale_sks_nodepool.go
+++ b/exoscale/resource_exoscale_sks_nodepool.go
@@ -85,6 +85,8 @@ func resourceSKSNodepool() *schema.Resource {
 			Type:             schema.TypeString,
 			Required:         true,
 			ValidateDiagFunc: validateComputeInstanceType,
+			// Ignore case differences
+			DiffSuppressFunc: suppressCaseDiff,
 		},
 		resSKSNodepoolAttrLabels: {
 			Type:     schema.TypeMap,

--- a/exoscale/util.go
+++ b/exoscale/util.go
@@ -1,6 +1,10 @@
 package exoscale
 
-import "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+import (
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
 
 // in returns true if v is found in list.
 func in(list []string, v string) bool {
@@ -56,4 +60,10 @@ func schemaSetToStringArray(set *schema.Set) []string {
 	}
 
 	return array
+}
+
+// DiffSuppressFunc https://www.terraform.io/plugin/sdkv2/schemas/schema-behaviors#diffsuppressfunc
+// Do no show case differences between state and resource
+func suppressCaseDiff(k, old, new string, d *schema.ResourceData) bool {
+	return strings.EqualFold(old, new)
 }


### PR DESCRIPTION
Do not show case differences between state and resource for:
- `instance-type` (compute_instance/instance_pool/sks_nodepool) (#40)
- `protocol` (security_group_rule) (#83)