### PR TITLE
Replacement for exoscale_nic (network_interface block on exoscale_compute_instance)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Next release
+
+DEPRECATIONS:
+
+- `exoscale_compute_instance`: the `private_network_ids` argument has been deprecated and is now read-only. Use `network_interface` blocks instead
+
+BUG FIXES:
+
+- `exoscale_compute_instance` data source crash when the instance belongs to an instance pool or an SKS node pool (#162)
+
 ## 0.33.1 (March 15, 2022)
 
 BUG FIXES:

--- a/docs/resources/compute_instance.md
+++ b/docs/resources/compute_instance.md
@@ -29,6 +29,15 @@ data "exoscale_security_group" "default" {
   name = "default"
 }
 
+resource "exoscale_private_network" "example" {
+  name = "privnet"
+  zone = local.zone
+
+  start_ip = "10.0.0.20"
+  end_ip   = "10.0.0.253"
+  netmask  = "255.255.255.0"
+}
+
 resource "exoscale_compute_instance" "example" {
   zone               = local.zone
   name               = "webserver"
@@ -44,6 +53,11 @@ resource "exoscale_compute_instance" "example" {
 #cloud-config
 manage_etc_hosts: localhost
 EOF
+
+  network_interface {
+    network_id = exoscale_private_network.example.id
+    ip_address = "10.0.0.20"
+  }
 }
 ```
 
@@ -65,7 +79,7 @@ EOF
 * `deploy_target_id` - A Deploy Target ID.
 * `labels` - A map of key/value labels.
 
-`network_interface` - Attach the compute instance to a private network:
+`network_interface` - Attach the compute instance to a private network (can be specified multiple times):
 
 * `network_id` - (Required) The [Private Network][r-private_network] ID to attach to the Compute instance.
 * `ip_address` - The IP address to request as static DHCP lease if the network interface is attached to a *managed* Private Network (see the [`exoscale_network`][r-private_network] resource).

--- a/docs/resources/compute_instance.md
+++ b/docs/resources/compute_instance.md
@@ -57,7 +57,6 @@ EOF
 * `disk_size` - (Required) The Compute instance disk size in GiB (at least `10`). **WARNING**: updating this attribute stops/restarts the Compute instance.
 * `anti_affinity_group_ids` - A list of [Anti-Affinity Group][r-anti_affinity_group] IDs (at creation time only) to assign the Compute instance. Usage of the [`exoscale_anti_affinity_group`][d-anti_affinity_group] data source is recommended.
 * `security_group_ids` - A list of [Security Group][r-security_group] IDs to attach to the Compute instance. Usage of the [`exoscale_security_group`][d-security_group] data source is recommended.
-* `private_network_ids` - A list of [Private Network][r-private_network] IDs to attach to the Compute instance. Usage of the [`exoscale_private_network`][d-private_network] data source is recommended.
 * `elastic_ip_ids` - A list of [Elastic IP][r-elastic_ip] IDs to attach to the Compute instance. Usage of the [`exoscale_elastic_ip`][d-elastic_ip] data source is recommended.
 * `ipv6` - Enable IPv6 on the Compute instance (default: `false`).
 * `ssh_key` - The name of the [SSH key pair][sshkeypair] to install to the Compute instance's user account during creation.
@@ -65,6 +64,11 @@ EOF
 * `state` - The state of the Compute instance (supported values: `started`, `stopped`).
 * `deploy_target_id` - A Deploy Target ID.
 * `labels` - A map of key/value labels.
+
+`network_interface` - Attach the compute instance to a private network:
+
+* `network_id` - (Required) The [Private Network][r-private_network] ID to attach to the Compute instance.
+* `ip_address` - The IP address to request as static DHCP lease if the network interface is attached to a *managed* Private Network (see the [`exoscale_network`][r-private_network] resource).
 
 
 ## Attributes Reference
@@ -74,6 +78,7 @@ In addition to the arguments listed above, the following attributes are exported
 * `created_at` - The creation date of the Compute instance.
 * `id` - The ID of the Compute instance.
 * `ipv6_address` - The IPv6 address of the Compute instance main network interface.
+* `private_network_ids` - (Deprecated) A list of [Private Network][r-private_network] IDs attached to the Compute instance. Attached network interfaces can be set using the `network_interface` block argument. Usage of the [`exoscale_private_network`][d-private_network] data source is recommended.
 * `public_ip_address` - The IPv4 address of the Compute instance's main network interface.
 
 

--- a/exoscale/datasource_exoscale_compute_instance_test.go
+++ b/exoscale/datasource_exoscale_compute_instance_test.go
@@ -64,10 +64,13 @@ resource "exoscale_compute_instance" "test" {
   ipv6                    = true
   anti_affinity_group_ids = [exoscale_anti_affinity_group.test.id]
   security_group_ids      = [exoscale_security_group.test.id]
-  private_network_ids     = [exoscale_private_network.test.id]
   elastic_ip_ids          = [exoscale_elastic_ip.test.id]
   user_data               = "%s"
   ssh_key                 = exoscale_ssh_key.test.name
+
+  network_interface {
+	network_id = exoscale_private_network.test.id
+  }
 
   labels = {
     test = "%s"

--- a/exoscale/provider_test.go
+++ b/exoscale/provider_test.go
@@ -32,7 +32,7 @@ const (
 		    zoneid=85664334-0fd5-47bd-94a1-b4f40b1d2eb7 \
 		    name="Linux Ubuntu 20.04 LTS 64-bit"
 	*/
-	testInstanceTemplateID = "67d62675-80fe-4932-88ac-5655b8ccca1b"
+	testInstanceTemplateID = "d19ba12a-39c5-4b6f-bd27-3fa82ef360dd"
 
 	testInstanceTypeIDTiny   = "b6cd1ff5-3a2f-4e9d-a4d1-8988c1191fe8"
 	testInstanceTypeIDSmall  = "21624abb-764e-4def-81d7-9fc54b5957fb"


### PR DESCRIPTION
On `exoscale_compute_instance` resource:
- `private_network_ids`  argument has been deprecated and is now read-only;
- `network_interface` block argument has been added to attach the instance to a private network, optionally specifying an IP address as a lease (can be specified multiple times).

Demo snippet:
```terraform
locals {
  zone = "de-fra-1"
}

resource "exoscale_private_network" "test" {
  name = "test"
  zone = local.zone

  start_ip = "172.30.0.1"
  end_ip = "172.30.0.200"
  netmask = "255.255.255.0"
}

data "exoscale_compute_template" "template" {
  zone = local.zone
  name = "Linux Ubuntu 20.04 LTS 64-bit"
}

resource "exoscale_compute_instance" "test" {
  zone          = local.zone
  name          = "test"
  template_id   = data.exoscale_compute_template.template.id
  type          = "standard.micro"
  disk_size     = 10

  # This is now read-only:
  # private_network_ids = [ exoscale_private_network.test.id ]

  # ... replaced by:
  network_interface {
    network_id = exoscale_private_network.test.id
    ip_address = "172.30.0.1"
  }
}
```

Allows to attach with the specified IP address:

![nic](https://user-images.githubusercontent.com/7113950/159723980-e744da8e-6b6f-496d-9d85-aa037988cec8.png)
