### PR TITLE
fix: manager type field missing from schema

### DIFF
--- a/exoscale/datasource_exoscale_compute_instance.go
+++ b/exoscale/datasource_exoscale_compute_instance.go
@@ -84,6 +84,10 @@ func dataSourceComputeInstance() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			dsComputeInstanceAttrManagerType: {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			dsComputeInstanceAttrName: {
 				Type:          schema.TypeString,
 				Optional:      true,


### PR DESCRIPTION
Fix the compute instance datasource when reading instances from instance-pools or sks node-pools

## Example snippet

```terraform
terraform {
  required_providers {
    exoscale = {
      source  = "exoscale/exoscale"
      version = "0.33.1"
    }
  }
}


locals {
  zone = "de-fra-1"
}

data "exoscale_compute_template" "test" {
  zone = local.zone
  name = "Linux Ubuntu 20.04 LTS 64-bit"
}

resource "exoscale_instance_pool" "test" {
  zone = local.zone
  name = "test"
  template_id = data.exoscale_compute_template.test.id
  size = 1
  instance_type = "standard.micro"
  disk_size = 10
}

# After having applied above declaration, try to apply this:
data "exoscale_compute_instance" "test" {
  zone = local.zone

  for_each = exoscale_instance_pool.test.virtual_machines
  id = each.value
}

output "vm" {
  value = jsonencode(data.exoscale_compute_instance.test)
}
```

## Before

```
➜ terraform apply
exoscale_instance_pool.test: Refreshing state... [id=531caa67-1220-4502-9bdf-77d94c82c0bb]
╷
│ Error: Invalid address to set: []string{"manager_type"}
│ 
│   with data.exoscale_compute_instance.test["971e3555-d12e-4713-8e6c-f392e6686d15"],
│   on main.tf line 30, in data "exoscale_compute_instance" "test":
│   30: data "exoscale_compute_instance" "test" {
│ 
╵
```

## After

```
➜ terraform apply
exoscale_instance_pool.test: Refreshing state... [id=531caa67-1220-4502-9bdf-77d94c82c0bb]

Changes to Outputs:
  + vm = jsonencode(
        {
          + 971e3555-d12e-4713-8e6c-f392e6686d15 = {
            # ... VM properties
            }
        }
    )

You can apply this plan to save these new output values to the Terraform state, without changing any real infrastructure.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes


Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

Outputs:

vm = "<VM properties in json format>"
```