### PR TITLE
Update kafka version used in tests

### DIFF
--- a/exoscale/resource_exoscale_database_kafka_test.go
+++ b/exoscale/resource_exoscale_database_kafka_test.go
@@ -14,7 +14,7 @@ import (
 
 var (
 	testAccResourceDatabaseKafkaIPFilter = []string{"1.2.3.4/32"}
-	testAccResourceDatabaseKafkaVersion  = "3.0"
+	testAccResourceDatabaseKafkaVersion  = "3.1"
 	testAccResourceDatabasePlanKafka     = "business-4"
 
 	testAccResourceDatabaseConfigCreateKafka = fmt.Sprintf(`


### PR DESCRIPTION
Fixes:
```
Error: Post "https://api-ch-dk-2.exoscale.com/v2/dbaas-kafka/test-terraform-exoscale-8729095303854885459": invalid request: Service 'kafka' version '3.0' has reached end of availability and cannot be created
```