### PR TITLE
add ca_certificate attribute reference to exoscale_database resource

### DIFF
--- a/exoscale/resource_exoscale_database.go
+++ b/exoscale/resource_exoscale_database.go
@@ -28,6 +28,7 @@ const (
 	resDatabaseAttrNodes                 = "nodes"
 	resDatabaseAttrPlan                  = "plan"
 	resDatabaseAttrState                 = "state"
+	resDatabaseAttrCA                    = "ca_certificate"
 	resDatabaseAttrTerminationProtection = "termination_protection"
 	resDatabaseAttrType                  = "type"
 	resDatabaseAttrURI                   = "uri"
@@ -95,6 +96,10 @@ func resourceDatabase() *schema.Resource {
 			Required: true,
 		},
 		resDatabaseAttrState: {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		resDatabaseAttrCA: {
 			Type:     schema.TypeString,
 			Computed: true,
 		},
@@ -223,9 +228,17 @@ func resourceDatabaseRead(ctx context.Context, d *schema.ResourceData, meta inte
 		}
 	}
 
+	CACertificate, err := client.GetDatabaseCACertificate(ctx, zone)
+	if err != nil {
+		return diag.Errorf("unable to get CA Certificate: %v", err)
+	}
+
+	if err := d.Set(resDatabaseAttrCA, CACertificate); err != nil {
+		return diag.FromErr(err)
+	}
+
 	databaseServiceType := d.Get(resDatabaseAttrType).(string)
 
-	var err error
 	switch databaseServiceType {
 	case "kafka":
 		err = resourceDatabaseApplyKafka(ctx, d, client.Client)


### PR DESCRIPTION
This changes introduce ca_certificate attribute to exoscale_database resource

The attribute is blocker of a connection to database itself.

Without CA certificate of a created instance of database there is no possibility to establish secured connection.

Before it could only be taken manually from the website (brrrr) or using CLI interface.

This changes bring possibility to get the CA certificate for a created DB instance right from the Terraform module where it was described.