### PR TITLE
Migrate DNS resources to Public API

### DIFF
--- a/exoscale/datasource_exoscale_domain_record.go
+++ b/exoscale/datasource_exoscale_domain_record.go
@@ -198,7 +198,7 @@ func dataSourceDomainRecordRead(ctx context.Context, d *schema.ResourceData, met
 	for i, r := range records {
 		recordsDetails[i] = map[string]interface{}{
 			"id":          r.ID,
-			"domain":      domainName,
+			"domain":      *domain.ID,
 			"name":        r.Name,
 			"content":     r.Content,
 			"record_type": r.Type,

--- a/exoscale/datasource_exoscale_domain_record_test.go
+++ b/exoscale/datasource_exoscale_domain_record_test.go
@@ -27,7 +27,7 @@ resource "exoscale_domain" "exo" {
 }
 
 resource "exoscale_domain_record" "mx" {
-  domain      = exoscale_domain.exo.id
+  domain      = exoscale_domain.exo.name
   name        = "%s"
   record_type = "%s"
   content     = "%s"
@@ -45,7 +45,7 @@ resource "exoscale_domain_record" "mx" {
 
 	testAccDataSourceDomainRecordConfigCreate2 = fmt.Sprintf(`
 resource "exoscale_domain_record" "mx2" {
-  domain      = exoscale_domain.exo.id
+  domain      = exoscale_domain.exo.name
   name        = "%s"
   record_type = "%s"
   content     = "%s"
@@ -73,10 +73,10 @@ func TestAccDataSourceDomainRecord(t *testing.T) {
 %s
 
 data "exoscale_domain_record" "test_record" {
-  domain = exoscale_domain.exo.id
+  domain = exoscale_domain.exo.name
   filter {}
 }`, testAccDataSourceDomainRecordConfigCreate1, testAccDataSourceDomainRecordConfigCreate2),
-				ExpectError: regexp.MustCompile("either name or id must be specified"),
+				ExpectError: regexp.MustCompile("filter not valid"),
 			},
 			{
 				Config: fmt.Sprintf(`
@@ -85,7 +85,7 @@ data "exoscale_domain_record" "test_record" {
 %s
 
 data "exoscale_domain_record" "test_record" {
-  domain = exoscale_domain.exo.id
+  domain = exoscale_domain.exo.name
   filter {
     name   = exoscale_domain_record.mx.name
   }
@@ -100,6 +100,29 @@ data "exoscale_domain_record" "test_record" {
 					),
 				),
 			},
+			// Commented out until domain record resource is ported to public API
+			//			{
+			//				Config: fmt.Sprintf(`
+			//	%s
+			//
+			//	%s
+			//
+			//			data "exoscale_domain_record" "test_record" {
+			//			  domain = exoscale_domain.exo.name
+			//			  filter {
+			//			    id = exoscale_domain_record.mx.id
+			//			  }
+			//			}`, testAccDataSourceDomainRecordConfigCreate1, testAccDataSourceDomainRecordConfigCreate2),
+			//				Check: resource.ComposeTestCheckFunc(
+			//					testAccDataSourceDomainRecordAttributes(
+			//						"data.exoscale_domain_record.test_record",
+			//						testAttrs{
+			//							"records.0.name":   validateString(testAccDataSourceDomainRecordName1),
+			//							"records.0.domain": validateString(testAccDataSourceDomainRecordDomainName),
+			//						},
+			//					),
+			//				),
+			//			},
 			{
 				Config: fmt.Sprintf(`
 %s
@@ -107,29 +130,7 @@ data "exoscale_domain_record" "test_record" {
 %s
 
 			data "exoscale_domain_record" "test_record" {
-			  domain = exoscale_domain.exo.id
-			  filter {
-			    id = exoscale_domain_record.mx.id
-			  }
-			}`, testAccDataSourceDomainRecordConfigCreate1, testAccDataSourceDomainRecordConfigCreate2),
-				Check: resource.ComposeTestCheckFunc(
-					testAccDataSourceDomainRecordAttributes(
-						"data.exoscale_domain_record.test_record",
-						testAttrs{
-							"records.0.name":   validateString(testAccDataSourceDomainRecordName1),
-							"records.0.domain": validateString(testAccDataSourceDomainRecordDomainName),
-						},
-					),
-				),
-			},
-			{
-				Config: fmt.Sprintf(`
-%s
-
-%s
-
-			data "exoscale_domain_record" "test_record" {
-			  domain = exoscale_domain.exo.id
+			  domain = exoscale_domain.exo.name
 			  filter {
 			    record_type = "MX"
 			  }
@@ -151,7 +152,7 @@ data "exoscale_domain_record" "test_record" {
 %s
 
 			data "exoscale_domain_record" "test_record" {
-			  domain = exoscale_domain.exo.id
+			  domain = exoscale_domain.exo.name
 			  filter {
 			    content_regex = "mta.*"
 			  }

--- a/exoscale/resource_exoscale_domain.go
+++ b/exoscale/resource_exoscale_domain.go
@@ -2,9 +2,14 @@ package exoscale
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"log"
 
-	"github.com/exoscale/egoscale"
+	exo "github.com/exoscale/egoscale/v2"
+	exoapi "github.com/exoscale/egoscale/v2/api"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -21,27 +26,31 @@ func resourceDomain() *schema.Resource {
 				ForceNew: true,
 			},
 			"token": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:       schema.TypeString,
+				Computed:   true,
+				Deprecated: "Not used, will be removed in the future",
 			},
 			"state": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:       schema.TypeString,
+				Computed:   true,
+				Deprecated: "Not used, will be removed in the future",
 			},
 			"auto_renew": {
-				Type:     schema.TypeBool,
-				Computed: true,
+				Type:       schema.TypeBool,
+				Computed:   true,
+				Deprecated: "Not used, will be removed in the future",
 			},
 			"expires_on": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:       schema.TypeString,
+				Computed:   true,
+				Deprecated: "Not used, will be removed in the future",
 			},
 		},
 
-		Create: resourceDomainCreate,
-		Read:   resourceDomainRead,
-		Delete: resourceDomainDelete,
-		Exists: resourceDomainExists,
+		CreateContext: resourceDomainCreate,
+		ReadContext:   resourceDomainRead,
+		DeleteContext: resourceDomainDelete,
+		Exists:        resourceDomainExists,
 
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceDomainImport,
@@ -52,74 +61,133 @@ func resourceDomain() *schema.Resource {
 			Read:   schema.DefaultTimeout(defaultTimeout),
 			Delete: schema.DefaultTimeout(defaultTimeout),
 		},
+
+		SchemaVersion: 1,
+		StateUpgraders: []schema.StateUpgrader{
+			{
+				Type:    resourceDomainV0().CoreConfigSchema().ImpliedType(),
+				Upgrade: resourceDomainStateUpgradeV0,
+				Version: 0,
+			},
+		},
 	}
 }
 
-func resourceDomainCreate(d *schema.ResourceData, meta interface{}) error {
-	log.Printf("[DEBUG] %s: beginning create", resourceDomainIDString(d))
+func resourceDomainV0() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type: schema.TypeString,
+			},
+		},
+	}
+}
 
-	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutCreate))
-	defer cancel()
+func resourceDomainStateUpgradeV0(
+	ctx context.Context,
+	rawState map[string]interface{},
+	meta interface{},
+) (map[string]interface{}, error) {
+	client := GetComputeClient(meta)
 
-	client := GetDNSClient(meta)
-
-	domain, err := client.CreateDomain(ctx, d.Get("name").(string))
+	name := rawState["id"].(string)
+	domains, err := client.ListDNSDomains(ctx, defaultZone)
 	if err != nil {
-		return err
+		return nil, fmt.Errorf("error retrieving domain list: %s", err)
 	}
 
-	d.SetId(domain.Name)
+	for _, domain := range domains {
+		if *domain.UnicodeName == name {
+			rawState["id"] = *domain.ID
+			return rawState, nil
+		}
+	}
+
+	return nil, fmt.Errorf("domain not found: %q", name)
+}
+
+func resourceDomainCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	log.Printf("[DEBUG] %s: beginning create", resourceDomainIDString(d))
+
+	ctx, cancel := context.WithTimeout(ctx, d.Timeout(schema.TimeoutRead))
+	defer cancel()
+
+	client := GetComputeClient(meta)
+
+	domainName := d.Get("name").(string)
+	domain, err := client.CreateDNSDomain(ctx, defaultZone, &exo.DNSDomain{UnicodeName: &domainName})
+	if err != nil {
+		return diag.Errorf("unable to retrieve instance type: %s", err)
+	}
+
+	d.SetId(*domain.ID)
 
 	log.Printf("[DEBUG] %s: create finished successfully", resourceDomainIDString(d))
 
-	return resourceDomainRead(d, meta)
+	err = resourceDomainApply(d, domain)
+	if err != nil {
+		return diag.Errorf("%s", err)
+	}
+
+	return nil
 }
 
 func resourceDomainExists(d *schema.ResourceData, meta interface{}) (bool, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutRead))
 	defer cancel()
 
-	client := GetDNSClient(meta)
+	client := GetComputeClient(meta)
 
-	_, err := client.GetDomain(ctx, d.Id())
+	_, err := client.GetDNSDomain(ctx, defaultZone, d.Id())
 	if err != nil {
-		if _, ok := err.(*egoscale.DNSErrorResponse); ok { // nolint: gosimple
+		if errors.Is(err, exoapi.ErrNotFound) {
 			return false, nil
 		}
+		return false, err
 	}
 
-	return err == nil, err
+	return true, nil
 }
 
-func resourceDomainRead(d *schema.ResourceData, meta interface{}) error {
+func resourceDomainRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	log.Printf("[DEBUG] %s: beginning read", resourceDomainIDString(d))
 
-	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutRead))
+	ctx, cancel := context.WithTimeout(ctx, d.Timeout(schema.TimeoutRead))
 	defer cancel()
 
-	client := GetDNSClient(meta)
+	client := GetComputeClient(meta)
 
-	domain, err := client.GetDomain(ctx, d.Id())
+	domain, err := client.GetDNSDomain(ctx, defaultZone, d.Id())
 	if err != nil {
-		return err
+		return diag.Errorf("error retrieving domain: %s", err)
 	}
 
 	log.Printf("[DEBUG] %s: read finished successfully", resourceDomainIDString(d))
 
-	return resourceDomainApply(d, *domain)
+	err = resourceDomainApply(d, domain)
+	if err != nil {
+		return diag.Errorf("%s", err)
+	}
+
+	return nil
 }
 
-func resourceDomainDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceDomainDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	log.Printf("[DEBUG] %s: beginning delete", resourceDomainIDString(d))
 
-	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutDelete))
+	ctx, cancel := context.WithTimeout(ctx, d.Timeout(schema.TimeoutRead))
 	defer cancel()
 
-	client := GetDNSClient(meta)
+	client := GetComputeClient(meta)
 
-	err := client.DeleteDomain(ctx, d.Id())
+	domain, err := client.GetDNSDomain(ctx, defaultZone, d.Id())
 	if err != nil {
-		return err
+		return diag.Errorf("error retrieving domain: %s", err)
+	}
+
+	err = client.DeleteDNSDomain(ctx, defaultZone, domain)
+	if err != nil {
+		return diag.Errorf("error deleting domain: %s", err)
 	}
 
 	log.Printf("[DEBUG] %s: delete finished successfully", resourceDomainIDString(d))
@@ -128,64 +196,53 @@ func resourceDomainDelete(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceDomainImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	ctx, cancel := context.WithTimeout(ctx, d.Timeout(schema.TimeoutRead))
+	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutRead))
 	defer cancel()
 
-	client := GetDNSClient(meta)
-	domain, err := client.GetDomain(ctx, d.Id())
+	client := GetComputeClient(meta)
+
+	domain, err := client.GetDNSDomain(ctx, defaultZone, d.Id())
 	if err != nil {
 		return nil, err
 	}
 
-	if err := resourceDomainApply(d, *domain); err != nil {
+	if err := resourceDomainApply(d, domain); err != nil {
 		return nil, err
 	}
 
 	resources := make([]*schema.ResourceData, 0, 1)
 	resources = append(resources, d)
 
-	records, err := client.GetRecords(ctx, d.Id())
+	records, err := client.ListDNSDomainRecords(ctx, defaultZone, d.Id())
 	if err != nil {
 		return nil, err
 	}
 
 	for _, record := range records {
 		// Ignore the default NS and SOA entries
-		if record.RecordType == "NS" || record.RecordType == "SOA" {
+		if *record.Type == "NS" || *record.Type == "SOA" {
 			continue
 		}
 		resource := resourceDomainRecord()
-		d := resource.Data(nil)
-		d.SetType("exoscale_domain_record")
-		if err := d.Set("domain", domain.Name); err != nil {
+		data := resource.Data(nil)
+		data.SetType("exoscale_domain_record")
+		if err := data.Set("domain", d.Id()); err != nil {
 			return nil, err
 		}
 
-		if err := resourceDomainRecordApply(d, record); err != nil {
+		if err := resourceDomainRecordApply(data, *domain.UnicodeName, &record); err != nil {
 			continue
 		}
 
-		resources = append(resources, d)
+		resources = append(resources, data)
 	}
 
 	return resources, nil
 }
 
-func resourceDomainApply(d *schema.ResourceData, domain egoscale.DNSDomain) error {
-	d.SetId(domain.Name)
-	if err := d.Set("name", domain.Name); err != nil {
-		return err
-	}
-	if err := d.Set("state", domain.State); err != nil {
-		return err
-	}
-	if err := d.Set("token", domain.Token); err != nil {
-		return err
-	}
-	if err := d.Set("auto_renew", domain.AutoRenew); err != nil {
-		return err
-	}
-	if err := d.Set("expires_on", domain.ExpiresOn); err != nil {
+func resourceDomainApply(d *schema.ResourceData, domain *exo.DNSDomain) error {
+	d.SetId(*domain.ID)
+	if err := d.Set("name", domain.UnicodeName); err != nil {
 		return err
 	}
 

--- a/exoscale/resource_exoscale_domain_record.go
+++ b/exoscale/resource_exoscale_domain_record.go
@@ -2,11 +2,14 @@ package exoscale
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
-	"strconv"
 
-	"github.com/exoscale/egoscale"
+	exo "github.com/exoscale/egoscale/v2"
+	exoapi "github.com/exoscale/egoscale/v2/api"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -59,11 +62,11 @@ func resourceDomainRecord() *schema.Resource {
 			},
 		},
 
-		Create: resourceDomainRecordCreate,
-		Read:   resourceDomainRecordRead,
-		Update: resourceDomainRecordUpdate,
-		Delete: resourceDomainRecordDelete,
-		Exists: resourceDomainRecordExists,
+		CreateContext: resourceDomainRecordCreate,
+		ReadContext:   resourceDomainRecordRead,
+		UpdateContext: resourceDomainRecordUpdate,
+		DeleteContext: resourceDomainRecordDelete,
+		Exists:        resourceDomainRecordExists,
 
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -75,75 +78,148 @@ func resourceDomainRecord() *schema.Resource {
 			Update: schema.DefaultTimeout(defaultTimeout),
 			Delete: schema.DefaultTimeout(defaultTimeout),
 		},
+
+		SchemaVersion: 1,
+		StateUpgraders: []schema.StateUpgrader{
+			{
+				Type:    resourceDomainRecordV0().CoreConfigSchema().ImpliedType(),
+				Upgrade: resourceDomainRecordStateUpgradeV0,
+				Version: 0,
+			},
+		},
 	}
 }
 
-func resourceDomainRecordCreate(d *schema.ResourceData, meta interface{}) error {
-	log.Printf("[DEBUG] %s: beginning create", resourceDomainRecordIDString(d))
+func resourceDomainRecordV0() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type: schema.TypeString,
+			},
+			"domain": {
+				Type: schema.TypeString,
+			},
+			"record_type": {
+				Type: schema.TypeString,
+			},
+			"name": {
+				Type: schema.TypeString,
+			},
+			"content": {
+				Type: schema.TypeString,
+			},
+		},
+	}
+}
 
-	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutCreate))
-	defer cancel()
+func resourceDomainRecordStateUpgradeV0(
+	ctx context.Context,
+	rawState map[string]interface{},
+	meta interface{},
+) (map[string]interface{}, error) {
+	client := GetComputeClient(meta)
 
-	client := GetDNSClient(meta)
-
-	record, err := client.CreateRecord(ctx, d.Get("domain").(string), egoscale.DNSRecord{
-		Name:       d.Get("name").(string),
-		Content:    d.Get("content").(string),
-		RecordType: d.Get("record_type").(string),
-		TTL:        d.Get("ttl").(int),
-		Prio:       d.Get("prio").(int),
-	})
+	domainName := rawState["domain"].(string)
+	domains, err := client.ListDNSDomains(ctx, defaultZone)
 	if err != nil {
-		return err
+		return nil, fmt.Errorf("error retrieving domain list: %s", err)
 	}
 
-	d.SetId(strconv.FormatInt(record.ID, 10))
+	for _, domain := range domains {
+		if *domain.UnicodeName == domainName {
+			rawState["domain"] = *domain.ID
+			break
+		}
+	}
+
+	records, err := client.ListDNSDomainRecords(ctx, defaultZone, rawState["domain"].(string))
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving domain records: %q", err)
+	}
+
+	for _, record := range records {
+		if *record.Type == rawState["record_type"].(string) &&
+			*record.Name == rawState["name"].(string) &&
+			*record.Content == rawState["content"] {
+			rawState["id"] = *record.ID
+			break
+		}
+	}
+
+	return rawState, nil
+}
+
+func resourceDomainRecordCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	log.Printf("[DEBUG] %s: beginning create", resourceDomainRecordIDString(d))
+
+	ctx, cancel := context.WithTimeout(ctx, d.Timeout(schema.TimeoutRead))
+	defer cancel()
+
+	client := GetComputeClient(meta)
+
+	name := d.Get("name").(string)
+	content := d.Get("content").(string)
+	rtype := d.Get("record_type").(string)
+	t := d.Get("ttl").(int)
+	ttl := int64(t)
+	p := d.Get("prio").(int)
+	prio := int64(p)
+	record, err := client.CreateDNSDomainRecord(ctx, defaultZone, d.Get("domain").(string), &exo.DNSDomainRecord{
+		Name:     &name,
+		Content:  &content,
+		Type:     &rtype,
+		TTL:      &ttl,
+		Priority: &prio,
+	})
+	if err != nil {
+		return diag.Errorf("error creating domain record: %q", err)
+	}
+
+	d.SetId(*record.ID)
 
 	log.Printf("[DEBUG] %s: create finished successfully", resourceDomainRecordIDString(d))
 
-	return resourceDomainRecordRead(d, meta)
+	return resourceDomainRecordRead(ctx, d, meta)
 }
 
 func resourceDomainRecordExists(d *schema.ResourceData, meta interface{}) (bool, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutRead))
 	defer cancel()
 
-	client := GetDNSClient(meta)
+	client := GetComputeClient(meta)
 
-	id, _ := strconv.ParseInt(d.Id(), 10, 64)
-	domain := d.Get("domain").(string)
+	domainID := d.Get("domain").(string)
 
-	if domain != "" {
-		record, err := client.GetRecord(ctx, domain, id)
+	if domainID != "" {
+		_, err := client.GetDNSDomainRecord(ctx, defaultZone, domainID, d.Id())
 		if err != nil {
-			if dnserr, ok := err.(*egoscale.DNSErrorResponse); ok && dnserr.Message == "Record not found" {
+			if errors.Is(err, exoapi.ErrNotFound) {
 				return false, nil
 			}
-
-			return true, fmt.Errorf("Failed to get DNS record id %d for domain %q from Exoscale API: %s", id, domain, err)
+			return false, err
 		}
 
-		return record != nil, nil
+		return true, nil
 	}
 
 	// If we reach this stage it means that we're in "import" mode, so we don't have the domain information yet.
 	// We have to scroll each existing domain's records and try to find one matching the resource ID.
 	log.Printf("[DEBUG] %s: import mode detected, trying to locate the record domain", resourceDomainRecordIDString(d))
 
-	domains, err := client.GetDomains(ctx)
+	domains, err := client.ListDNSDomains(ctx, defaultZone)
 	if err != nil {
 		return false, err
 	}
 
 	for _, domain := range domains {
-		records, err := client.GetRecords(ctx, domain.Name)
+		records, err := client.ListDNSDomainRecords(ctx, defaultZone, *domain.ID)
 		if err != nil {
 			return false, err
 		}
 
 		for _, record := range records {
-			if record.ID == id {
-				log.Printf("[DEBUG] %s: found record domain: %s", resourceDomainRecordIDString(d), domain.Name)
+			if *record.ID == d.Id() {
+				log.Printf("[DEBUG] %s: found record domain: %s", resourceDomainRecordIDString(d), *domain.UnicodeName)
 				return true, nil
 			}
 		}
@@ -152,95 +228,139 @@ func resourceDomainRecordExists(d *schema.ResourceData, meta interface{}) (bool,
 	return false, nil
 }
 
-func resourceDomainRecordRead(d *schema.ResourceData, meta interface{}) error {
+func resourceDomainRecordRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	log.Printf("[DEBUG] %s: beginning read", resourceDomainRecordIDString(d))
 
-	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutRead))
+	ctx, cancel := context.WithTimeout(ctx, d.Timeout(schema.TimeoutRead))
 	defer cancel()
 
-	client := GetDNSClient(meta)
+	client := GetComputeClient(meta)
 
-	id, _ := strconv.ParseInt(d.Id(), 10, 64)
-	domain := d.Get("domain").(string)
+	domainID := d.Get("domain").(string)
 
-	if domain != "" {
-		record, err := client.GetRecord(ctx, domain, id)
+	if domainID != "" {
+		domain, err := client.GetDNSDomain(ctx, defaultZone, domainID)
 		if err != nil {
-			return err
+			return diag.Errorf("error retrieving domain: %s", err)
+		}
+
+		record, err := client.GetDNSDomainRecord(ctx, defaultZone, domainID, d.Id())
+		if err != nil {
+			return diag.Errorf("error retrieving domain record: %s", err)
 		}
 
 		log.Printf("[DEBUG] %s: read finished successfully", resourceDomainRecordIDString(d))
 
-		return resourceDomainRecordApply(d, *record)
+		err = resourceDomainRecordApply(d, *domain.UnicodeName, record)
+		if err != nil {
+			return diag.Errorf("%s", err)
+		}
+
+		return nil
 	}
 
 	// If we reach this stage it means that we're in "import" mode, so we don't have the domain information yet.
 	// We have to scroll each existing domain's records and try to find one matching the resource ID.
 	log.Printf("[DEBUG] %s: import mode detected, trying to locate the record domain", resourceDomainRecordIDString(d))
 
-	domains, err := client.GetDomains(ctx)
+	domains, err := client.ListDNSDomains(ctx, defaultZone)
 	if err != nil {
-		return err
+		return diag.Errorf("error retrieving domains: %s", err)
 	}
 
 	for _, domain := range domains {
-		records, err := client.GetRecords(ctx, domain.Name)
+		records, err := client.ListDNSDomainRecords(ctx, defaultZone, *domain.ID)
 		if err != nil {
-			return err
+			return diag.Errorf("error retrieving domain records: %s", err)
 		}
 
 		for _, record := range records {
-			if record.ID == id {
-				if err := d.Set("domain", domain.Name); err != nil {
-					return err
+			if *record.ID == d.Id() {
+				if err := d.Set("domain", domain.ID); err != nil {
+					return diag.Errorf("%s", err)
 				}
 
 				log.Printf("[DEBUG] %s: read finished successfully", resourceDomainRecordIDString(d))
 
-				return resourceDomainRecordApply(d, record)
+				err = resourceDomainRecordApply(d, *domain.UnicodeName, &record)
+				if err != nil {
+					return diag.Errorf("%s", err)
+				}
+
+				return nil
 			}
 		}
 	}
 
-	return fmt.Errorf("domain record %s not found", d.Id())
+	return diag.Errorf("domain record %s not found", d.Id())
 }
 
-func resourceDomainRecordUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceDomainRecordUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	log.Printf("[DEBUG] %s: beginning update", resourceDomainRecordIDString(d))
 
-	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutUpdate))
+	ctx, cancel := context.WithTimeout(ctx, d.Timeout(schema.TimeoutRead))
 	defer cancel()
 
-	client := GetDNSClient(meta)
+	client := GetComputeClient(meta)
 
-	id, _ := strconv.ParseInt(d.Id(), 10, 64)
-	record, err := client.UpdateRecord(ctx, d.Get("domain").(string), egoscale.UpdateDNSRecord{
-		ID:      id,
-		Name:    d.Get("name").(string),
-		Content: d.Get("content").(string),
-		TTL:     d.Get("ttl").(int),
-		Prio:    d.Get("prio").(int),
+	name := d.Get("name").(string)
+	content := d.Get("content").(string)
+	rtype := d.Get("record_type").(string)
+	t := d.Get("ttl").(int)
+	ttl := int64(t)
+	p := d.Get("prio").(int)
+	prio := int64(p)
+	id := d.Id()
+	err := client.UpdateDNSDomainRecord(ctx, defaultZone, d.Get("domain").(string), &exo.DNSDomainRecord{
+		ID:       &id,
+		Name:     &name,
+		Content:  &content,
+		Type:     &rtype,
+		TTL:      &ttl,
+		Priority: &prio,
 	})
 	if err != nil {
-		return err
+		return diag.Errorf("error updating domain record: %s", err)
 	}
 
 	log.Printf("[DEBUG] %s: update finished successfully", resourceDomainRecordIDString(d))
 
-	return resourceDomainRecordApply(d, *record) // FIXME: use resourceDomainRecordRead()
+	domainID := d.Get("domain").(string)
+
+	domain, err := client.GetDNSDomain(ctx, defaultZone, domainID)
+	if err != nil {
+		return diag.Errorf("error retrieving domain: %s", err)
+	}
+
+	record, err := client.GetDNSDomainRecord(ctx, defaultZone, domainID, d.Id())
+	if err != nil {
+		return diag.Errorf("error retrieving domain record: %s", err)
+	}
+
+	err = resourceDomainRecordApply(d, *domain.UnicodeName, record) // FIXME: use resourceDomainRecordRead()
+	if err != nil {
+		return diag.Errorf("%s", err)
+	}
+
+	return nil
 }
 
-func resourceDomainRecordDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceDomainRecordDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	log.Printf("[DEBUG] %s: beginning delete", resourceDomainRecordIDString(d))
 
-	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutDelete))
+	ctx, cancel := context.WithTimeout(ctx, d.Timeout(schema.TimeoutRead))
 	defer cancel()
 
-	client := GetDNSClient(meta)
+	client := GetComputeClient(meta)
 
-	id, _ := strconv.ParseInt(d.Id(), 10, 64)
-	if err := client.DeleteRecord(ctx, d.Get("domain").(string), id); err != nil {
-		return err
+	record, err := client.GetDNSDomainRecord(ctx, defaultZone, d.Get("domain").(string), d.Id())
+	if err != nil {
+		return diag.Errorf("error retrieving domain record: %s", err)
+	}
+
+	err = client.DeleteDNSDomainRecord(ctx, defaultZone, d.Get("domain").(string), record)
+	if err != nil {
+		return diag.Errorf("error deleting domain record: %s", err)
 	}
 
 	log.Printf("[DEBUG] %s: delete finished successfully", resourceDomainRecordIDString(d))
@@ -248,30 +368,30 @@ func resourceDomainRecordDelete(d *schema.ResourceData, meta interface{}) error 
 	return nil
 }
 
-func resourceDomainRecordApply(d *schema.ResourceData, record egoscale.DNSRecord) error {
-	d.SetId(strconv.FormatInt(record.ID, 10))
+func resourceDomainRecordApply(d *schema.ResourceData, domainName string, record *exo.DNSDomainRecord) error {
+	d.SetId(*record.ID)
 	if err := d.Set("name", record.Name); err != nil {
 		return err
 	}
 	if err := d.Set("content", record.Content); err != nil {
 		return err
 	}
-	if err := d.Set("record_type", record.RecordType); err != nil {
+	if err := d.Set("record_type", record.Type); err != nil {
 		return err
 	}
 	if err := d.Set("ttl", record.TTL); err != nil {
 		return err
 	}
-	if err := d.Set("prio", record.Prio); err != nil {
+	if err := d.Set("prio", record.Priority); err != nil {
 		return err
 	}
 
-	domain := d.Get("domain").(string)
-	if record.Name != "" {
-		domain = fmt.Sprintf("%s.%s", record.Name, domain)
+	hostname := domainName
+	if record.Name != nil && *record.Name != "" {
+		hostname = fmt.Sprintf("%s.%s", *record.Name, domainName)
 	}
 
-	if err := d.Set("hostname", domain); err != nil {
+	if err := d.Set("hostname", hostname); err != nil {
 		return nil
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/exoscale/terraform-provider-exoscale
 
 require (
-	github.com/exoscale/egoscale v0.88.1
+	github.com/exoscale/egoscale v0.89.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.10.0

--- a/go.sum
+++ b/go.sum
@@ -93,8 +93,8 @@ github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymF
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/exoscale/egoscale v0.88.1 h1:c3zQh7troDWTDxDEAoMn/SNBcNLlDL6nyli8JIHFiGA=
-github.com/exoscale/egoscale v0.88.1/go.mod h1:QTKIIsYlpdD21XgUCE/pAx91FFRbpBo1GGwBD8Euktg=
+github.com/exoscale/egoscale v0.89.0 h1:YEA3pG97j14diC6okttXMOH9mLwlMuv/184uZyUGxhk=
+github.com/exoscale/egoscale v0.89.0/go.mod h1:wyXE5zrnFynMXA0jMhwQqSe24CfUhmBk2WI5wFZcq6Y=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
@@ -129,7 +129,6 @@ github.com/go-playground/validator/v10 v10.9.0/go.mod h1:74x4gJWsvQexRdW8Pn3dXSG
 github.com/go-test/deep v1.0.3 h1:ZrJSEWsXzPOxaZnFteGEfooLba+ju3FYIbOrS+rQd68=
 github.com/go-test/deep v1.0.3/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/goccy/go-json v0.7.8/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
-github.com/gofrs/uuid v3.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gofrs/uuid v4.0.0+incompatible h1:1SD/1F5pU8p29ybwgQSwpQk+mwdRrXCYuPhW6m+TnJw=
 github.com/gofrs/uuid v4.0.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=

--- a/vendor/github.com/exoscale/egoscale/.golangci.yml
+++ b/vendor/github.com/exoscale/egoscale/.golangci.yml
@@ -25,3 +25,10 @@ linters:
     - unused
     - varcheck
   disable-all: true
+
+issues:
+  exclude-rules:
+    # stop revive from complaining about naming issues that originate from oapi generated code.
+    - path: v2/client_mock.go
+      linters:
+        - revive

--- a/vendor/github.com/exoscale/egoscale/CHANGELOG.md
+++ b/vendor/github.com/exoscale/egoscale/CHANGELOG.md
@@ -1,6 +1,16 @@
 Changelog
 =========
 
+0.89.0
+----
+
+- feature: v2: add support for DNS management
+
+0.88.2
+----
+
+- feature: v2: add support for Build, Maintainer and Version attributes to RegisterTemplate
+
 0.88.1
 ------
 

--- a/vendor/github.com/exoscale/egoscale/Makefile
+++ b/vendor/github.com/exoscale/egoscale/Makefile
@@ -1,18 +1,51 @@
+## Project
+
+PACKAGE := github.com/exoscale/egoscale
+PROJECT_URL := https://$(PACKAGE)
+
+# Dependencies
+
+# Requires: https://github.com/exoscale/go.mk
+# - install: git submodule update --init --recursive go.mk
+# - update:  git submodule update --remote
 include go.mk/init.mk
 include go.mk/public.mk
 
-PACKAGE := github.com/exoscale/egoscale
+# GoLang
 
-PROJECT_URL := https://$(PACKAGE)
+GO_VERSION := $(shell go version | sed -nE 's|^.*\s+go([0-9]+\.[0-9]+)[^0-9].*$$|\1|p')
+GO_MOD_VERSION := $(shell sed -nE 's|^go\s+([0-9]+\.[0-9]+)$$|\1|p' go.mod)
+ifneq ($(GO_VERSION), $(GO_MOD_VERSION))
+$(warning GoLang versions mismatch (Toolchain: $(GO_VERSION); go.mod: $(GO_MOD_VERSION)))
+endif
 
 GO_TEST_EXTRA_ARGS := -mod=readonly -v
-
 GOLANGCI_EXTRA_ARGS := --modules-download-mode=readonly
 
+# OpenAPI code generator
+# REF: https://github.com/deepmap/oapi-codegen
+
+OAPI_CODEGEN_VERSION := v1.9.1
+
+OAPI_CODEGEN_MOD_VERSION := $(shell sed -nE 's|^\s*github.com/deepmap/oapi-codegen\s+(v[.0-9]+)$$|\1|p' go.mod)
+ifneq ($(OAPI_CODEGEN_VERSION), $(OAPI_CODEGEN_MOD_VERSION))
+$(warning OpenAPI code generator (oapi-codegen) versions mismatch (Makefile: $(OAPI_CODEGEN_VERSION); go.mod: $(OAPI_CODEGEN_MOD_VERSION)))
+endif
+
+
+## Targets
+
+# Dependencies
+.PHONY: install-oapi-codegen
+install-oapi-codegen:
+	go install github.com/deepmap/oapi-codegen/cmd/oapi-codegen@$(OAPI_CODEGEN_VERSION)
+
+# OpenAPI specifications (JSON)
 .PHONY: oapigen
-oapigen:
+oapigen: install-oapi-codegen
 	cd v2/oapi/
-	go install github.com/deepmap/oapi-codegen/cmd/oapi-codegen@v1.9.1
-	wget -q https://openapi-v2.exoscale.com/source.json
+	wget -q --show-progress --progress=dot https://openapi-v2.exoscale.com/source.json -O- > source.json
+	@echo
 	go generate
 	@rm source.json
+	ls -l oapi.gen.go

--- a/vendor/github.com/exoscale/egoscale/v2/client_mock.go
+++ b/vendor/github.com/exoscale/egoscale/v2/client_mock.go
@@ -1006,3 +1006,97 @@ func (m *oapiClientMock) GetDbaasMigrationStatusWithResponse(
 	args := m.Called(ctx, name, reqEditors)
 	return args.Get(0).(*oapi.GetDbaasMigrationStatusResponse), args.Error(1)
 }
+
+func (m *oapiClientMock) ListDnsDomainsWithResponse(
+	ctx context.Context,
+	reqEditors ...oapi.RequestEditorFn,
+) (*oapi.ListDnsDomainsResponse, error) {
+	args := m.Called(ctx, reqEditors)
+	return args.Get(0).(*oapi.ListDnsDomainsResponse), args.Error(1)
+}
+
+func (m *oapiClientMock) GetDnsDomainWithResponse(
+	ctx context.Context,
+	id string,
+	reqEditors ...oapi.RequestEditorFn,
+) (*oapi.GetDnsDomainResponse, error) {
+	args := m.Called(ctx, id, reqEditors)
+	return args.Get(0).(*oapi.GetDnsDomainResponse), args.Error(1)
+}
+
+func (m *oapiClientMock) CreateDnsDomainWithResponse(
+	ctx context.Context,
+	body oapi.CreateDnsDomainJSONRequestBody,
+	reqEditors ...oapi.RequestEditorFn,
+) (*oapi.CreateDnsDomainResponse, error) {
+	args := m.Called(ctx, body, reqEditors)
+	return args.Get(0).(*oapi.CreateDnsDomainResponse), args.Error(1)
+}
+
+func (m *oapiClientMock) DeleteDnsDomainWithResponse(
+	ctx context.Context,
+	id string,
+	reqEditors ...oapi.RequestEditorFn,
+) (*oapi.DeleteDnsDomainResponse, error) {
+	args := m.Called(ctx, id, reqEditors)
+	return args.Get(0).(*oapi.DeleteDnsDomainResponse), args.Error(1)
+}
+
+func (m *oapiClientMock) GetDnsDomainZoneFileWithResponse(
+	ctx context.Context,
+	id string,
+	reqEditors ...oapi.RequestEditorFn,
+) (*oapi.GetDnsDomainZoneFileResponse, error) {
+	args := m.Called(ctx, id, reqEditors)
+	return args.Get(0).(*oapi.GetDnsDomainZoneFileResponse), args.Error(1)
+}
+
+func (m *oapiClientMock) ListDnsDomainRecordsWithResponse(
+	ctx context.Context,
+	id string,
+	reqEditors ...oapi.RequestEditorFn,
+) (*oapi.ListDnsDomainRecordsResponse, error) {
+	args := m.Called(ctx, id, reqEditors)
+	return args.Get(0).(*oapi.ListDnsDomainRecordsResponse), args.Error(1)
+}
+
+func (m *oapiClientMock) GetDnsDomainRecordWithResponse(
+	ctx context.Context,
+	domainId string,
+	recordId string,
+	reqEditors ...oapi.RequestEditorFn,
+) (*oapi.GetDnsDomainRecordResponse, error) {
+	args := m.Called(ctx, domainId, recordId, reqEditors)
+	return args.Get(0).(*oapi.GetDnsDomainRecordResponse), args.Error(1)
+}
+
+func (m *oapiClientMock) CreateDnsDomainRecordWithResponse(
+	ctx context.Context,
+	domainId string,
+	body oapi.CreateDnsDomainRecordJSONRequestBody,
+	reqEditors ...oapi.RequestEditorFn,
+) (*oapi.CreateDnsDomainRecordResponse, error) {
+	args := m.Called(ctx, domainId, body, reqEditors)
+	return args.Get(0).(*oapi.CreateDnsDomainRecordResponse), args.Error(1)
+}
+
+func (m *oapiClientMock) DeleteDnsDomainRecordWithResponse(
+	ctx context.Context,
+	domainId string,
+	recordId string,
+	reqEditors ...oapi.RequestEditorFn,
+) (*oapi.DeleteDnsDomainRecordResponse, error) {
+	args := m.Called(ctx, domainId, recordId, reqEditors)
+	return args.Get(0).(*oapi.DeleteDnsDomainRecordResponse), args.Error(1)
+}
+
+func (m *oapiClientMock) UpdateDnsDomainRecordWithResponse(
+	ctx context.Context,
+	domainId string,
+	recordId string,
+	body oapi.UpdateDnsDomainRecordJSONRequestBody,
+	reqEditors ...oapi.RequestEditorFn,
+) (*oapi.UpdateDnsDomainRecordResponse, error) {
+	args := m.Called(ctx, domainId, recordId, body, reqEditors)
+	return args.Get(0).(*oapi.UpdateDnsDomainRecordResponse), args.Error(1)
+}

--- a/vendor/github.com/exoscale/egoscale/v2/dns.go
+++ b/vendor/github.com/exoscale/egoscale/v2/dns.go
@@ -1,0 +1,260 @@
+package v2
+
+import (
+	"context"
+	"time"
+
+	apiv2 "github.com/exoscale/egoscale/v2/api"
+	"github.com/exoscale/egoscale/v2/oapi"
+)
+
+// DNSDomain represents a DNS domain.
+type DNSDomain struct {
+	CreatedAt   *time.Time
+	ID          *string `req-for:"delete"`
+	UnicodeName *string `req-for:"create"`
+}
+
+// DNSDomainRecord represents a DNS record.
+type DNSDomainRecord struct {
+	Content   *string `req-for:"create"`
+	CreatedAt *time.Time
+	ID        *string `req-for:"delete,update"`
+	Name      *string `req-for:"create"`
+	Priority  *int64
+	TTL       *int64
+	Type      *string `req-for:"create"`
+	UpdatedAt *time.Time
+}
+
+func dnsDomainFromAPI(d *oapi.DnsDomain) *DNSDomain {
+	return &DNSDomain{
+		CreatedAt:   d.CreatedAt,
+		ID:          d.Id,
+		UnicodeName: d.UnicodeName,
+	}
+}
+
+func dnsDomainRecordFromAPI(d *oapi.DnsDomainRecord) *DNSDomainRecord {
+	var t *string
+	if d.Type != nil {
+		x := string(*d.Type)
+		t = &x
+	}
+	return &DNSDomainRecord{
+		Content:   d.Content,
+		CreatedAt: d.CreatedAt,
+		ID:        d.Id,
+		Name:      d.Name,
+		Priority:  d.Priority,
+		TTL:       d.Ttl,
+		Type:      t,
+		UpdatedAt: d.UpdatedAt,
+	}
+}
+
+// ListDNSDomains returns the list of DNS domains.
+func (c *Client) ListDNSDomains(ctx context.Context, zone string) ([]DNSDomain, error) {
+	var list []DNSDomain
+
+	resp, err := c.ListDnsDomainsWithResponse(apiv2.WithZone(ctx, zone))
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.JSON200.DnsDomains != nil {
+		for _, domain := range *resp.JSON200.DnsDomains {
+			list = append(list, *dnsDomainFromAPI(&domain))
+		}
+	}
+
+	return list, nil
+}
+
+// GetDNSDomain returns DNS domain details.
+func (c *Client) GetDNSDomain(ctx context.Context, zone, id string) (*DNSDomain, error) {
+	resp, err := c.GetDnsDomainWithResponse(apiv2.WithZone(ctx, zone), id)
+	if err != nil {
+		return nil, err
+	}
+
+	return dnsDomainFromAPI(resp.JSON200), nil
+}
+
+// DeleteDNSDomain deletes a DNS domain.
+func (c *Client) DeleteDNSDomain(ctx context.Context, zone string, domain *DNSDomain) error {
+	if err := validateOperationParams(domain, "delete"); err != nil {
+		return err
+	}
+
+	resp, err := c.DeleteDnsDomainWithResponse(apiv2.WithZone(ctx, zone), *domain.ID)
+	if err != nil {
+		return err
+	}
+
+	_, err = oapi.NewPoller().
+		WithTimeout(c.timeout).
+		WithInterval(c.pollInterval).
+		Poll(ctx, oapi.OperationPoller(c, zone, *resp.JSON200.Id))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// CreateDNSDomain adds a new DNS domain.
+func (c *Client) CreateDNSDomain(
+	ctx context.Context,
+	zone string,
+	domain *DNSDomain,
+) (*DNSDomain, error) {
+	if err := validateOperationParams(domain, "create"); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.CreateDnsDomainWithResponse(apiv2.WithZone(ctx, zone), oapi.CreateDnsDomainJSONRequestBody{
+		UnicodeName: domain.UnicodeName,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	r, err := oapi.NewPoller().
+		WithTimeout(c.timeout).
+		WithInterval(c.pollInterval).
+		Poll(ctx, oapi.OperationPoller(c, zone, *resp.JSON200.Id))
+	if err != nil {
+		return nil, err
+	}
+
+	return c.GetDNSDomain(ctx, zone, *r.(*struct {
+		Command *string `json:"command,omitempty"`
+		Id      *string `json:"id,omitempty"` // revive:disable-line
+		Link    *string `json:"link,omitempty"`
+	}).Id)
+}
+
+// GetDNSDomainZoneFile returns zone file of a DNS domain.
+func (c *Client) GetDNSDomainZoneFile(ctx context.Context, zone, id string) ([]byte, error) {
+	resp, err := c.GetDnsDomainZoneFileWithResponse(apiv2.WithZone(ctx, zone), id)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.Body, nil
+}
+
+// ListDNSDomainRecords returns the list of records for DNS domain.
+func (c *Client) ListDNSDomainRecords(ctx context.Context, zone, id string) ([]DNSDomainRecord, error) {
+	var list []DNSDomainRecord
+
+	resp, err := c.ListDnsDomainRecordsWithResponse(apiv2.WithZone(ctx, zone), id)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.JSON200.DnsDomainRecords != nil {
+		for _, record := range *resp.JSON200.DnsDomainRecords {
+			list = append(list, *dnsDomainRecordFromAPI(&record))
+		}
+	}
+
+	return list, nil
+}
+
+// GetDNSDomainRecord returns a single DNS domain record.
+func (c *Client) GetDNSDomainRecord(ctx context.Context, zone, domainID, recordID string) (*DNSDomainRecord, error) {
+	resp, err := c.GetDnsDomainRecordWithResponse(apiv2.WithZone(ctx, zone), domainID, recordID)
+	if err != nil {
+		return nil, err
+	}
+
+	return dnsDomainRecordFromAPI(resp.JSON200), nil
+}
+
+// CreateDNSDomainRecord adds a new DNS record for domain.
+func (c *Client) CreateDNSDomainRecord(
+	ctx context.Context,
+	zone string,
+	domainID string,
+	record *DNSDomainRecord,
+) (*DNSDomainRecord, error) {
+	if err := validateOperationParams(record, "create"); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.CreateDnsDomainRecordWithResponse(apiv2.WithZone(ctx, zone), domainID, oapi.CreateDnsDomainRecordJSONRequestBody{
+		Content:  *record.Content,
+		Name:     *record.Name,
+		Priority: record.Priority,
+		Ttl:      record.TTL,
+		Type:     oapi.CreateDnsDomainRecordJSONBodyType(*record.Type),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	r, err := oapi.NewPoller().
+		WithTimeout(c.timeout).
+		WithInterval(c.pollInterval).
+		Poll(ctx, oapi.OperationPoller(c, zone, *resp.JSON200.Id))
+	if err != nil {
+		return nil, err
+	}
+
+	return c.GetDNSDomainRecord(ctx, zone, domainID, *r.(*struct {
+		Command *string `json:"command,omitempty"`
+		Id      *string `json:"id,omitempty"` // revive:disable-line
+		Link    *string `json:"link,omitempty"`
+	}).Id)
+}
+
+// DeleteDNSDomainRecord deletes a DNS domain record.
+func (c *Client) DeleteDNSDomainRecord(ctx context.Context, zone, domainID string, record *DNSDomainRecord) error {
+	if err := validateOperationParams(record, "delete"); err != nil {
+		return err
+	}
+
+	resp, err := c.DeleteDnsDomainRecordWithResponse(apiv2.WithZone(ctx, zone), domainID, *record.ID)
+	if err != nil {
+		return err
+	}
+
+	_, err = oapi.NewPoller().
+		WithTimeout(c.timeout).
+		WithInterval(c.pollInterval).
+		Poll(ctx, oapi.OperationPoller(c, zone, *resp.JSON200.Id))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// UpdateDNSDomainRecord updates existing DNS domain record.
+func (c *Client) UpdateDNSDomainRecord(ctx context.Context, zone, domainID string, record *DNSDomainRecord) error {
+	if err := validateOperationParams(record, "update"); err != nil {
+		return err
+	}
+
+	resp, err := c.UpdateDnsDomainRecordWithResponse(apiv2.WithZone(ctx, zone), domainID, *record.ID, oapi.UpdateDnsDomainRecordJSONRequestBody{
+		Content:  record.Content,
+		Name:     record.Name,
+		Priority: record.Priority,
+		Ttl:      record.TTL,
+	})
+	if err != nil {
+		return err
+	}
+
+	_, err = oapi.NewPoller().
+		WithTimeout(c.timeout).
+		WithInterval(c.pollInterval).
+		Poll(ctx, oapi.OperationPoller(c, zone, *resp.JSON200.Id))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/vendor/github.com/exoscale/egoscale/v2/oapi/.gitignore
+++ b/vendor/github.com/exoscale/egoscale/v2/oapi/.gitignore
@@ -1,0 +1,1 @@
+source.json

--- a/vendor/github.com/exoscale/egoscale/v2/oapi/oapi.gen.go
+++ b/vendor/github.com/exoscale/egoscale/v2/oapi/oapi.gen.go
@@ -128,9 +128,43 @@ const (
 
 // Defines values for DnsDomainRecordType.
 const (
-	DnsDomainRecordTypeNs DnsDomainRecordType = "ns"
+	DnsDomainRecordTypeA DnsDomainRecordType = "A"
 
-	DnsDomainRecordTypeSoa DnsDomainRecordType = "soa"
+	DnsDomainRecordTypeAAAA DnsDomainRecordType = "AAAA"
+
+	DnsDomainRecordTypeALIAS DnsDomainRecordType = "ALIAS"
+
+	DnsDomainRecordTypeCAA DnsDomainRecordType = "CAA"
+
+	DnsDomainRecordTypeCNAME DnsDomainRecordType = "CNAME"
+
+	DnsDomainRecordTypeDNSKEY DnsDomainRecordType = "DNSKEY"
+
+	DnsDomainRecordTypeDS DnsDomainRecordType = "DS"
+
+	DnsDomainRecordTypeHINFO DnsDomainRecordType = "HINFO"
+
+	DnsDomainRecordTypeMX DnsDomainRecordType = "MX"
+
+	DnsDomainRecordTypeNAPTR DnsDomainRecordType = "NAPTR"
+
+	DnsDomainRecordTypeNS DnsDomainRecordType = "NS"
+
+	DnsDomainRecordTypePOOL DnsDomainRecordType = "POOL"
+
+	DnsDomainRecordTypePTR DnsDomainRecordType = "PTR"
+
+	DnsDomainRecordTypeSOA DnsDomainRecordType = "SOA"
+
+	DnsDomainRecordTypeSPF DnsDomainRecordType = "SPF"
+
+	DnsDomainRecordTypeSRV DnsDomainRecordType = "SRV"
+
+	DnsDomainRecordTypeSSHFP DnsDomainRecordType = "SSHFP"
+
+	DnsDomainRecordTypeTXT DnsDomainRecordType = "TXT"
+
+	DnsDomainRecordTypeURL DnsDomainRecordType = "URL"
 )
 
 // Defines values for ElasticIpHealthcheckMode.
@@ -466,6 +500,8 @@ const (
 // Defines values for SksClusterCni.
 const (
 	SksClusterCniCalico SksClusterCni = "calico"
+
+	SksClusterCniCilium SksClusterCni = "cilium"
 )
 
 // Defines values for SksClusterLevel.
@@ -563,8 +599,6 @@ const (
 	ZoneNameChDk2 ZoneName = "ch-dk-2"
 
 	ZoneNameChGva2 ZoneName = "ch-gva-2"
-
-	ZoneNameChZrh1 ZoneName = "ch-zrh-1"
 
 	ZoneNameDeFra1 ZoneName = "de-fra-1"
 
@@ -807,6 +841,18 @@ type DbaasNodeStateProgressUpdate struct {
 
 // Key identifying this phase
 type DbaasNodeStateProgressUpdatePhase string
+
+// DbaasPgDatabaseName defines model for dbaas-pg-database-name.
+type DbaasPgDatabaseName string
+
+// DbaasPgPoolName defines model for dbaas-pg-pool-name.
+type DbaasPgPoolName string
+
+// DbaasPgPoolSize defines model for dbaas-pg-pool-size.
+type DbaasPgPoolSize int64
+
+// DbaasPgPoolUsername defines model for dbaas-pg-pool-username.
+type DbaasPgPoolUsername string
 
 // DBaaS plan
 type DbaasPlan struct {
@@ -1346,24 +1392,19 @@ type DbaasServicePg struct {
 	// PostgreSQL PGBouncer connection pools
 	ConnectionPools *[]struct {
 		// Connection URI for the DB pool
-		ConnectionUri string `json:"connection-uri"`
-
-		// Service database name
-		Database string         `json:"database"`
-		Mode     EnumPgPoolMode `json:"mode"`
-
-		// Connection pool name
-		Name string `json:"name"`
-
-		// Size of PGBouncer's PostgreSQL side connection pool
-		Size int64 `json:"size"`
-
-		// Pool username
-		Username string `json:"username"`
+		ConnectionUri string              `json:"connection-uri"`
+		Database      DbaasPgDatabaseName `json:"database"`
+		Mode          EnumPgPoolMode      `json:"mode"`
+		Name          DbaasPgPoolName     `json:"name"`
+		Size          DbaasPgPoolSize     `json:"size"`
+		Username      DbaasPgPoolUsername `json:"username"`
 	} `json:"connection-pools,omitempty"`
 
 	// Service creation timestamp (ISO 8601)
 	CreatedAt *time.Time `json:"created-at,omitempty"`
+
+	// List of PostgreSQL databases
+	Databases *[]DbaasPgDatabaseName `json:"databases,omitempty"`
 
 	// TODO UNIT disk space for data storage
 	DiskSize *int64 `json:"disk-size,omitempty"`
@@ -1621,19 +1662,19 @@ type DnsDomainRecord struct {
 	Name *string `json:"name,omitempty"`
 
 	// DNS domain record priority
-	Priority *int64 `json:"priority,omitempty"`
+	Priority *int64 `json:"priority"`
 
 	// DNS domain record TTL
 	Ttl *int64 `json:"ttl,omitempty"`
 
-	// DNS domain record priority
+	// DNS domain record type
 	Type *DnsDomainRecordType `json:"type,omitempty"`
 
 	// DNS domain record update date
 	UpdatedAt *time.Time `json:"updated-at,omitempty"`
 }
 
-// DNS domain record priority
+// DNS domain record type
 type DnsDomainRecordType string
 
 // Elastic IP
@@ -1829,6 +1870,9 @@ type InstancePool struct {
 
 	// Resource manager
 	Manager *Manager `json:"manager,omitempty"`
+
+	// Minimum number of running instances
+	MinAvailable *int64 `json:"min-available,omitempty"`
 
 	// Instance Pool name
 	Name *string `json:"name,omitempty"`
@@ -2446,6 +2490,9 @@ type Template struct {
 
 	// Template visibility
 	Visibility *TemplateVisibility `json:"visibility,omitempty"`
+
+	// Zones availability
+	Zones *[]ZoneName `json:"zones,omitempty"`
 }
 
 // Boot mode (default: legacy)
@@ -3259,6 +3306,48 @@ type CreateDbaasTaskMigrationCheckJSONBody struct {
 	SourceServiceUri string `json:"source-service-uri"`
 }
 
+// CreateDnsDomainJSONBody defines parameters for CreateDnsDomain.
+type CreateDnsDomainJSONBody struct {
+	// Domain name
+	UnicodeName *string `json:"unicode-name,omitempty"`
+}
+
+// CreateDnsDomainRecordJSONBody defines parameters for CreateDnsDomainRecord.
+type CreateDnsDomainRecordJSONBody struct {
+	// DNS domain record content
+	Content string `json:"content"`
+
+	// DNS domain record name
+	Name string `json:"name"`
+
+	// DNS domain record priority
+	Priority *int64 `json:"priority,omitempty"`
+
+	// DNS domain record TTL
+	Ttl *int64 `json:"ttl,omitempty"`
+
+	// DNS domain record type
+	Type CreateDnsDomainRecordJSONBodyType `json:"type"`
+}
+
+// CreateDnsDomainRecordJSONBodyType defines parameters for CreateDnsDomainRecord.
+type CreateDnsDomainRecordJSONBodyType string
+
+// UpdateDnsDomainRecordJSONBody defines parameters for UpdateDnsDomainRecord.
+type UpdateDnsDomainRecordJSONBody struct {
+	// DNS domain record content
+	Content *string `json:"content,omitempty"`
+
+	// DNS domain record name
+	Name *string `json:"name,omitempty"`
+
+	// DNS domain record priority
+	Priority *int64 `json:"priority,omitempty"`
+
+	// DNS domain record TTL
+	Ttl *int64 `json:"ttl,omitempty"`
+}
+
 // CreateElasticIpJSONBody defines parameters for CreateElasticIp.
 type CreateElasticIpJSONBody struct {
 	// Elastic IP description
@@ -3370,6 +3459,9 @@ type CreateInstancePoolJSONBody struct {
 	Ipv6Enabled *bool   `json:"ipv6-enabled,omitempty"`
 	Labels      *Labels `json:"labels,omitempty"`
 
+	// Minimum number of running instances
+	MinAvailable *int64 `json:"min-available,omitempty"`
+
 	// Instance Pool name
 	Name string `json:"name"`
 
@@ -3418,6 +3510,9 @@ type UpdateInstancePoolJSONBody struct {
 	// Enable IPv6 for instances
 	Ipv6Enabled *bool   `json:"ipv6-enabled,omitempty"`
 	Labels      *Labels `json:"labels,omitempty"`
+
+	// Minimum number of running instances
+	MinAvailable *int64 `json:"min-available"`
 
 	// Instance Pool name
 	Name *string `json:"name,omitempty"`
@@ -3610,7 +3705,7 @@ type CreatePrivateNetworkJSONBody struct {
 // UpdatePrivateNetworkJSONBody defines parameters for UpdatePrivateNetwork.
 type UpdatePrivateNetworkJSONBody struct {
 	// Private Network description
-	Description *string `json:"description,omitempty"`
+	Description *string `json:"description"`
 
 	// Private Network end IP address
 	EndIp  *string `json:"end-ip,omitempty"`
@@ -3769,6 +3864,9 @@ type ListSksClusterVersionsParams struct {
 
 // UpdateSksClusterJSONBody defines parameters for UpdateSksCluster.
 type UpdateSksClusterJSONBody struct {
+	// Cluster addons
+	Addons *[]UpdateSksClusterJSONBodyAddons `json:"addons,omitempty"`
+
 	// Enable auto upgrade of the control plane to the latest patch version available
 	AutoUpgrade *bool `json:"auto-upgrade,omitempty"`
 
@@ -3779,6 +3877,9 @@ type UpdateSksClusterJSONBody struct {
 	// Cluster name
 	Name *string `json:"name,omitempty"`
 }
+
+// UpdateSksClusterJSONBodyAddons defines parameters for UpdateSksCluster.
+type UpdateSksClusterJSONBodyAddons string
 
 // GetSksClusterAuthorityCertParamsAuthority defines parameters for GetSksClusterAuthorityCert.
 type GetSksClusterAuthorityCertParamsAuthority string
@@ -3884,6 +3985,9 @@ type PromoteSnapshotToTemplateJSONBody struct {
 	// Template default user
 	DefaultUser *string `json:"default-user,omitempty"`
 
+	// Template description
+	Description *string `json:"description,omitempty"`
+
 	// Template name
 	Name string `json:"name"`
 
@@ -3922,6 +4026,9 @@ type RegisterTemplateJSONBody struct {
 	// Boot mode (default: legacy)
 	BootMode *RegisterTemplateJSONBodyBootMode `json:"boot-mode,omitempty"`
 
+	// Template build
+	Build *string `json:"build,omitempty"`
+
 	// Template MD5 checksum
 	Checksum string `json:"checksum"`
 
@@ -3930,6 +4037,9 @@ type RegisterTemplateJSONBody struct {
 
 	// Template description
 	Description *string `json:"description,omitempty"`
+
+	// Template maintainer
+	Maintainer *string `json:"maintainer,omitempty"`
 
 	// Template name
 	Name string `json:"name"`
@@ -3945,6 +4055,9 @@ type RegisterTemplateJSONBody struct {
 
 	// Template source URL
 	Url string `json:"url"`
+
+	// Template version
+	Version *string `json:"version,omitempty"`
 }
 
 // RegisterTemplateJSONBodyBootMode defines parameters for RegisterTemplate.
@@ -4015,6 +4128,15 @@ type GetDbaasServiceMetricsJSONRequestBody GetDbaasServiceMetricsJSONBody
 
 // CreateDbaasTaskMigrationCheckJSONRequestBody defines body for CreateDbaasTaskMigrationCheck for application/json ContentType.
 type CreateDbaasTaskMigrationCheckJSONRequestBody CreateDbaasTaskMigrationCheckJSONBody
+
+// CreateDnsDomainJSONRequestBody defines body for CreateDnsDomain for application/json ContentType.
+type CreateDnsDomainJSONRequestBody CreateDnsDomainJSONBody
+
+// CreateDnsDomainRecordJSONRequestBody defines body for CreateDnsDomainRecord for application/json ContentType.
+type CreateDnsDomainRecordJSONRequestBody CreateDnsDomainRecordJSONBody
+
+// UpdateDnsDomainRecordJSONRequestBody defines body for UpdateDnsDomainRecord for application/json ContentType.
+type UpdateDnsDomainRecordJSONRequestBody UpdateDnsDomainRecordJSONBody
 
 // CreateElasticIpJSONRequestBody defines body for CreateElasticIp for application/json ContentType.
 type CreateElasticIpJSONRequestBody CreateElasticIpJSONBody
@@ -4611,14 +4733,38 @@ type ClientInterface interface {
 	// ListDnsDomains request
 	ListDnsDomains(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// GetDnsDomain request
-	GetDnsDomain(ctx context.Context, id int64, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// CreateDnsDomain request with any body
+	CreateDnsDomainWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	CreateDnsDomain(ctx context.Context, body CreateDnsDomainJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ListDnsDomainRecords request
-	ListDnsDomainRecords(ctx context.Context, id int64, reqEditors ...RequestEditorFn) (*http.Response, error)
+	ListDnsDomainRecords(ctx context.Context, domainId string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// CreateDnsDomainRecord request with any body
+	CreateDnsDomainRecordWithBody(ctx context.Context, domainId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	CreateDnsDomainRecord(ctx context.Context, domainId string, body CreateDnsDomainRecordJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// DeleteDnsDomainRecord request
+	DeleteDnsDomainRecord(ctx context.Context, domainId string, recordId string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetDnsDomainRecord request
-	GetDnsDomainRecord(ctx context.Context, id int64, recordId int64, reqEditors ...RequestEditorFn) (*http.Response, error)
+	GetDnsDomainRecord(ctx context.Context, domainId string, recordId string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UpdateDnsDomainRecord request with any body
+	UpdateDnsDomainRecordWithBody(ctx context.Context, domainId string, recordId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UpdateDnsDomainRecord(ctx context.Context, domainId string, recordId string, body UpdateDnsDomainRecordJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// DeleteDnsDomain request
+	DeleteDnsDomain(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetDnsDomain request
+	GetDnsDomain(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetDnsDomainZoneFile request
+	GetDnsDomainZoneFile(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ListElasticIps request
 	ListElasticIps(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -5820,7 +5966,127 @@ func (c *Client) ListDnsDomains(ctx context.Context, reqEditors ...RequestEditor
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetDnsDomain(ctx context.Context, id int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
+func (c *Client) CreateDnsDomainWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateDnsDomainRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CreateDnsDomain(ctx context.Context, body CreateDnsDomainJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateDnsDomainRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ListDnsDomainRecords(ctx context.Context, domainId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListDnsDomainRecordsRequest(c.Server, domainId)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CreateDnsDomainRecordWithBody(ctx context.Context, domainId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateDnsDomainRecordRequestWithBody(c.Server, domainId, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CreateDnsDomainRecord(ctx context.Context, domainId string, body CreateDnsDomainRecordJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateDnsDomainRecordRequest(c.Server, domainId, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) DeleteDnsDomainRecord(ctx context.Context, domainId string, recordId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeleteDnsDomainRecordRequest(c.Server, domainId, recordId)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetDnsDomainRecord(ctx context.Context, domainId string, recordId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetDnsDomainRecordRequest(c.Server, domainId, recordId)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateDnsDomainRecordWithBody(ctx context.Context, domainId string, recordId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateDnsDomainRecordRequestWithBody(c.Server, domainId, recordId, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateDnsDomainRecord(ctx context.Context, domainId string, recordId string, body UpdateDnsDomainRecordJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateDnsDomainRecordRequest(c.Server, domainId, recordId, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) DeleteDnsDomain(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeleteDnsDomainRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetDnsDomain(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewGetDnsDomainRequest(c.Server, id)
 	if err != nil {
 		return nil, err
@@ -5832,20 +6098,8 @@ func (c *Client) GetDnsDomain(ctx context.Context, id int64, reqEditors ...Reque
 	return c.Client.Do(req)
 }
 
-func (c *Client) ListDnsDomainRecords(ctx context.Context, id int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewListDnsDomainRecordsRequest(c.Server, id)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-}
-
-func (c *Client) GetDnsDomainRecord(ctx context.Context, id int64, recordId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetDnsDomainRecordRequest(c.Server, id, recordId)
+func (c *Client) GetDnsDomainZoneFile(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetDnsDomainZoneFileRequest(c.Server, id)
 	if err != nil {
 		return nil, err
 	}
@@ -9438,8 +9692,299 @@ func NewListDnsDomainsRequest(server string) (*http.Request, error) {
 	return req, nil
 }
 
+// NewCreateDnsDomainRequest calls the generic CreateDnsDomain builder with application/json body
+func NewCreateDnsDomainRequest(server string, body CreateDnsDomainJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewCreateDnsDomainRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewCreateDnsDomainRequestWithBody generates requests for CreateDnsDomain with any type of body
+func NewCreateDnsDomainRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/dns-domain")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewListDnsDomainRecordsRequest generates requests for ListDnsDomainRecords
+func NewListDnsDomainRecordsRequest(server string, domainId string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "domain-id", runtime.ParamLocationPath, domainId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/dns-domain/%s/record", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewCreateDnsDomainRecordRequest calls the generic CreateDnsDomainRecord builder with application/json body
+func NewCreateDnsDomainRecordRequest(server string, domainId string, body CreateDnsDomainRecordJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewCreateDnsDomainRecordRequestWithBody(server, domainId, "application/json", bodyReader)
+}
+
+// NewCreateDnsDomainRecordRequestWithBody generates requests for CreateDnsDomainRecord with any type of body
+func NewCreateDnsDomainRecordRequestWithBody(server string, domainId string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "domain-id", runtime.ParamLocationPath, domainId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/dns-domain/%s/record", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewDeleteDnsDomainRecordRequest generates requests for DeleteDnsDomainRecord
+func NewDeleteDnsDomainRecordRequest(server string, domainId string, recordId string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "domain-id", runtime.ParamLocationPath, domainId)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "record-id", runtime.ParamLocationPath, recordId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/dns-domain/%s/record/%s", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("DELETE", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetDnsDomainRecordRequest generates requests for GetDnsDomainRecord
+func NewGetDnsDomainRecordRequest(server string, domainId string, recordId string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "domain-id", runtime.ParamLocationPath, domainId)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "record-id", runtime.ParamLocationPath, recordId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/dns-domain/%s/record/%s", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewUpdateDnsDomainRecordRequest calls the generic UpdateDnsDomainRecord builder with application/json body
+func NewUpdateDnsDomainRecordRequest(server string, domainId string, recordId string, body UpdateDnsDomainRecordJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUpdateDnsDomainRecordRequestWithBody(server, domainId, recordId, "application/json", bodyReader)
+}
+
+// NewUpdateDnsDomainRecordRequestWithBody generates requests for UpdateDnsDomainRecord with any type of body
+func NewUpdateDnsDomainRecordRequestWithBody(server string, domainId string, recordId string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "domain-id", runtime.ParamLocationPath, domainId)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "record-id", runtime.ParamLocationPath, recordId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/dns-domain/%s/record/%s", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PUT", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewDeleteDnsDomainRequest generates requests for DeleteDnsDomain
+func NewDeleteDnsDomainRequest(server string, id string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/dns-domain/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("DELETE", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewGetDnsDomainRequest generates requests for GetDnsDomain
-func NewGetDnsDomainRequest(server string, id int64) (*http.Request, error) {
+func NewGetDnsDomainRequest(server string, id string) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -9472,8 +10017,8 @@ func NewGetDnsDomainRequest(server string, id int64) (*http.Request, error) {
 	return req, nil
 }
 
-// NewListDnsDomainRecordsRequest generates requests for ListDnsDomainRecords
-func NewListDnsDomainRecordsRequest(server string, id int64) (*http.Request, error) {
+// NewGetDnsDomainZoneFileRequest generates requests for GetDnsDomainZoneFile
+func NewGetDnsDomainZoneFileRequest(server string, id string) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -9488,48 +10033,7 @@ func NewListDnsDomainRecordsRequest(server string, id int64) (*http.Request, err
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/dns-domain/%s/record", pathParam0)
-	if operationPath[0] == '/' {
-		operationPath = "." + operationPath
-	}
-
-	queryURL, err := serverURL.Parse(operationPath)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest("GET", queryURL.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return req, nil
-}
-
-// NewGetDnsDomainRecordRequest generates requests for GetDnsDomainRecord
-func NewGetDnsDomainRecordRequest(server string, id int64, recordId int64) (*http.Request, error) {
-	var err error
-
-	var pathParam0 string
-
-	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
-	if err != nil {
-		return nil, err
-	}
-
-	var pathParam1 string
-
-	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "record-id", runtime.ParamLocationPath, recordId)
-	if err != nil {
-		return nil, err
-	}
-
-	serverURL, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	operationPath := fmt.Sprintf("/dns-domain/%s/record/%s", pathParam0, pathParam1)
+	operationPath := fmt.Sprintf("/dns-domain/%s/zone", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -14081,14 +14585,38 @@ type ClientWithResponsesInterface interface {
 	// ListDnsDomains request
 	ListDnsDomainsWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListDnsDomainsResponse, error)
 
-	// GetDnsDomain request
-	GetDnsDomainWithResponse(ctx context.Context, id int64, reqEditors ...RequestEditorFn) (*GetDnsDomainResponse, error)
+	// CreateDnsDomain request with any body
+	CreateDnsDomainWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateDnsDomainResponse, error)
+
+	CreateDnsDomainWithResponse(ctx context.Context, body CreateDnsDomainJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateDnsDomainResponse, error)
 
 	// ListDnsDomainRecords request
-	ListDnsDomainRecordsWithResponse(ctx context.Context, id int64, reqEditors ...RequestEditorFn) (*ListDnsDomainRecordsResponse, error)
+	ListDnsDomainRecordsWithResponse(ctx context.Context, domainId string, reqEditors ...RequestEditorFn) (*ListDnsDomainRecordsResponse, error)
+
+	// CreateDnsDomainRecord request with any body
+	CreateDnsDomainRecordWithBodyWithResponse(ctx context.Context, domainId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateDnsDomainRecordResponse, error)
+
+	CreateDnsDomainRecordWithResponse(ctx context.Context, domainId string, body CreateDnsDomainRecordJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateDnsDomainRecordResponse, error)
+
+	// DeleteDnsDomainRecord request
+	DeleteDnsDomainRecordWithResponse(ctx context.Context, domainId string, recordId string, reqEditors ...RequestEditorFn) (*DeleteDnsDomainRecordResponse, error)
 
 	// GetDnsDomainRecord request
-	GetDnsDomainRecordWithResponse(ctx context.Context, id int64, recordId int64, reqEditors ...RequestEditorFn) (*GetDnsDomainRecordResponse, error)
+	GetDnsDomainRecordWithResponse(ctx context.Context, domainId string, recordId string, reqEditors ...RequestEditorFn) (*GetDnsDomainRecordResponse, error)
+
+	// UpdateDnsDomainRecord request with any body
+	UpdateDnsDomainRecordWithBodyWithResponse(ctx context.Context, domainId string, recordId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateDnsDomainRecordResponse, error)
+
+	UpdateDnsDomainRecordWithResponse(ctx context.Context, domainId string, recordId string, body UpdateDnsDomainRecordJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateDnsDomainRecordResponse, error)
+
+	// DeleteDnsDomain request
+	DeleteDnsDomainWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*DeleteDnsDomainResponse, error)
+
+	// GetDnsDomain request
+	GetDnsDomainWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*GetDnsDomainResponse, error)
+
+	// GetDnsDomainZoneFile request
+	GetDnsDomainZoneFileWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*GetDnsDomainZoneFileResponse, error)
 
 	// ListElasticIps request
 	ListElasticIpsWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListElasticIpsResponse, error)
@@ -15714,14 +16242,14 @@ func (r ListDnsDomainsResponse) StatusCode() int {
 	return 0
 }
 
-type GetDnsDomainResponse struct {
+type CreateDnsDomainResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *DnsDomain
 }
 
 // Status returns HTTPResponse.Status
-func (r GetDnsDomainResponse) Status() string {
+func (r CreateDnsDomainResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -15729,7 +16257,7 @@ func (r GetDnsDomainResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r GetDnsDomainResponse) StatusCode() int {
+func (r CreateDnsDomainResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -15760,6 +16288,50 @@ func (r ListDnsDomainRecordsResponse) StatusCode() int {
 	return 0
 }
 
+type CreateDnsDomainRecordResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *Operation
+}
+
+// Status returns HTTPResponse.Status
+func (r CreateDnsDomainRecordResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CreateDnsDomainRecordResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type DeleteDnsDomainRecordResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *Operation
+}
+
+// Status returns HTTPResponse.Status
+func (r DeleteDnsDomainRecordResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DeleteDnsDomainRecordResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type GetDnsDomainRecordResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -15776,6 +16348,94 @@ func (r GetDnsDomainRecordResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r GetDnsDomainRecordResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UpdateDnsDomainRecordResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *Operation
+}
+
+// Status returns HTTPResponse.Status
+func (r UpdateDnsDomainRecordResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UpdateDnsDomainRecordResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type DeleteDnsDomainResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *Operation
+}
+
+// Status returns HTTPResponse.Status
+func (r DeleteDnsDomainResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DeleteDnsDomainResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetDnsDomainResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *DnsDomain
+}
+
+// Status returns HTTPResponse.Status
+func (r GetDnsDomainResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetDnsDomainResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetDnsDomainZoneFileResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *string
+}
+
+// Status returns HTTPResponse.Status
+func (r GetDnsDomainZoneFileResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetDnsDomainZoneFileResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -18749,8 +19409,95 @@ func (c *ClientWithResponses) ListDnsDomainsWithResponse(ctx context.Context, re
 	return ParseListDnsDomainsResponse(rsp)
 }
 
+// CreateDnsDomainWithBodyWithResponse request with arbitrary body returning *CreateDnsDomainResponse
+func (c *ClientWithResponses) CreateDnsDomainWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateDnsDomainResponse, error) {
+	rsp, err := c.CreateDnsDomainWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateDnsDomainResponse(rsp)
+}
+
+func (c *ClientWithResponses) CreateDnsDomainWithResponse(ctx context.Context, body CreateDnsDomainJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateDnsDomainResponse, error) {
+	rsp, err := c.CreateDnsDomain(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateDnsDomainResponse(rsp)
+}
+
+// ListDnsDomainRecordsWithResponse request returning *ListDnsDomainRecordsResponse
+func (c *ClientWithResponses) ListDnsDomainRecordsWithResponse(ctx context.Context, domainId string, reqEditors ...RequestEditorFn) (*ListDnsDomainRecordsResponse, error) {
+	rsp, err := c.ListDnsDomainRecords(ctx, domainId, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListDnsDomainRecordsResponse(rsp)
+}
+
+// CreateDnsDomainRecordWithBodyWithResponse request with arbitrary body returning *CreateDnsDomainRecordResponse
+func (c *ClientWithResponses) CreateDnsDomainRecordWithBodyWithResponse(ctx context.Context, domainId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateDnsDomainRecordResponse, error) {
+	rsp, err := c.CreateDnsDomainRecordWithBody(ctx, domainId, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateDnsDomainRecordResponse(rsp)
+}
+
+func (c *ClientWithResponses) CreateDnsDomainRecordWithResponse(ctx context.Context, domainId string, body CreateDnsDomainRecordJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateDnsDomainRecordResponse, error) {
+	rsp, err := c.CreateDnsDomainRecord(ctx, domainId, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateDnsDomainRecordResponse(rsp)
+}
+
+// DeleteDnsDomainRecordWithResponse request returning *DeleteDnsDomainRecordResponse
+func (c *ClientWithResponses) DeleteDnsDomainRecordWithResponse(ctx context.Context, domainId string, recordId string, reqEditors ...RequestEditorFn) (*DeleteDnsDomainRecordResponse, error) {
+	rsp, err := c.DeleteDnsDomainRecord(ctx, domainId, recordId, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDeleteDnsDomainRecordResponse(rsp)
+}
+
+// GetDnsDomainRecordWithResponse request returning *GetDnsDomainRecordResponse
+func (c *ClientWithResponses) GetDnsDomainRecordWithResponse(ctx context.Context, domainId string, recordId string, reqEditors ...RequestEditorFn) (*GetDnsDomainRecordResponse, error) {
+	rsp, err := c.GetDnsDomainRecord(ctx, domainId, recordId, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetDnsDomainRecordResponse(rsp)
+}
+
+// UpdateDnsDomainRecordWithBodyWithResponse request with arbitrary body returning *UpdateDnsDomainRecordResponse
+func (c *ClientWithResponses) UpdateDnsDomainRecordWithBodyWithResponse(ctx context.Context, domainId string, recordId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateDnsDomainRecordResponse, error) {
+	rsp, err := c.UpdateDnsDomainRecordWithBody(ctx, domainId, recordId, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateDnsDomainRecordResponse(rsp)
+}
+
+func (c *ClientWithResponses) UpdateDnsDomainRecordWithResponse(ctx context.Context, domainId string, recordId string, body UpdateDnsDomainRecordJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateDnsDomainRecordResponse, error) {
+	rsp, err := c.UpdateDnsDomainRecord(ctx, domainId, recordId, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateDnsDomainRecordResponse(rsp)
+}
+
+// DeleteDnsDomainWithResponse request returning *DeleteDnsDomainResponse
+func (c *ClientWithResponses) DeleteDnsDomainWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*DeleteDnsDomainResponse, error) {
+	rsp, err := c.DeleteDnsDomain(ctx, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDeleteDnsDomainResponse(rsp)
+}
+
 // GetDnsDomainWithResponse request returning *GetDnsDomainResponse
-func (c *ClientWithResponses) GetDnsDomainWithResponse(ctx context.Context, id int64, reqEditors ...RequestEditorFn) (*GetDnsDomainResponse, error) {
+func (c *ClientWithResponses) GetDnsDomainWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*GetDnsDomainResponse, error) {
 	rsp, err := c.GetDnsDomain(ctx, id, reqEditors...)
 	if err != nil {
 		return nil, err
@@ -18758,22 +19505,13 @@ func (c *ClientWithResponses) GetDnsDomainWithResponse(ctx context.Context, id i
 	return ParseGetDnsDomainResponse(rsp)
 }
 
-// ListDnsDomainRecordsWithResponse request returning *ListDnsDomainRecordsResponse
-func (c *ClientWithResponses) ListDnsDomainRecordsWithResponse(ctx context.Context, id int64, reqEditors ...RequestEditorFn) (*ListDnsDomainRecordsResponse, error) {
-	rsp, err := c.ListDnsDomainRecords(ctx, id, reqEditors...)
+// GetDnsDomainZoneFileWithResponse request returning *GetDnsDomainZoneFileResponse
+func (c *ClientWithResponses) GetDnsDomainZoneFileWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*GetDnsDomainZoneFileResponse, error) {
+	rsp, err := c.GetDnsDomainZoneFile(ctx, id, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseListDnsDomainRecordsResponse(rsp)
-}
-
-// GetDnsDomainRecordWithResponse request returning *GetDnsDomainRecordResponse
-func (c *ClientWithResponses) GetDnsDomainRecordWithResponse(ctx context.Context, id int64, recordId int64, reqEditors ...RequestEditorFn) (*GetDnsDomainRecordResponse, error) {
-	rsp, err := c.GetDnsDomainRecord(ctx, id, recordId, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseGetDnsDomainRecordResponse(rsp)
+	return ParseGetDnsDomainZoneFileResponse(rsp)
 }
 
 // ListElasticIpsWithResponse request returning *ListElasticIpsResponse
@@ -21495,15 +22233,15 @@ func ParseListDnsDomainsResponse(rsp *http.Response) (*ListDnsDomainsResponse, e
 	return response, nil
 }
 
-// ParseGetDnsDomainResponse parses an HTTP response from a GetDnsDomainWithResponse call
-func ParseGetDnsDomainResponse(rsp *http.Response) (*GetDnsDomainResponse, error) {
+// ParseCreateDnsDomainResponse parses an HTTP response from a CreateDnsDomainWithResponse call
+func ParseCreateDnsDomainResponse(rsp *http.Response) (*CreateDnsDomainResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &GetDnsDomainResponse{
+	response := &CreateDnsDomainResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -21549,6 +22287,58 @@ func ParseListDnsDomainRecordsResponse(rsp *http.Response) (*ListDnsDomainRecord
 	return response, nil
 }
 
+// ParseCreateDnsDomainRecordResponse parses an HTTP response from a CreateDnsDomainRecordWithResponse call
+func ParseCreateDnsDomainRecordResponse(rsp *http.Response) (*CreateDnsDomainRecordResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CreateDnsDomainRecordResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest Operation
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseDeleteDnsDomainRecordResponse parses an HTTP response from a DeleteDnsDomainRecordWithResponse call
+func ParseDeleteDnsDomainRecordResponse(rsp *http.Response) (*DeleteDnsDomainRecordResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DeleteDnsDomainRecordResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest Operation
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
 // ParseGetDnsDomainRecordResponse parses an HTTP response from a GetDnsDomainRecordWithResponse call
 func ParseGetDnsDomainRecordResponse(rsp *http.Response) (*GetDnsDomainRecordResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
@@ -21565,6 +22355,110 @@ func ParseGetDnsDomainRecordResponse(rsp *http.Response) (*GetDnsDomainRecordRes
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest DnsDomainRecord
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUpdateDnsDomainRecordResponse parses an HTTP response from a UpdateDnsDomainRecordWithResponse call
+func ParseUpdateDnsDomainRecordResponse(rsp *http.Response) (*UpdateDnsDomainRecordResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UpdateDnsDomainRecordResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest Operation
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseDeleteDnsDomainResponse parses an HTTP response from a DeleteDnsDomainWithResponse call
+func ParseDeleteDnsDomainResponse(rsp *http.Response) (*DeleteDnsDomainResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DeleteDnsDomainResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest Operation
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetDnsDomainResponse parses an HTTP response from a GetDnsDomainWithResponse call
+func ParseGetDnsDomainResponse(rsp *http.Response) (*GetDnsDomainResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetDnsDomainResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest DnsDomain
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetDnsDomainZoneFileResponse parses an HTTP response from a GetDnsDomainZoneFileWithResponse call
+func ParseGetDnsDomainZoneFileResponse(rsp *http.Response) (*GetDnsDomainZoneFileResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetDnsDomainZoneFileResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest string
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/vendor/github.com/exoscale/egoscale/v2/template.go
+++ b/vendor/github.com/exoscale/egoscale/v2/template.go
@@ -18,6 +18,7 @@ type Template struct {
 	Description     *string
 	Family          *string
 	ID              *string `req-for:"update,delete"`
+	Maintainer      *string
 	Name            *string `req-for:"create"`
 	PasswordEnabled *bool   `req-for:"create"`
 	SSHKeyEnabled   *bool   `req-for:"create"`
@@ -59,6 +60,7 @@ func templateFromAPI(t *oapi.Template, zone string) *Template {
 		Description:     t.Description,
 		Family:          t.Family,
 		ID:              t.Id,
+		Maintainer:      t.Maintainer,
 		Name:            t.Name,
 		PasswordEnabled: t.PasswordEnabled,
 		SSHKeyEnabled:   t.SshKeyEnabled,
@@ -169,13 +171,16 @@ func (c *Client) RegisterTemplate(ctx context.Context, zone string, template *Te
 		apiv2.WithZone(ctx, zone),
 		oapi.RegisterTemplateJSONRequestBody{
 			BootMode:        (*oapi.RegisterTemplateJSONBodyBootMode)(template.BootMode),
+			Build:           template.Build,
 			Checksum:        *template.Checksum,
 			DefaultUser:     template.DefaultUser,
 			Description:     template.Description,
+			Maintainer:      template.Maintainer,
 			Name:            *template.Name,
 			PasswordEnabled: *template.PasswordEnabled,
 			SshKeyEnabled:   *template.SSHKeyEnabled,
 			Url:             *template.URL,
+			Version:         template.Version,
 		})
 	if err != nil {
 		return nil, err

--- a/vendor/github.com/exoscale/egoscale/version/version.go
+++ b/vendor/github.com/exoscale/egoscale/version/version.go
@@ -2,4 +2,4 @@
 package version
 
 // Version represents the current egoscale version.
-const Version = "0.88.0"
+const Version = "0.89.0"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -19,8 +19,8 @@ github.com/davecgh/go-spew/spew
 ## explicit; go 1.16
 github.com/deepmap/oapi-codegen/pkg/runtime
 github.com/deepmap/oapi-codegen/pkg/types
-# github.com/exoscale/egoscale v0.88.1
-## explicit; go 1.16
+# github.com/exoscale/egoscale v0.89.0
+## explicit; go 1.17
 github.com/exoscale/egoscale
 github.com/exoscale/egoscale/v2
 github.com/exoscale/egoscale/v2/api


### PR DESCRIPTION
This PR migrates all DNS related API calls to new endpoints in Public API.

New API is **not** fully compatible and there are some terrraform schema changes:

- datasource `exoscale_domain_record.domain`: now a domain ID (UUID), was a domain name;
- resource `exoscale_domain.id`: now a domain ID (UUID), was a domain name;
- resource `exoscale_domain_record.id`: new value in UUID format;
- resource `exoscale_domain_record.domain`: now a domain ID (UUID), was a domain name.

State migration handles the change, for example new tf-provider would report following changes on existing state:

```
$ cat main.tf 
...

resource "exoscale_domain" "example" {
  name = "example.net"
}

resource "exoscale_domain_record" "myserver" {
  domain      = exoscale_domain.example.id
  name        = "myserver"
  record_type = "A"
  content     = "1.2.3.4"
}

resource "exoscale_domain_record" "myserver_alias" {
  domain      = exoscale_domain.example.id
  name        = "myserver-new"
  record_type = "CNAME"
  content     = exoscale_domain_record.myserver.hostname
}


output "my-domain" {
  value = resource.exoscale_domain.example
}

output "my-record1" {
  value = resource.exoscale_domain_record.myserver
}

output "my-record2" {
  value = resource.exoscale_domain_record.myserver_alias
}

$ terraform plan
...
Changes to Outputs:
  ~ my-domain  = {
      ~ id         = "example.net" -> "89083a5c-b648-474a-0000-0000000ee0a9"
        name       = "example.net"
        # (5 unchanged elements hidden)
    }
  ~ my-record1 = {
      ~ domain      = "example.net" -> "89083a5c-b648-474a-0000-0000000ee0a9"
      ~ id          = "35217758" -> "89083a5c-b648-474a-0000-00000219615e"
        name        = "myserver"
        # (6 unchanged elements hidden)
    }
  ~ my-record2 = {
      ~ domain      = "example.net" -> "89083a5c-b648-474a-0000-0000000ee0a9"
      ~ id          = "35217759" -> "89083a5c-b648-474a-0000-00000219615f"
        name        = "myserver-new"
        # (6 unchanged elements hidden)
    }

You can apply this plan to save these new output values to the Terraform state, without changing any real infrastructure.
```