### PR TITLE
New data sources: exoscale_instance_pool and exoscale_instance_pool_list

### DIFF
--- a/docs/data-sources/instance_pool.md
+++ b/docs/data-sources/instance_pool.md
@@ -1,0 +1,73 @@
+---
+page_title: "Exoscale: exoscale_instance_pool"
+description: |-
+  Provides information about a Instance Pool.
+---
+
+# exoscale\_instance\_pool
+
+Provides information on an [Exoscale Instance Pool][pool-doc].
+
+
+## Example Usage
+
+```hcl
+data "exoscale_instance_pool" "example" {
+  zone = "ch-gva-2"
+  name = "my-instance-pool"
+}
+
+output "instance_pool_state" {
+  value = data.exoscale_instance_pool.example.state
+}
+```
+
+## Arguments Reference
+
+* `zone` - (Required) The [zone][zone] of the Compute instance pool.
+
+One of the following arguments is required:
+
+* `id` - The ID of the Compute instance pool.
+* `name` - The name of the Compute instance pool.
+
+
+## Attributes Reference
+
+In addition to the arguments listed above, the following attributes are exported:
+
+* `affinity_group_ids` - A list of [Anti-Affinity Group][r-affinity] IDs.
+* `deploy_target_id` - A Deploy Target ID.
+* `description` - The description of the Instance Pool.
+* `disk_size` - The managed Compute instances disk size.
+* `elastic_ip_ids` - A list of [Elastic IP][eip-doc] IDs.
+* `instance_prefix` - The string to add as prefix to managed Compute instances name.
+* `instance_type` - The managed Compute instances [type][type].
+* `ipv6` - Whether IPv6 is enabled on managed Compute instances.
+* `key_pair` - The name of the [SSH key pair][sshkeypair].
+* `labels` - A map of key/value labels.
+* `network_ids` - A list of [Private Network][privnet-doc] IDs.
+* `security_group_ids` - A list of [Security Group][r-security_group] IDs.
+* `size` - The number of Compute instance members the Instance Pool manages.
+* `state` - Instance Pool state.
+* `template_id` - The ID of the instance [template][template].
+* `user_data` - A [cloud-init][cloudinit] configuration.
+* `instances` - The list of Instance Pool members.
+
+The `instances` items contains:
+
+* `id` - The ID of the compute instance.
+* `ipv6_address` - The IPv6 address of the compute instance's main network interface.
+* `name` - The name of the compute instance.
+* `public_ip_address` - The IPv4 address of the compute instance's main network interface.
+
+[pool-doc]: https://community.exoscale.com/documentation/compute/instance-pools/
+[zone]: https://www.exoscale.com/datacenters/
+[r-affinity]: ../resources/affinity
+[eip-doc]: https://community.exoscale.com/documentation/compute/eip/
+[type]: https://www.exoscale.com/pricing/#/compute/
+[sshkeypair]: https://community.exoscale.com/documentation/compute/ssh-keypairs/
+[privnet-doc]: https://community.exoscale.com/documentation/compute/private-networks/
+[r-security_group]: ../resources/security_group
+[template]: https://www.exoscale.com/templates/
+[cloudinit]: http://cloudinit.readthedocs.io/en/latest/

--- a/docs/data-sources/instance_pool_list.md
+++ b/docs/data-sources/instance_pool_list.md
@@ -1,0 +1,32 @@
+---
+page_title: "Exoscale: exoscale_instance_pool_list"
+description: |-
+  Shows a list of instance Pools.
+---
+
+# exoscale\_instance\_pool\_list
+
+Lists available [Exoscale Instance Pools][pool-doc].
+
+
+## Example Usage
+
+```hcl
+data "exoscale_instance_pool_list" "example" {
+  zone = "ch-gva-2"
+}
+```
+
+## Arguments Reference
+
+* `zone` - (Required) The [zone][zone] of the Compute instance pool.
+
+## Attributes Reference
+
+* `pools` - The list of instance pools.
+
+For `pools` items schema see [exoscale_instance_pool][d-instance_pool] data source.
+
+[pool-doc]: https://community.exoscale.com/documentation/compute/instance-pools/
+[zone]: https://www.exoscale.com/datacenters/
+[d-instance_pool]: ../data-sources/instance_pool

