### PR TITLE
domain/domain_record: use environment config

### DIFF
--- a/exoscale/datasource_exoscale_domain.go
+++ b/exoscale/datasource_exoscale_domain.go
@@ -5,6 +5,7 @@ import (
 	"log"
 
 	exo "github.com/exoscale/egoscale/v2"
+	exoapi "github.com/exoscale/egoscale/v2/api"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -27,6 +28,7 @@ func dataSourceDomainRead(ctx context.Context, d *schema.ResourceData, meta inte
 	log.Printf("[DEBUG] %s: beginning read", resourceIDString(d, "exoscale_domain"))
 
 	ctx, cancel := context.WithTimeout(ctx, d.Timeout(schema.TimeoutRead))
+	ctx = exoapi.WithEndpoint(ctx, exoapi.NewReqEndpoint(getEnvironment(meta), defaultZone))
 	defer cancel()
 
 	client := GetComputeClient(meta)

--- a/exoscale/datasource_exoscale_domain_record.go
+++ b/exoscale/datasource_exoscale_domain_record.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	exo "github.com/exoscale/egoscale/v2"
+	exoapi "github.com/exoscale/egoscale/v2/api"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -106,6 +107,7 @@ func dataSourceDomainRecordRead(ctx context.Context, d *schema.ResourceData, met
 	log.Printf("[DEBUG] %s: beginning read", resourceIDString(d, "exoscale_domain"))
 
 	ctx, cancel := context.WithTimeout(ctx, d.Timeout(schema.TimeoutRead))
+	ctx = exoapi.WithEndpoint(ctx, exoapi.NewReqEndpoint(getEnvironment(meta), defaultZone))
 	defer cancel()
 
 	client := GetComputeClient(meta)

--- a/exoscale/resource_exoscale_domain.go
+++ b/exoscale/resource_exoscale_domain.go
@@ -110,6 +110,7 @@ func resourceDomainCreate(ctx context.Context, d *schema.ResourceData, meta inte
 	log.Printf("[DEBUG] %s: beginning create", resourceDomainIDString(d))
 
 	ctx, cancel := context.WithTimeout(ctx, d.Timeout(schema.TimeoutRead))
+	ctx = exoapi.WithEndpoint(ctx, exoapi.NewReqEndpoint(getEnvironment(meta), defaultZone))
 	defer cancel()
 
 	client := GetComputeClient(meta)
@@ -117,7 +118,7 @@ func resourceDomainCreate(ctx context.Context, d *schema.ResourceData, meta inte
 	domainName := d.Get("name").(string)
 	domain, err := client.CreateDNSDomain(ctx, defaultZone, &exo.DNSDomain{UnicodeName: &domainName})
 	if err != nil {
-		return diag.Errorf("unable to retrieve instance type: %s", err)
+		return diag.Errorf("unable to create domain: %s", err)
 	}
 
 	d.SetId(*domain.ID)
@@ -134,6 +135,7 @@ func resourceDomainCreate(ctx context.Context, d *schema.ResourceData, meta inte
 
 func resourceDomainExists(d *schema.ResourceData, meta interface{}) (bool, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutRead))
+	ctx = exoapi.WithEndpoint(ctx, exoapi.NewReqEndpoint(getEnvironment(meta), defaultZone))
 	defer cancel()
 
 	client := GetComputeClient(meta)
@@ -153,6 +155,7 @@ func resourceDomainRead(ctx context.Context, d *schema.ResourceData, meta interf
 	log.Printf("[DEBUG] %s: beginning read", resourceDomainIDString(d))
 
 	ctx, cancel := context.WithTimeout(ctx, d.Timeout(schema.TimeoutRead))
+	ctx = exoapi.WithEndpoint(ctx, exoapi.NewReqEndpoint(getEnvironment(meta), defaultZone))
 	defer cancel()
 
 	client := GetComputeClient(meta)
@@ -176,6 +179,7 @@ func resourceDomainDelete(ctx context.Context, d *schema.ResourceData, meta inte
 	log.Printf("[DEBUG] %s: beginning delete", resourceDomainIDString(d))
 
 	ctx, cancel := context.WithTimeout(ctx, d.Timeout(schema.TimeoutRead))
+	ctx = exoapi.WithEndpoint(ctx, exoapi.NewReqEndpoint(getEnvironment(meta), defaultZone))
 	defer cancel()
 
 	client := GetComputeClient(meta)
@@ -197,6 +201,7 @@ func resourceDomainDelete(ctx context.Context, d *schema.ResourceData, meta inte
 
 func resourceDomainImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutRead))
+	ctx = exoapi.WithEndpoint(ctx, exoapi.NewReqEndpoint(getEnvironment(meta), defaultZone))
 	defer cancel()
 
 	client := GetComputeClient(meta)

--- a/exoscale/resource_exoscale_domain_record.go
+++ b/exoscale/resource_exoscale_domain_record.go
@@ -153,6 +153,7 @@ func resourceDomainRecordCreate(ctx context.Context, d *schema.ResourceData, met
 	log.Printf("[DEBUG] %s: beginning create", resourceDomainRecordIDString(d))
 
 	ctx, cancel := context.WithTimeout(ctx, d.Timeout(schema.TimeoutRead))
+	ctx = exoapi.WithEndpoint(ctx, exoapi.NewReqEndpoint(getEnvironment(meta), defaultZone))
 	defer cancel()
 
 	client := GetComputeClient(meta)
@@ -188,6 +189,7 @@ func resourceDomainRecordCreate(ctx context.Context, d *schema.ResourceData, met
 
 func resourceDomainRecordExists(d *schema.ResourceData, meta interface{}) (bool, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutRead))
+	ctx = exoapi.WithEndpoint(ctx, exoapi.NewReqEndpoint(getEnvironment(meta), defaultZone))
 	defer cancel()
 
 	client := GetComputeClient(meta)
@@ -236,6 +238,7 @@ func resourceDomainRecordRead(ctx context.Context, d *schema.ResourceData, meta 
 	log.Printf("[DEBUG] %s: beginning read", resourceDomainRecordIDString(d))
 
 	ctx, cancel := context.WithTimeout(ctx, d.Timeout(schema.TimeoutRead))
+	ctx = exoapi.WithEndpoint(ctx, exoapi.NewReqEndpoint(getEnvironment(meta), defaultZone))
 	defer cancel()
 
 	client := GetComputeClient(meta)
@@ -303,6 +306,7 @@ func resourceDomainRecordUpdate(ctx context.Context, d *schema.ResourceData, met
 	log.Printf("[DEBUG] %s: beginning update", resourceDomainRecordIDString(d))
 
 	ctx, cancel := context.WithTimeout(ctx, d.Timeout(schema.TimeoutRead))
+	ctx = exoapi.WithEndpoint(ctx, exoapi.NewReqEndpoint(getEnvironment(meta), defaultZone))
 	defer cancel()
 
 	client := GetComputeClient(meta)
@@ -357,6 +361,7 @@ func resourceDomainRecordDelete(ctx context.Context, d *schema.ResourceData, met
 	log.Printf("[DEBUG] %s: beginning delete", resourceDomainRecordIDString(d))
 
 	ctx, cancel := context.WithTimeout(ctx, d.Timeout(schema.TimeoutRead))
+	ctx = exoapi.WithEndpoint(ctx, exoapi.NewReqEndpoint(getEnvironment(meta), defaultZone))
 	defer cancel()
 
 	client := GetComputeClient(meta)


### PR DESCRIPTION
This PR fixes the issue with running provider against non-production API.