### PR TITLE
New data source: compute_instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Next release
+
+FEATURES:
+
+- **New Data Source:** `exoscale_compute_instances`
+
 ## 0.36.0 (May 6, 2022)
 
 FEATURES:

--- a/docs/data-sources/compute_instances.md
+++ b/docs/data-sources/compute_instances.md
@@ -1,0 +1,47 @@
+---
+page_title: "Exoscale: exoscale_compute_instances"
+description: |-
+  Shows a list of Compute instances.
+---
+
+# exoscale\_compute\_instance
+
+Lists available [Exoscale Compute instances][compute-doc].
+
+
+## Example Usage
+
+```hcl
+data "exoscale_compute_instances" "example" {
+  zone = "ch-gva-2"
+}
+```
+
+## Arguments Reference
+
+* `zone` - (Required) The [zone][zone] of the Compute instance.
+* `instances` - The list of instances.
+
+The `instances` items contains:
+
+* `created_at` - The creation date of the Compute instance.
+* `id` - The ID of the compute instance.
+* `ipv6_address` - The IPv6 address of the compute instance's main network interface.
+* `labels` - A map of key/value labels.
+* `name` - The name of the compute instance.
+* `private_network_ids` - A list of [Private Network][r-private_network] IDs attached to the Compute instance.
+* `public_ip_address` - The IPv4 address of the compute instance's main network interface.
+* `ssh_key` - The name of the [SSH key pair][sshkeypair] installed to the Compute instance's user account during creation.
+* `security_group_ids` - A list of [Security Group][r-security_group] IDs attached to the Compute instance.
+* `state` - The state of the Compute instance.
+* `template_id` - The ID of the instance [template][template] used when creating the Compute instance.
+* `type` - The Compute instance [type][type].
+
+
+[compute-doc]: https://community.exoscale.com/documentation/compute/
+[r-private_network]: ../resources/private_network
+[r-security_group]: ../resources/security_group
+[sshkeypair-doc]: https://community.exoscale.com/documentation/compute/ssh-keypairs/
+[template]: https://www.exoscale.com/templates/
+[type]: https://www.exoscale.com/pricing/#/compute/
+[zone]: https://www.exoscale.com/datacenters/