--- a/exoscale/datasource_exoscale_instance_pool.go
+++ b/exoscale/datasource_exoscale_instance_pool.go
@@ -1,0 +1,309 @@
+package exoscale
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	exo "github.com/exoscale/egoscale/v2"
+	exoapi "github.com/exoscale/egoscale/v2/api"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+const (
+	dsInstancePoolAttrAffinityGroupIDs        = "affinity_group_ids"
+	dsInstancePoolAttrDeployTargetID          = "deploy_target_id"
+	dsInstancePoolAttrDescription             = "description"
+	dsInstancePoolAttrDiskSize                = "disk_size"
+	dsInstancePoolAttrElasticIPIDs            = "elastic_ip_ids"
+	dsInstancePoolAttrInstancePrefix          = "instance_prefix"
+	dsInstancePoolAttrInstanceType            = "instance_type"
+	dsInstancePoolAttrIPv6                    = "ipv6"
+	dsInstancePoolAttrKeyPair                 = "key_pair"
+	dsInstancePoolAttrLabels                  = "labels"
+	dsInstancePoolAttrID                      = "id"
+	dsInstancePoolAttrName                    = "name"
+	dsInstancePoolAttrNetworkIDs              = "network_ids"
+	dsInstancePoolAttrSecurityGroupIDs        = "security_group_ids"
+	dsInstancePoolAttrSize                    = "size"
+	dsInstancePoolAttrState                   = "state"
+	dsInstancePoolAttrTemplateID              = "template_id"
+	dsInstancePoolAttrUserData                = "user_data"
+	dsInstancePoolAttrInstances               = "instances"
+	dsInstancePoolAttrInstanceID              = "id"
+	dsInstancePoolAttrInstanceIPv6Address     = "ipv6_address"
+	dsInstancePoolAttrInstanceName            = "name"
+	dsInstancePoolAttrInstancePublicIPAddress = "public_ip_address"
+	dsInstancePoolAttrZone                    = "zone"
+)
+
+// getDataSourceInstancePoolSchema returns a schema for a single instance pool data source.
+func getDataSourceInstancePoolSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		dsInstancePoolAttrAffinityGroupIDs: {
+			Type:     schema.TypeSet,
+			Computed: true,
+			Set:      schema.HashString,
+			Elem:     &schema.Schema{Type: schema.TypeString},
+		},
+		dsInstancePoolAttrDeployTargetID: {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		dsInstancePoolAttrDescription: {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		dsInstancePoolAttrDiskSize: {
+			Type:     schema.TypeInt,
+			Computed: true,
+		},
+		dsInstancePoolAttrElasticIPIDs: {
+			Type:     schema.TypeSet,
+			Computed: true,
+			Set:      schema.HashString,
+			Elem:     &schema.Schema{Type: schema.TypeString},
+		},
+		dsInstancePoolAttrInstancePrefix: {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		dsInstancePoolAttrInstanceType: {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		dsInstancePoolAttrIPv6: {
+			Type:     schema.TypeBool,
+			Computed: true,
+		},
+		dsInstancePoolAttrKeyPair: {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		dsInstancePoolAttrLabels: {
+			Type:     schema.TypeMap,
+			Elem:     &schema.Schema{Type: schema.TypeString},
+			Optional: true,
+		},
+		dsInstancePoolAttrName: {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		dsInstancePoolAttrID: {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		dsInstancePoolAttrNetworkIDs: {
+			Type:     schema.TypeSet,
+			Computed: true,
+			Set:      schema.HashString,
+			Elem:     &schema.Schema{Type: schema.TypeString},
+		},
+		dsInstancePoolAttrSecurityGroupIDs: {
+			Type:     schema.TypeSet,
+			Computed: true,
+			Set:      schema.HashString,
+			Elem:     &schema.Schema{Type: schema.TypeString},
+		},
+		dsInstancePoolAttrSize: {
+			Type:     schema.TypeInt,
+			Computed: true,
+		},
+		dsInstancePoolAttrState: {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		dsInstancePoolAttrTemplateID: {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		dsInstancePoolAttrUserData: {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		dsInstancePoolAttrInstances: {
+			Type:     schema.TypeSet,
+			Computed: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					dsInstancePoolAttrInstanceID: {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+					dsInstancePoolAttrInstanceIPv6Address: {
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+					dsInstancePoolAttrInstanceName: {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+					dsInstancePoolAttrInstancePublicIPAddress: {
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+				},
+			},
+		},
+		dsInstancePoolAttrZone: {
+			Type:     schema.TypeString,
+			Required: true,
+		},
+	}
+}
+
+func dataSourceInstancePool() *schema.Resource {
+	return &schema.Resource{
+		Schema: func() map[string]*schema.Schema {
+			schema := getDataSourceInstancePoolSchema()
+
+			// adding context-aware schema settings here so getDataSourceInstancePoolSchema can be used in list method
+			schema[dsInstancePoolAttrID].ConflictsWith = []string{dsInstancePoolAttrName}
+			schema[dsInstancePoolAttrName].ConflictsWith = []string{dsInstancePoolAttrID}
+			return schema
+		}(),
+		ReadContext: dataSourceInstancePoolRead,
+	}
+}
+
+func dataSourceInstancePoolRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	log.Printf("[DEBUG] %s: beginning read", resourceInstancePoolIDString(d))
+
+	zone := d.Get(dsInstancePoolAttrZone).(string)
+
+	ctx, cancel := context.WithTimeout(ctx, d.Timeout(schema.TimeoutRead))
+	ctx = exoapi.WithEndpoint(ctx, exoapi.NewReqEndpoint(getEnvironment(meta), zone))
+	defer cancel()
+
+	client := GetComputeClient(meta)
+
+	instancePoolID, byInstancePoolID := d.GetOk(dsInstancePoolAttrID)
+	instancePoolName, byInstancePoolName := d.GetOk(dsInstancePoolAttrName)
+	if !byInstancePoolID && !byInstancePoolName {
+		return diag.Errorf(
+			"either %s or %s must be specified",
+			dsInstancePoolAttrName,
+			dsInstancePoolAttrID,
+		)
+	}
+
+	instancePool, err := client.FindInstancePool(
+		ctx,
+		zone, func() string {
+			if byInstancePoolID {
+				return instancePoolID.(string)
+			}
+			return instancePoolName.(string)
+		}(),
+	)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(*instancePool.ID)
+
+	data, err := dataSourceInstancePoolBuildData(instancePool)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	instanceType, err := client.GetInstanceType(
+		ctx,
+		zone,
+		*instancePool.InstanceTypeID,
+	)
+	if err != nil {
+		return diag.Errorf("error retrieving instance type: %s", err)
+	}
+
+	data[dsInstancePoolAttrInstanceType] = fmt.Sprintf(
+		"%s.%s",
+		strings.ToLower(*instanceType.Family),
+		strings.ToLower(*instanceType.Size),
+	)
+
+	if instancePool.InstanceIDs != nil {
+		instancesData := make([]interface{}, len(*instancePool.InstanceIDs))
+		for i, id := range *instancePool.InstanceIDs {
+			instance, err := client.GetInstance(ctx, zone, id)
+			if err != nil {
+				return diag.FromErr(err)
+			}
+
+			var ipv6, publicIp string
+			if instance.IPv6Address != nil {
+				ipv6 = instance.IPv6Address.String()
+			}
+			if instance.PublicIPAddress != nil {
+				publicIp = instance.PublicIPAddress.String()
+			}
+
+			instancesData[i] = map[string]interface{}{
+				dsInstancePoolAttrInstanceID:              id,
+				dsInstancePoolAttrInstanceIPv6Address:     ipv6,
+				dsInstancePoolAttrInstanceName:            instance.Name,
+				dsInstancePoolAttrInstancePublicIPAddress: publicIp,
+			}
+		}
+
+		data[dsInstancePoolAttrInstances] = instancesData
+	}
+
+	for key, value := range data {
+		err := d.Set(key, value)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	log.Printf("[DEBUG] %s: read finished successfully", resourceInstancePoolIDString(d))
+
+	return nil
+}
+
+// dataSourceInstancePoolBuildData builds terraform data object from egoscale API struct.
+func dataSourceInstancePoolBuildData(pool *exo.InstancePool) (map[string]interface{}, error) {
+	data := map[string]interface{}{}
+
+	data[dsInstancePoolAttrDeployTargetID] = pool.DeployTargetID
+	data[dsInstancePoolAttrDescription] = defaultString(pool.Description, "")
+	data[dsInstancePoolAttrDiskSize] = pool.DiskSize
+	data[dsInstancePoolAttrID] = pool.ID
+	data[dsInstancePoolAttrInstancePrefix] = defaultString(pool.InstancePrefix, "")
+	data[dsInstancePoolAttrIPv6] = defaultBool(pool.IPv6Enabled, false)
+	data[dsInstancePoolAttrKeyPair] = pool.SSHKey
+	data[dsInstancePoolAttrLabels] = pool.Labels
+	data[dsInstancePoolAttrName] = pool.Name
+	data[dsInstancePoolAttrSize] = pool.Size
+	data[dsInstancePoolAttrState] = pool.State
+	data[dsInstancePoolAttrTemplateID] = pool.TemplateID
+	data[dsInstancePoolAttrZone] = pool.Zone
+
+	if pool.AntiAffinityGroupIDs != nil {
+		data[dsInstancePoolAttrAffinityGroupIDs] = *pool.AntiAffinityGroupIDs
+	}
+
+	if pool.ElasticIPIDs != nil {
+		data[dsInstancePoolAttrElasticIPIDs] = *pool.ElasticIPIDs
+	}
+
+	if pool.PrivateNetworkIDs != nil {
+		data[dsInstancePoolAttrNetworkIDs] = *pool.PrivateNetworkIDs
+	}
+
+	if pool.SecurityGroupIDs != nil {
+		data[dsInstancePoolAttrSecurityGroupIDs] = *pool.SecurityGroupIDs
+	}
+
+	if pool.UserData != nil {
+		userData, err := decodeUserData(*pool.UserData)
+		if err != nil {
+			return nil, fmt.Errorf("error decoding user data: %w", err)
+		}
+		data[dsInstancePoolAttrUserData] = userData
+	}
+
+	return data, nil
+}

--- a/exoscale/datasource_exoscale_instance_pool_list.go
+++ b/exoscale/datasource_exoscale_instance_pool_list.go
@@ -1,0 +1,146 @@
+package exoscale
+
+import (
+	"context"
+	"crypto/md5"
+	"fmt"
+	"log"
+	"sort"
+	"strings"
+
+	exoapi "github.com/exoscale/egoscale/v2/api"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceInstancePoolList() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			dsInstancePoolAttrZone: {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"pools": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: getDataSourceInstancePoolSchema(),
+				},
+			},
+		},
+
+		ReadContext: dataSourceInstancePoolListRead,
+	}
+}
+
+func dataSourceInstancePoolListRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	log.Printf("[DEBUG] %s: beginning read", resourceIDString(d, "exoscale_instance_pool_list"))
+
+	zone := d.Get(dsInstancePoolAttrZone).(string)
+
+	ctx, cancel := context.WithTimeout(ctx, d.Timeout(schema.TimeoutRead))
+	ctx = exoapi.WithEndpoint(ctx, exoapi.NewReqEndpoint(getEnvironment(meta), zone))
+	defer cancel()
+
+	client := GetComputeClient(meta)
+
+	pools, err := client.ListInstancePools(
+		ctx,
+		zone,
+	)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	data := make([]interface{}, 0, len(pools))
+	ids := make([]string, 0, len(pools))
+	instanceTypes := map[string]string{}
+
+	for _, item := range pools {
+		// we use ID to generate a resource ID, we cannot list instance pools without ID.
+		if item.ID == nil {
+			continue
+		}
+
+		ids = append(ids, *item.ID)
+
+		pool, err := client.FindInstancePool(
+			ctx,
+			zone,
+			*item.ID,
+		)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		poolData, err := dataSourceInstancePoolBuildData(pool)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		if pool.InstanceTypeID != nil {
+			tid := *pool.InstanceTypeID
+			if _, ok := instanceTypes[tid]; !ok {
+				instanceType, err := client.GetInstanceType(
+					ctx,
+					zone,
+					tid,
+				)
+				if err != nil {
+					return diag.Errorf("unable to retrieve instance type: %s", err)
+				}
+				instanceTypes[tid] = fmt.Sprintf(
+					"%s.%s",
+					strings.ToLower(*instanceType.Family),
+					strings.ToLower(*instanceType.Size),
+				)
+			}
+
+			poolData[dsInstancePoolAttrInstanceType] = instanceTypes[tid]
+		}
+
+		if pool.InstanceIDs != nil {
+			instancesData := make([]interface{}, len(*pool.InstanceIDs))
+			for i, id := range *pool.InstanceIDs {
+				instance, err := client.GetInstance(ctx, zone, id)
+				if err != nil {
+					return diag.FromErr(err)
+				}
+
+				var ipv6, publicIp string
+				if instance.IPv6Address != nil {
+					ipv6 = instance.IPv6Address.String()
+				}
+				if instance.PublicIPAddress != nil {
+					publicIp = instance.PublicIPAddress.String()
+				}
+
+				instancesData[i] = map[string]interface{}{
+					dsInstancePoolAttrInstanceID:              id,
+					dsInstancePoolAttrInstanceIPv6Address:     ipv6,
+					dsInstancePoolAttrInstanceName:            instance.Name,
+					dsInstancePoolAttrInstancePublicIPAddress: publicIp,
+				}
+			}
+
+			poolData[dsInstancePoolAttrInstances] = instancesData
+		}
+
+		data = append(data, poolData)
+	}
+
+	err = d.Set("pools", &data)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	// by sorting instance IDs we can generate the same resource ID regardless of the order in which
+	// API returns instances in thelist.
+	sort.Strings(ids)
+
+	d.SetId(fmt.Sprintf("%x", md5.Sum([]byte(strings.Join(ids, "")))))
+
+	log.Printf("[DEBUG] %s: read finished successfully", resourceIDString(d, "exoscale_instance_pool_list"))
+
+	return nil
+}

--- a/exoscale/datasource_exoscale_instance_pool_list_test.go
+++ b/exoscale/datasource_exoscale_instance_pool_list_test.go
@@ -1,0 +1,98 @@
+package exoscale
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+var (
+	testAccDataSourceInstancePoolListDiskSize     = "10"
+	testAccDataSourceInstancePoolListInstanceType = "standard.tiny"
+	testAccDataSourceInstancePoolListKeyPair      = acctest.RandomWithPrefix(testPrefix)
+	testAccDataSourceInstancePoolListName         = acctest.RandomWithPrefix(testPrefix)
+)
+
+var testAccDataSourceInstancePoolListConfig = fmt.Sprintf(`
+locals {
+  zone = "%s"
+	instance_type = "%s"
+	disk_size = "%s"
+}
+resource "exoscale_ssh_keypair" "test" {
+  name = "%s"
+}
+data "exoscale_compute_template" "ubuntu" {
+  zone = local.zone
+  name = "Linux Ubuntu 20.04 LTS 64-bit"
+}
+resource "exoscale_instance_pool" "test1" {
+  zone = local.zone
+  name = "%s"
+  template_id = data.exoscale_compute_template.ubuntu.id
+  instance_type = local.instance_type
+  size = 1
+  disk_size = local.disk_size
+  key_pair = exoscale_ssh_keypair.test.name
+}
+resource "exoscale_instance_pool" "test2" {
+  zone = local.zone
+  name = "%s"
+  template_id = data.exoscale_compute_template.ubuntu.id
+  instance_type = local.instance_type
+  size = 1
+  disk_size = local.disk_size
+  key_pair = exoscale_ssh_keypair.test.name
+}`,
+	testZoneName,
+	testAccDataSourceInstancePoolListInstanceType,
+	testAccDataSourceInstancePoolListDiskSize,
+	testAccDataSourceInstancePoolListKeyPair,
+	testAccDataSourceInstancePoolListName+"_1",
+	testAccDataSourceInstancePoolListName+"_2",
+)
+
+func TestAccDataSourceInstancePoolList(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceInstancePoolListConfig,
+			},
+			{
+				Config: fmt.Sprintf(`
+%s
+data "exoscale_instance_pool_list" "test" {
+  zone = local.zone
+}
+`,
+					testAccDataSourceInstancePoolListConfig,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceInstancePoolListAttributes("data.exoscale_instance_pool_list.test", testAttrs{
+						"pools.#":             validateString("2"),
+						"pools.0.instances.#": validateString("1"),
+						"pools.1.instances.#": validateString("1"),
+					}),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceInstancePoolListAttributes(ds string, expected testAttrs) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		for name, res := range s.RootModule().Resources {
+			if name == ds {
+				return checkResourceAttributes(expected, res.Primary.Attributes)
+			}
+		}
+
+		return errors.New("exoscale_instance_pool_list data source not found in the state")
+	}
+}

--- a/exoscale/datasource_exoscale_instance_pool_test.go
+++ b/exoscale/datasource_exoscale_instance_pool_test.go
@@ -1,0 +1,138 @@
+package exoscale
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+var (
+	testAccDataSourceInstancePoolAttrAffinityGroupName = acctest.RandomWithPrefix(testPrefix)
+	testAccDataSourceInstancePoolDescription           = acctest.RandString(10)
+	testAccDataSourceInstancePoolDiskSize              = "10"
+	testAccDataSourceInstancePoolInstancePrefix        = "test"
+	testAccDataSourceInstancePoolInstanceType          = "standard.tiny"
+	testAccDataSourceInstancePoolKeyPair               = acctest.RandomWithPrefix(testPrefix)
+	testAccDataSourceInstancePoolLabelValue            = acctest.RandomWithPrefix(testPrefix)
+	testAccDataSourceInstancePoolNetwork               = acctest.RandomWithPrefix(testPrefix)
+	testAccDataSourceInstancePoolName                  = acctest.RandomWithPrefix(testPrefix)
+	testAccDataSourceInstancePoolSize                  = "2"
+	testAccDataSourceInstancePoolTemplateID            = testInstanceTemplateID
+	testAccDataSourceInstancePoolUserData              = acctest.RandString(10)
+)
+
+func TestAccDataSourceInstancePool(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      `data "exoscale_instance_pool" "test" { zone = "lolnope" }`,
+				ExpectError: regexp.MustCompile("either name or id must be specified"),
+			},
+			{
+				Config: fmt.Sprintf(`
+locals {
+  zone = "%s"
+}
+
+resource "exoscale_affinity" "test" {
+  name = "%s"
+}
+
+resource "exoscale_network" "test" {
+  zone = local.zone
+  name = "%s"
+}
+
+resource "exoscale_ssh_keypair" "test" {
+  name = "%s"
+}
+
+resource "exoscale_ipaddress" "test" {
+  zone = local.zone
+}
+
+resource "exoscale_instance_pool" "test" {
+  zone = local.zone
+  name = "%s"
+  description = "%s"
+  template_id = "%s"
+  instance_type = "%s"
+  instance_prefix = "%s"
+  size = %s
+  disk_size = %s
+  ipv6 = false
+  key_pair = exoscale_ssh_keypair.test.name
+  affinity_group_ids = [exoscale_affinity.test.id]
+  network_ids = [exoscale_network.test.id]
+  elastic_ip_ids = [exoscale_ipaddress.test.id]
+  user_data = "%s"
+  labels = {
+    test = "%s"
+  }
+}
+
+data "exoscale_instance_pool" "by-id" {
+  zone = exoscale_instance_pool.test.zone
+  id   = exoscale_instance_pool.test.id
+}`,
+					testZoneName,
+					testAccDataSourceInstancePoolAttrAffinityGroupName,
+					testAccDataSourceInstancePoolNetwork,
+					testAccDataSourceInstancePoolKeyPair,
+					testAccDataSourceInstancePoolName,
+					testAccDataSourceInstancePoolDescription,
+					testAccDataSourceInstancePoolTemplateID,
+					testAccDataSourceInstancePoolInstanceType,
+					testAccDataSourceInstancePoolInstancePrefix,
+					testAccDataSourceInstancePoolSize,
+					testAccDataSourceInstancePoolDiskSize,
+					testAccDataSourceInstancePoolUserData,
+					testAccDataSourceInstancePoolLabelValue,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceInstancePoolAttributes("data.exoscale_instance_pool.by-id", testAttrs{
+						"affinity_group_ids.#": validateString("1"),
+						"affinity_group_ids.0": validation.ToDiagFunc(validation.IsUUID),
+						"description":          validateString(testAccDataSourceInstancePoolDescription),
+						"disk_size":            validateString(testAccDataSourceInstancePoolDiskSize),
+						"instance_type":        validateComputeInstanceType,
+						"instance_prefix":      validateString(testAccDataSourceInstancePoolInstancePrefix),
+						"key_pair":             validateString(testAccDataSourceInstancePoolKeyPair),
+						"labels.test":          validateString(testAccDataSourceInstancePoolLabelValue),
+						"id":                   validation.ToDiagFunc(validation.IsUUID),
+						"name":                 validateString(testAccDataSourceInstancePoolName),
+						"network_ids.#":        validateString("1"),
+						"network_ids.0":        validation.ToDiagFunc(validation.IsUUID),
+						"size":                 validateString(testAccDataSourceInstancePoolSize),
+						"state":                validateString("running"),
+						"template_id":          validateString(testAccDataSourceInstancePoolTemplateID),
+						"user_data":            validateString(testAccDataSourceInstancePoolUserData),
+						"instances.#":          validateString("2"),
+						"instances.0.id":       validation.ToDiagFunc(validation.IsUUID),
+						"instances.1.id":       validation.ToDiagFunc(validation.IsUUID),
+					}),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceInstancePoolAttributes(ds string, expected testAttrs) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		for name, res := range s.RootModule().Resources {
+			if name == ds {
+				return checkResourceAttributes(expected, res.Primary.Attributes)
+			}
+		}
+
+		return errors.New("exoscale_instance_pool data source not found in the state")
+	}
+}

--- a/exoscale/provider.go
+++ b/exoscale/provider.go
@@ -146,6 +146,8 @@ func Provider() *schema.Provider {
 			"exoscale_domain":                dataSourceDomain(),
 			"exoscale_domain_record":         dataSourceDomainRecord(),
 			"exoscale_elastic_ip":            dataSourceElasticIP(),
+			"exoscale_instance_pool":         dataSourceInstancePool(),
+			"exoscale_instance_pool_list":    dataSourceInstancePoolList(),
 			"exoscale_network":               dataSourceNetwork(),
 			"exoscale_nlb":                   dataSourceNLB(),
 			"exoscale_private_network":       dataSourcePrivateNetwork(),

--- a/exoscale/provider_test.go
+++ b/exoscale/provider_test.go
@@ -32,7 +32,7 @@ const (
 		    zoneid=85664334-0fd5-47bd-94a1-b4f40b1d2eb7 \
 		    name="Linux Ubuntu 20.04 LTS 64-bit"
 	*/
-	testInstanceTemplateID = "e199db71-49ce-4daa-826d-57fad9dfac77"
+	testInstanceTemplateID = "ac881037-b3d1-46f7-8385-ffb040088c7a"
 
 	testInstanceTypeIDTiny   = "b6cd1ff5-3a2f-4e9d-a4d1-8988c1191fe8"
 	testInstanceTypeIDSmall  = "21624abb-764e-4def-81d7-9fc54b5957fb"


### PR DESCRIPTION
This PR adds 2 new data sources:

- `exoscale_instance_pool`: provides details about a single instance pool,
- `exoscale_instance_pool_list`: lists all instance pools in the zone.