### PR TITLE
Add early check for user data length

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
       with:
-        go-version: '^1.17'
+        go-version: '~1.17'
     - name: Run tests
       run: |
         git submodule update --init --recursive go.mk

--- a/exoscale/resource_exoscale_compute.go
+++ b/exoscale/resource_exoscale_compute.go
@@ -83,9 +83,10 @@ func resourceCompute() *schema.Resource {
 			Default:  "Medium",
 		},
 		"user_data": {
-			Type:        schema.TypeString,
-			Optional:    true,
-			Description: "cloud-init configuration",
+			Type:         schema.TypeString,
+			Optional:     true,
+			Description:  "cloud-init configuration",
+			ValidateDiagFunc: validateComputeUserData,
 		},
 		"user_data_base64": {
 			Type:        schema.TypeBool,

--- a/exoscale/resource_exoscale_compute.go
+++ b/exoscale/resource_exoscale_compute.go
@@ -1,13 +1,9 @@
 package exoscale
 
 import (
-	"bytes"
-	"compress/gzip"
 	"context"
-	"encoding/base64"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"regexp"
 	"strconv"
@@ -83,9 +79,9 @@ func resourceCompute() *schema.Resource {
 			Default:  "Medium",
 		},
 		"user_data": {
-			Type:         schema.TypeString,
-			Optional:     true,
-			Description:  "cloud-init configuration",
+			Type:             schema.TypeString,
+			Optional:         true,
+			Description:      "cloud-init configuration",
 			ValidateDiagFunc: validateComputeUserData,
 		},
 		"user_data_base64": {
@@ -341,12 +337,12 @@ func resourceComputeCreate(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	userData, base64Encoded, err := prepareUserData(d, meta, "user_data")
+	userData, userDataBase64, err := prepareUserData(d, meta, "user_data")
 	if err != nil {
 		return err
 	}
 
-	if err := d.Set("user_data_base64", base64Encoded); err != nil {
+	if err := d.Set("user_data_base64", userDataBase64); err != nil {
 		return err
 	}
 	startVM := d.Get("state").(string) != "Stopped"
@@ -597,7 +593,7 @@ func resourceComputeUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if d.HasChange("user_data") {
-		userData, base64Encoded, err := prepareUserData(d, meta, "user_data")
+		userData, userDataBase64, err := prepareUserData(d, meta, "user_data")
 		if err != nil {
 			return err
 		}
@@ -605,7 +601,7 @@ func resourceComputeUpdate(d *schema.ResourceData, meta interface{}) error {
 		req.UserData = userData
 		rebootRequired = true
 
-		if err := d.Set("user_data_base64", base64Encoded); err != nil {
+		if err := d.Set("user_data_base64", userDataBase64); err != nil {
 			return err
 		}
 	}
@@ -1104,71 +1100,12 @@ func getSecurityGroup(ctx context.Context, client *egoscale.Client, name string)
 func prepareUserData(d *schema.ResourceData, meta interface{}, key string) (string, bool, error) {
 	userData := d.Get(key).(string)
 
-	// template_cloudinit_config alows to gzip but not base64, prevent such case
-	if len(userData) > 2 && userData[0] == '\x1f' && userData[1] == '\x8b' {
-		return "", false, errors.New("user_data appears to be gzipped: it should be left raw, or also be base64 encoded")
-	}
-
-	// If the data is already base64 encoded, do nothing.
-	_, err := base64.StdEncoding.DecodeString(userData)
-	if err == nil {
-		return userData, true, nil
-	}
-
-	b64UserData, err := encodeUserData(userData)
+	userData, userDataBase64, err := encodeUserData(userData)
 	if err != nil {
 		return "", false, err
 	}
 
-	return b64UserData, false, nil
-}
-
-func encodeUserData(data string) (string, error) {
-	b := new(bytes.Buffer)
-	gz := gzip.NewWriter(b)
-
-	if _, err := gz.Write([]byte(data)); err != nil {
-		return "", err
-	}
-	if err := gz.Flush(); err != nil {
-		return "", err
-	}
-	if err := gz.Close(); err != nil {
-		return "", err
-	}
-
-	b64UserData := base64.StdEncoding.EncodeToString(b.Bytes())
-
-	if len(b64UserData) >= computeMaxUserDataLength {
-		return "", fmt.Errorf("user-data maximum allowed length is %d bytes", computeMaxUserDataLength)
-	}
-
-	return b64UserData, nil
-}
-
-func decodeUserData(data string) (string, error) {
-	b64Decoded, err := base64.StdEncoding.DecodeString(data)
-	if err != nil {
-		return "", err
-	}
-
-	gz, err := gzip.NewReader(bytes.NewReader(b64Decoded))
-	if err != nil {
-		if errors.Is(err, gzip.ErrHeader) {
-			// User data are not compressed, returning as-is.
-			return string(b64Decoded), nil
-		}
-
-		return "", err
-	}
-	defer gz.Close()
-
-	userData, err := ioutil.ReadAll(gz)
-	if err != nil {
-		return "", err
-	}
-
-	return string(userData), nil
+	return userData, userDataBase64, nil
 }
 
 func reverseDNSApply(ctx context.Context, d *schema.ResourceData, client *egoscale.Client) error {

--- a/exoscale/resource_exoscale_compute_instance.go
+++ b/exoscale/resource_exoscale_compute_instance.go
@@ -145,8 +145,9 @@ func resourceComputeInstance() *schema.Resource {
 			DiffSuppressFunc: suppressCaseDiff,
 		},
 		resComputeInstanceAttrUserData: {
-			Type:     schema.TypeString,
-			Optional: true,
+			Type:             schema.TypeString,
+			ValidateDiagFunc: validateComputeUserData,
+			Optional:         true,
 		},
 		resComputeInstanceAttrZone: {
 			Type:     schema.TypeString,

--- a/exoscale/resource_exoscale_compute_instance.go
+++ b/exoscale/resource_exoscale_compute_instance.go
@@ -286,7 +286,7 @@ func resourceComputeInstanceCreate(ctx context.Context, d *schema.ResourceData, 
 	computeInstance.InstanceTypeID = instanceType.ID
 
 	if v := d.Get(resComputeInstanceAttrUserData).(string); v != "" {
-		userData, err := encodeUserData(v)
+		userData, _, err := encodeUserData(v)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -414,7 +414,7 @@ func resourceComputeInstanceUpdate(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	if d.HasChange(resComputeInstanceAttrUserData) {
-		v, err := encodeUserData(d.Get(resComputeInstanceAttrUserData).(string))
+		v, _, err := encodeUserData(d.Get(resComputeInstanceAttrUserData).(string))
 		if err != nil {
 			return diag.FromErr(err)
 		}

--- a/exoscale/resource_exoscale_compute_instance_test.go
+++ b/exoscale/resource_exoscale_compute_instance_test.go
@@ -221,7 +221,7 @@ func TestAccResourceComputeInstance(t *testing.T) {
 						defaultSecurityGroupID, err := attrFromState(s, "data.exoscale_security_group.default", "id")
 						a.NoError(err, "unable to retrieve default Security Group ID from state")
 
-						expectedUserData, err := encodeUserData(testAccResourceComputeInstanceUserData)
+						expectedUserData, _, err := encodeUserData(testAccResourceComputeInstanceUserData)
 						if err != nil {
 							return err
 						}
@@ -278,7 +278,7 @@ func TestAccResourceComputeInstance(t *testing.T) {
 						defaultSecurityGroupID, err := attrFromState(s, "data.exoscale_security_group.default", "id")
 						a.NoError(err, "unable to retrieve default Security Group ID from state")
 
-						expectedUserData, err := encodeUserData(testAccResourceComputeInstanceUserDataUpdated)
+						expectedUserData, _, err := encodeUserData(testAccResourceComputeInstanceUserDataUpdated)
 						if err != nil {
 							return err
 						}

--- a/exoscale/resource_exoscale_instance_pool.go
+++ b/exoscale/resource_exoscale_instance_pool.go
@@ -317,7 +317,7 @@ func resourceInstancePoolCreate(ctx context.Context, d *schema.ResourceData, met
 	instancePool.IPv6Enabled = &enableIPv6
 
 	if v := d.Get(resInstancePoolAttrUserData).(string); v != "" {
-		userData, err := encodeUserData(v)
+		userData, _, err := encodeUserData(v)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -498,7 +498,7 @@ func resourceInstancePoolUpdate(ctx context.Context, d *schema.ResourceData, met
 	}
 
 	if d.HasChange(resInstancePoolAttrUserData) {
-		v, err := encodeUserData(d.Get(resInstancePoolAttrUserData).(string))
+		v, _, err := encodeUserData(d.Get(resInstancePoolAttrUserData).(string))
 		if err != nil {
 			return diag.FromErr(err)
 		}

--- a/exoscale/resource_exoscale_instance_pool_test.go
+++ b/exoscale/resource_exoscale_instance_pool_test.go
@@ -175,7 +175,7 @@ func TestAccResourceInstancePool(t *testing.T) {
 						templateID, err := attrFromState(s, "data.exoscale_compute_template.ubuntu", "id")
 						a.NoError(err, "unable to retrieve template ID from state")
 
-						expectedUserData, err := encodeUserData(testAccResourceInstancePoolUserData)
+						expectedUserData, _, err := encodeUserData(testAccResourceInstancePoolUserData)
 						if err != nil {
 							return err
 						}
@@ -225,7 +225,7 @@ func TestAccResourceInstancePool(t *testing.T) {
 						templateID, err := attrFromState(s, "data.exoscale_compute_template.debian", "id")
 						a.NoError(err, "unable to retrieve template ID from state")
 
-						expectedUserData, err := encodeUserData(testAccResourceInstancePoolUserDataUpdated)
+						expectedUserData, _, err := encodeUserData(testAccResourceInstancePoolUserDataUpdated)
 						if err != nil {
 							return err
 						}

--- a/exoscale/util.go
+++ b/exoscale/util.go
@@ -1,6 +1,12 @@
 package exoscale
 
 import (
+	"bytes"
+	"compress/gzip"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io/ioutil"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -66,4 +72,66 @@ func schemaSetToStringArray(set *schema.Set) []string {
 // Do no show case differences between state and resource
 func suppressCaseDiff(k, old, new string, d *schema.ResourceData) bool {
 	return strings.EqualFold(old, new)
+}
+
+// user-data compression and base64 encoding, used in resource_exoscale_compute[_instance[_pool]]
+// returns (user_data, user_data_already_base64, error)
+func encodeUserData(userData string) (string, bool, error) {
+	// template_cloudinit_config alows to gzip but not base64, prevent such case
+	if len(userData) > 2 && userData[0] == '\x1f' && userData[1] == '\x8b' {
+		return "", false, errors.New("user_data appears to be gzipped: it should be left raw, or also be base64 encoded")
+	}
+
+	// If user supplied data is already base64 encoded, do nothing.
+	_, err := base64.StdEncoding.DecodeString(userData)
+	if err == nil {
+		return userData, true, nil
+	}
+
+	b := new(bytes.Buffer)
+	gz := gzip.NewWriter(b)
+
+	if _, err := gz.Write([]byte(userData)); err != nil {
+		return "", false, err
+	}
+	if err := gz.Flush(); err != nil {
+		return "", false, err
+	}
+	if err := gz.Close(); err != nil {
+		return "", false, err
+	}
+
+	userDataBase64 := base64.StdEncoding.EncodeToString(b.Bytes())
+
+	if len(userDataBase64) >= computeMaxUserDataLength {
+		return "", false, fmt.Errorf("user-data maximum allowed length is %d bytes", computeMaxUserDataLength)
+	}
+
+	return userDataBase64, false, nil
+}
+
+// user-data base64 decoding & decompression, used in resource_exoscale_compute[_instance[_pool]]
+func decodeUserData(data string) (string, error) {
+	b64Decoded, err := base64.StdEncoding.DecodeString(data)
+	if err != nil {
+		return "", err
+	}
+
+	gz, err := gzip.NewReader(bytes.NewReader(b64Decoded))
+	if err != nil {
+		if errors.Is(err, gzip.ErrHeader) {
+			// User data are not compressed, returning as-is.
+			return string(b64Decoded), nil
+		}
+
+		return "", err
+	}
+	defer gz.Close()
+
+	userData, err := ioutil.ReadAll(gz)
+	if err != nil {
+		return "", err
+	}
+
+	return string(userData), nil
 }

--- a/exoscale/validation.go
+++ b/exoscale/validation.go
@@ -1,7 +1,6 @@
 package exoscale
 
 import (
-	"encoding/base64"
 	"fmt"
 	"strconv"
 	"strings"
@@ -99,17 +98,7 @@ func validateComputeUserData(v interface{}, _ cty.Path) diag.Diagnostics {
 		return diag.Errorf("expected field %q type to be string", v)
 	}
 
-	// If the data is already base64 encoded, only check length.
-	_, err := base64.StdEncoding.DecodeString(value)
-	if err == nil {
-		if len(value) > computeMaxUserDataLength {
-			return diag.Errorf("user-data maximum allowed length is %d bytes", computeMaxUserDataLength)
-		}
-
-		return nil
-	}
-
-	_, err = encodeUserData(value)
+	_, _, err := encodeUserData(value)
 	if err != nil {
 		return diag.FromErr(err)
 	}


### PR DESCRIPTION
When user_data is too large (> 32k), Terraform generates a valid plan but fails to apply.
This PR fixes this situation by failing way earlier.

Also refactored the `encodeUserData` to handle all the input validation logic. This will help ensure user_data is valid not only in `instance`, but also in `compute_instance` and `exoscale_instance_pool`.

Example before:

```
➜ terraform apply

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated
with the following symbols:
  + create

Terraform will perform the following actions:

  # exoscale_compute_instance.example will be created
  + resource "exoscale_compute_instance" "example" {
      + created_at          = (known after apply)
      + disk_size           = 10
      + id                  = (known after apply)
      + ipv6                = false
      + ipv6_address        = (known after apply)
      + name                = "webserver"
      + private_network_ids = (known after apply)
      + public_ip_address   = (known after apply)
      + ssh_key             = "my-key"
      + state               = (known after apply)
      + template_id         = "d19ba12a-39c5-4b6f-bd27-3fa82ef360dd"
      + type                = "standard.micro"
      + user_data           = "[[[ LOTS OF DATA ]]]"
      + zone                = "de-fra-1"
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value:
```

Example after:

```
➜ terraform apply
╷
│ Error: user-data maximum allowed length is 32768 bytes
│
│   with exoscale_compute_instance.example,
│   on main.tf line 17, in resource "exoscale_compute_instance" "example":
│   17:   user_data          = base64encode(file("${path.module}/user_data"))
│
╵
```