### PR TITLE
Implementing primitive cache to reduce dnsimple API calls for state upgrade

### DIFF
--- a/exoscale/resource_exoscale_domain_record.go
+++ b/exoscale/resource_exoscale_domain_record.go
@@ -176,7 +176,7 @@ func resourceDomainRecordStateUpgradeV0(
 		if err != nil {
 			return nil, fmt.Errorf("error retrieving domain records: %q", err)
 		}
-		tflog.Debug(ctx, "statee-upgrader: adding records to cache")
+		tflog.Debug(ctx, "state-upgrader: adding records to cache")
 		resourceDomainRecordUpgradeCache.AddRecords(rawState["domain"].(string), records)
 	} else {
 		tflog.Debug(ctx, "state-upgrader: records found in cache")


### PR DESCRIPTION
For 2 domain records, relevant log during state upgrade would like like bellow:
```
2022-07-22T19:49:33.683+0200 [DEBUG] provider.terraform-provider-exoscale: state_upgrader: reading records from cache: @module=provider tf_req_id=9b613039-318f-5a57-520f-1c883430b0f3 tf_provider_addr=provider tf_resource_type=exoscale_dom
ain_record tf_rpc=UpgradeResourceState @caller=/home/predrag/Workspace/exoscale/terraform-provider/exoscale/resource_exoscale_domain_record.go:171 timestamp=2022-07-22T19:49:33.682+0200                                                     
2022-07-22T19:49:33.683+0200 [DEBUG] provider.terraform-provider-exoscale: state-upgrader: records not found in cache: @module=provider tf_provider_addr=provider tf_rpc=UpgradeResourceState @caller=/home/predrag/Workspace/exoscale/terrafo
rm-provider/exoscale/resource_exoscale_domain_record.go:174 tf_req_id=9b613039-318f-5a57-520f-1c883430b0f3 tf_resource_type=exoscale_domain_record timestamp=2022-07-22T19:49:33.682+0200                                                     
2022-07-22T19:49:33.684+0200 [INFO]  provider.terraform-provider-exoscale: 2022/07/22 19:49:33 [DEBUG] exoscale API Request Details:                                                                                                          
---[ REQUEST ]---------------------------------------                                                                                                                                                                                         
GET /v2/dns-domain/89083a5c-b648-474a-0000-0000000f00ab/record HTTP/1.1                                                                                                                                                                       
...


2022-07-22T19:49:34.334+0200 [DEBUG] provider.terraform-provider-exoscale: statee-upgrader: adding records to cache: @module=provider tf_req_id=9b613039-318f-5a57-520f-1c883430b0f3 tf_rpc=UpgradeResourceState @caller=/home/predrag/Workspa
ce/exoscale/terraform-provider/exoscale/resource_exoscale_domain_record.go:179 tf_provider_addr=provider tf_resource_type=exoscale_domain_record timestamp=2022-07-22T19:49:34.333+0200
2022-07-22T19:49:34.334+0200 [DEBUG] provider.terraform-provider-exoscale: state_upgrader: reading records from cache: @module=provider tf_provider_addr=provider @caller=/home/predrag/Workspace/exoscale/terraform-provider/exoscale/resourc
e_exoscale_domain_record.go:171 tf_req_id=f1b3bebb-fa9c-75b6-cdb2-8271d22787fd tf_resource_type=exoscale_domain_record tf_rpc=UpgradeResourceState timestamp=2022-07-22T19:49:34.334+0200
2022-07-22T19:49:34.334+0200 [DEBUG] provider.terraform-provider-exoscale: state-upgrader: records found in cache: @caller=/home/predrag/Workspace/exoscale/terraform-provider/exoscale/resource_exoscale_domain_record.go:182 @module=provide
r tf_req_id=f1b3bebb-fa9c-75b6-cdb2-8271d22787fd tf_resource_type=exoscale_domain_record tf_rpc=UpgradeResourceState tf_provider_addr=provider timestamp=2022-07-22T19:49:34.334+0200
exoscale_domain_record.myserver2: Refreshing state... [id=89083a5c-b648-474a-0000-000002224767]                                                                                                                                               
exoscale_domain_record.myserver1: Refreshing state... [id=89083a5c-b648-474a-0000-000002224766]
...
```