--- a/exoscale/datasource_exoscale_compute_instances.go
+++ b/exoscale/datasource_exoscale_compute_instances.go
@@ -1,0 +1,186 @@
+package exoscale
+
+import (
+	"context"
+	"crypto/md5"
+	"fmt"
+	"log"
+	"sort"
+	"strings"
+
+	exoapi "github.com/exoscale/egoscale/v2/api"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceComputeInstances() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			dsComputeInstanceAttrZone: {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"instances": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						dsComputeInstanceAttrCreatedAt: {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						dsComputeInstanceAttrID: {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						dsComputeInstanceAttrIPv6Address: {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						dsComputeInstanceAttrLabels: {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						dsComputeInstanceAttrName: {
+							Type:     schema.TypeString,
+							Computed: true,
+							Optional: true,
+						},
+						dsComputeInstanceAttrPrivateNetworkIDs: {
+							Type:     schema.TypeSet,
+							Computed: true,
+							Set:      schema.HashString,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						dsComputeInstanceAttrPublicIPAddress: {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						dsComputeInstanceAttrSSHKey: {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						dsComputeInstanceAttrSecurityGroupIDs: {
+							Type:     schema.TypeSet,
+							Computed: true,
+							Set:      schema.HashString,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						dsComputeInstanceAttrState: {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						dsComputeInstanceAttrTemplateID: {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						dsComputeInstanceAttrType: {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+
+		ReadContext: dataSourceComputeInstancesRead,
+	}
+}
+
+func dataSourceComputeInstancesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	log.Printf("[DEBUG] %s: beginning read", resourceIDString(d, "exoscale_compute_instances"))
+
+	zone := d.Get(dsComputeInstanceAttrZone).(string)
+
+	ctx, cancel := context.WithTimeout(ctx, d.Timeout(schema.TimeoutRead))
+	ctx = exoapi.WithEndpoint(ctx, exoapi.NewReqEndpoint(getEnvironment(meta), zone))
+	defer cancel()
+
+	client := GetComputeClient(meta)
+
+	instances, err := client.ListInstances(
+		ctx,
+		zone,
+	)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	data := make([]interface{}, 0, len(instances))
+	ids := make([]string, 0, len(instances))
+	instanceTypes := map[string]string{}
+
+	for _, computeInstance := range instances {
+		// we use ID to generate a resource ID, we cannot list instances without ID.
+		if computeInstance.ID == nil {
+			continue
+		}
+
+		ids = append(ids, *computeInstance.ID)
+		instanceData := map[string]interface{}{}
+
+		instanceData[dsComputeInstanceAttrID] = computeInstance.ID
+		instanceData[dsComputeInstanceAttrState] = computeInstance.State
+		instanceData[dsComputeInstanceAttrSSHKey] = computeInstance.SSHKey
+		instanceData[dsComputeInstanceAttrTemplateID] = computeInstance.TemplateID
+		instanceData[dsComputeInstanceAttrName] = computeInstance.Name
+
+		if computeInstance.CreatedAt != nil {
+			instanceData[dsComputeInstanceAttrCreatedAt] = computeInstance.CreatedAt.String()
+		}
+		if computeInstance.IPv6Address != nil {
+			instanceData[dsComputeInstanceAttrIPv6Address] = computeInstance.IPv6Address.String()
+		}
+		if computeInstance.PublicIPAddress != nil {
+			instanceData[dsComputeInstanceAttrPublicIPAddress] = computeInstance.PublicIPAddress.String()
+		}
+		if computeInstance.PrivateNetworkIDs != nil {
+			instanceData[dsComputeInstanceAttrPrivateNetworkIDs] = *computeInstance.PrivateNetworkIDs
+		}
+		if computeInstance.SecurityGroupIDs != nil {
+			instanceData[dsComputeInstanceAttrSecurityGroupIDs] = *computeInstance.SecurityGroupIDs
+		}
+		if computeInstance.Labels != nil {
+			instanceData[dsComputeInstanceAttrLabels] = *computeInstance.Labels
+		}
+
+		if computeInstance.InstanceTypeID != nil {
+			tid := *computeInstance.InstanceTypeID
+			if _, ok := instanceTypes[tid]; !ok {
+				instanceType, err := client.GetInstanceType(
+					ctx,
+					zone,
+					tid,
+				)
+				if err != nil {
+					return diag.Errorf("unable to retrieve instance type: %s", err)
+				}
+				instanceTypes[tid] = fmt.Sprintf(
+					"%s.%s",
+					strings.ToLower(*instanceType.Family),
+					strings.ToLower(*instanceType.Size),
+				)
+			}
+
+			instanceData[dsComputeInstanceAttrType] = instanceTypes[tid]
+		}
+
+		data = append(data, instanceData)
+	}
+
+	err = d.Set("instances", data)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	// by sorting instance IDs we can generate the same resource ID regardless of the order in which
+	// API returns instances in thelist.
+	sort.Strings(ids)
+
+	d.SetId(fmt.Sprintf("%x", md5.Sum([]byte(strings.Join(ids, "")))))
+
+	log.Printf("[DEBUG] %s: read finished successfully", resourceIDString(d, "exoscale_compute_instances"))
+
+	return nil
+}

--- a/exoscale/datasource_exoscale_compute_instances_test.go
+++ b/exoscale/datasource_exoscale_compute_instances_test.go
@@ -1,0 +1,100 @@
+package exoscale
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+var (
+	testAccDataSourceComputeInstancesDiskSize   int64 = 10
+	testAccDataSourceComputeInstancesName             = acctest.RandomWithPrefix(testPrefix)
+	testAccDataSourceComputeInstancesSSHKeyName       = acctest.RandomWithPrefix(testPrefix)
+	testAccDataSourceComputeInstancesType             = "standard.tiny"
+
+	testAccDataSourceComputeInstancesConfig = fmt.Sprintf(`
+locals {
+  zone = "%s"
+}
+data "exoscale_compute_template" "ubuntu" {
+  zone = local.zone
+  name = "Linux Ubuntu 20.04 LTS 64-bit"
+}
+
+resource "exoscale_security_group" "test" {
+  name = "%s"
+}
+
+resource "exoscale_ssh_key" "test" {
+  name       = "%s"
+  public_key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIB8bfA67mQWv4eGND/XVtPx1JW6RAqafub1lV1EcpB+b test"
+}
+
+resource "exoscale_compute_instance" "test" {
+  zone                    = local.zone
+  name                    = "%s"
+  type                    = "%s"
+  disk_size               = %d
+  template_id             = data.exoscale_compute_template.ubuntu.id
+  ipv6                    = true
+  ssh_key                 = exoscale_ssh_key.test.name
+
+  timeouts {
+    delete = "10m"
+  }
+}
+`,
+		testZoneName,
+		testAccDataSourceComputeInstanceSecurityGroupName,
+		testAccDataSourceComputeInstancesSSHKeyName,
+		testAccDataSourceComputeInstancesName,
+		testAccDataSourceComputeInstancesType,
+		testAccDataSourceComputeInstancesDiskSize,
+	)
+)
+
+func TestAccDataSourceComputeInstances(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:             testAccDataSourceComputeInstancesConfig,
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				Config: fmt.Sprintf(`
+%s
+
+data "exoscale_compute_instances" "test" {
+  zone = local.zone
+}
+`, testAccDataSourceComputeInstancesConfig),
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceComputeInstancesAttributes("data.exoscale_compute_instances.test", testAttrs{
+						"instances.#":         validateString("1"),
+						"instances.0.name":    validateString(testAccDataSourceComputeInstancesName),
+						"instances.0.type":    validateString(testAccDataSourceComputeInstancesType),
+						"instances.0.ssh_key": validateString(testAccDataSourceComputeInstancesSSHKeyName),
+					}),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceComputeInstancesAttributes(ds string, expected testAttrs) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		for name, res := range s.RootModule().Resources {
+			if name == ds {
+				return checkResourceAttributes(expected, res.Primary.Attributes)
+			}
+		}
+
+		return errors.New("exoscale_compute_instances data source not found in the state")
+	}
+}

--- a/exoscale/provider.go
+++ b/exoscale/provider.go
@@ -140,6 +140,7 @@ func Provider() *schema.Provider {
 			"exoscale_anti_affinity_group": dataSourceAntiAffinityGroup(),
 			"exoscale_compute":             dataSourceCompute(),
 			"exoscale_compute_instance":    dataSourceComputeInstance(),
+			"exoscale_compute_instances":   dataSourceComputeInstances(),
 			"exoscale_compute_ipaddress":   dataSourceComputeIPAddress(),
 			"exoscale_compute_template":    dataSourceComputeTemplate(),
 			"exoscale_domain":              dataSourceDomain(),


### PR DESCRIPTION
This PR adds a new data source that lists all instances using [List Compute instances API](https://openapi-v2.exoscale.com/#operation-list-instances).