### PR TITLE
Dbaas: fix infinite version attribute update

### DIFF
--- a/docs/resources/database.md
+++ b/docs/resources/database.md
@@ -122,7 +122,7 @@ The `opensearch` block supports:
 	* `max_old_space_size` -           {Type -  schema.TypeInt, Optional -  true, Default -  128},
 	* `request_timeout` -  {Type -  schema.TypeInt, Optional -  true, Default -  30000},
 `settings` -  OpenSearch-specific settings, in json. e.g.`jsonencode({thread_pool_search_size: 64})`. Use `exo x get-dbaas-settings-opensearch` to get a list of available settings.
-`version` -  OpenSearch major version.
+* `version` -  OpenSearch major version.
 
 ## Attributes Reference
 

--- a/exoscale/resource_exoscale_database_kafka.go
+++ b/exoscale/resource_exoscale_database_kafka.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 
 	egoscale "github.com/exoscale/egoscale/v2"
 	"github.com/exoscale/egoscale/v2/oapi"
@@ -498,7 +499,10 @@ func resourceDatabaseApplyKafka(ctx context.Context, d *schema.ResourceData, cli
 	}
 
 	if v := databaseService.Version; v != nil {
-		kafka[resDatabaseAttrKafkaVersion] = *v
+		// for kafka, the user specifies the major.minor e.g. 3.0
+		// and the api return major.minor.patch e.g. 3.0.0
+		version := strings.SplitN(*v, ".", 3)
+		kafka[resDatabaseAttrKafkaVersion] = version[0] + "." + version[1]
 	}
 
 	if len(kafka) > 0 {

--- a/exoscale/resource_exoscale_database_kafka.go
+++ b/exoscale/resource_exoscale_database_kafka.go
@@ -499,8 +499,8 @@ func resourceDatabaseApplyKafka(ctx context.Context, d *schema.ResourceData, cli
 	}
 
 	if v := databaseService.Version; v != nil {
-		// for kafka, the user specifies the major.minor e.g. 3.0
-		// and the api return major.minor.patch e.g. 3.0.0
+		// for kafka, the user specifies major.minor e.g. 3.0
+		// and the api returns major.minor.patch e.g. 3.0.0
 		version := strings.SplitN(*v, ".", 3)
 		kafka[resDatabaseAttrKafkaVersion] = version[0] + "." + version[1]
 	}

--- a/exoscale/resource_exoscale_database_mysql.go
+++ b/exoscale/resource_exoscale_database_mysql.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 
 	egoscale "github.com/exoscale/egoscale/v2"
 	"github.com/exoscale/egoscale/v2/oapi"
@@ -362,7 +363,7 @@ func resourceDatabaseApplyMysql(ctx context.Context, d *schema.ResourceData, cli
 	}
 
 	if v := databaseService.Version; v != nil {
-		mysql[resDatabaseAttrMysqlVersion] = *v
+		mysql[resDatabaseAttrMysqlVersion] = strings.SplitN(*v, ".", 2)[0]
 	}
 
 	if len(mysql) > 0 {

--- a/exoscale/resource_exoscale_database_pg.go
+++ b/exoscale/resource_exoscale_database_pg.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 
 	egoscale "github.com/exoscale/egoscale/v2"
 	"github.com/exoscale/egoscale/v2/oapi"
@@ -414,7 +415,7 @@ func resourceDatabaseApplyPg(ctx context.Context, d *schema.ResourceData, client
 	}
 
 	if v := databaseService.Version; v != nil {
-		pg[resDatabaseAttrPgVersion] = *v
+		pg[resDatabaseAttrPgVersion] = strings.SplitN(*v, ".", 2)[0]
 	}
 
 	if v := databaseService.PgbouncerSettings; v != nil {


### PR DESCRIPTION


For some databases types, the user specified version and the version returned by the API is different (e.g. `3` vs `3.0.1`). Because of that the plan always has changes.

```
  # exoscale_database.kafka_prod will be updated in-place
  ~ resource "exoscale_database" "kafka_prod" {
        id                     = "kafka-prod"
        name                   = "kafka-prod"
        # (14 unchanged attributes hidden)

      ~ kafka {
          ~ version                = "3.0.0" -> "3.0"
            # (6 unchanged attributes hidden)
        }
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

This PR fixes this issue for all affected databases:
- kafka → fixed
- mysql → fixed
- opensearch → was already fixed in the initial implementation 
- postgres → fixed
- redis → doesn't have a version field


fixes #173 