### PR TITLE
Adding support for EIPv6

### DIFF
--- a/docs/data-sources/elastic_ip.md
+++ b/docs/data-sources/elastic_ip.md
@@ -42,12 +42,10 @@ directory for complete configuration examples.
 
 In addition to the arguments listed above, the following attributes are exported:
 
-* `address_family` - The Elastic IP (EIP) address family (`inet4` or `inet6`).
-
-* `cidr` - The Elastic IP (EIP) CIDR.
-
 * `description` - The Elastic IP (EIP) description.
 
+* `address_family` - The Elastic IP (EIP) address family (`inet4` or `inet6`).
+* `cidr` - The Elastic IP (EIP) CIDR.
 * `healthcheck` - (Block) The *managed* EIP healthcheck configuration. Structure is documented below.
 
 ### `healthcheck` block

--- a/docs/data-sources/elastic_ip.md
+++ b/docs/data-sources/elastic_ip.md
@@ -35,12 +35,16 @@ directory for complete configuration examples.
 * `zone` - (Required) The Exocale [Zone][zone] name.
 
 * `id` - The Elastic IP (EIP) ID to match (conflicts with `ip_address`).
-* `ip_address` - The EIP IPv4 address to match (conflicts with `id`).
+* `ip_address` - The EIP IPv4 or IPv6 address to match (conflicts with `id`).
 
 
 ## Attributes Reference
 
 In addition to the arguments listed above, the following attributes are exported:
+
+* `address_family` - The Elastic IP (EIP) address family (`inet4` or `inet6`).
+
+* `cidr` - The Elastic IP (EIP) CIDR.
 
 * `description` - The Elastic IP (EIP) description.
 

--- a/docs/resources/elastic_ip.md
+++ b/docs/resources/elastic_ip.md
@@ -13,7 +13,7 @@ Corresponding data source: [exoscale_elastic_ip](../data-sources/elastic_ip.md).
 
 ### Usage
 
-*Unmanaged* EIP:
+*Unmanaged* EIPv4:
 
 ```hcl
 resource "exoscale_elastic_ip" "my_elastic_ip" {
@@ -21,11 +21,12 @@ resource "exoscale_elastic_ip" "my_elastic_ip" {
 }
 ```
 
-*Managed* EIP:
+*Managed* EIPv6:
 
 ```hcl
 resource "exoscale_elastic_ip" "my_managed_elastic_ip" {
   zone = "ch-gva-2"
+  address_family = "inet6"
 
   healthcheck {
     mode         = "https"
@@ -50,6 +51,8 @@ directory for complete configuration examples.
 
 * `zone` - (Required) The Exoscale [Zone][zone] name.
 
+* `address_family` - The Elastic IP (EIP) address family (`inet4` or `inet6`; default: `inet4`).
+
 * `description` - A free-form text describing the Elastic IP (EIP).
 
 * `healthcheck` - (Block) Healthcheck configuration for *managed* EIPs. Structure is documented below.
@@ -72,7 +75,10 @@ directory for complete configuration examples.
 
 In addition to the arguments listed above, the following attributes are exported:
 
-* `ip_address` - The Elastic IP (EIP) IPv4 address.
+* `cidr` - The Elastic IP (EIP) CIDR.
+
+* `ip_address` - The Elastic IP (EIP) IPv4 or IPv6 address.
+
 
 
 ## Import

--- a/docs/resources/elastic_ip.md
+++ b/docs/resources/elastic_ip.md
@@ -50,6 +50,7 @@ directory for complete configuration examples.
 [zone]: https://www.exoscale.com/datacenters/
 
 * `zone` - (Required) The Exoscale [Zone][zone] name.
+
 * `description` - A free-form text describing the Elastic IP (EIP).
 
 * `address_family` - The Elastic IP (EIP) address family (`inet4` or `inet6`; default: `inet4`).

--- a/docs/resources/elastic_ip.md
+++ b/docs/resources/elastic_ip.md
@@ -50,11 +50,9 @@ directory for complete configuration examples.
 [zone]: https://www.exoscale.com/datacenters/
 
 * `zone` - (Required) The Exoscale [Zone][zone] name.
-
-* `address_family` - The Elastic IP (EIP) address family (`inet4` or `inet6`; default: `inet4`).
-
 * `description` - A free-form text describing the Elastic IP (EIP).
 
+* `address_family` - The Elastic IP (EIP) address family (`inet4` or `inet6`; default: `inet4`).
 * `healthcheck` - (Block) Healthcheck configuration for *managed* EIPs. Structure is documented below.
 
 ### `healthcheck` block
@@ -76,7 +74,6 @@ directory for complete configuration examples.
 In addition to the arguments listed above, the following attributes are exported:
 
 * `cidr` - The Elastic IP (EIP) CIDR.
-
 * `ip_address` - The Elastic IP (EIP) IPv4 or IPv6 address.
 
 

--- a/exoscale/datasource_exoscale_elastic_ip.go
+++ b/exoscale/datasource_exoscale_elastic_ip.go
@@ -10,6 +10,8 @@ import (
 )
 
 const (
+	dsElasticIPAttrAddressFamily            = "address_family"
+	dsElasticIPAttrCIDR                     = "cidr"
 	dsElasticIPAttrDescription              = "description"
 	dsElasticIPAttrHealthcheckInterval      = "interval"
 	dsElasticIPAttrHealthcheckMode          = "mode"
@@ -28,6 +30,14 @@ const (
 func dataSourceElasticIP() *schema.Resource {
 	return &schema.Resource{
 		Schema: map[string]*schema.Schema{
+			dsElasticIPAttrAddressFamily: {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			dsElasticIPAttrCIDR: {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			dsElasticIPAttrDescription: {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -134,6 +144,12 @@ func dataSourceElasticIPRead(ctx context.Context, d *schema.ResourceData, meta i
 
 	d.SetId(*elasticIP.ID)
 
+	if err := d.Set(dsElasticIPAttrAddressFamily, defaultString(elasticIP.AddressFamily, "")); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set(dsElasticIPAttrCIDR, defaultString(elasticIP.CIDR, "")); err != nil {
+		return diag.FromErr(err)
+	}
 	if err := d.Set(dsElasticIPAttrDescription, defaultString(elasticIP.Description, "")); err != nil {
 		return diag.FromErr(err)
 	}

--- a/exoscale/resource_exoscale_database_test.go
+++ b/exoscale/resource_exoscale_database_test.go
@@ -133,7 +133,7 @@ func testAccCheckResourceDatabaseDestroy(dbType, dbName string) resource.TestChe
 		}
 
 		if err != nil {
-			if errors.As(err, &exoapi.ErrNotFound) {
+			if errors.Is(err, exoapi.ErrNotFound) {
 				return nil
 			}
 			return err

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/go-retryablehttp v0.7.1
+	github.com/hashicorp/terraform-plugin-log v0.2.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.10.0
 	github.com/stretchr/testify v1.7.0
 	github.com/xeipuuv/gojsonschema v1.2.0
@@ -38,7 +39,6 @@ require (
 	github.com/hashicorp/terraform-exec v0.15.0 // indirect
 	github.com/hashicorp/terraform-json v0.13.0 // indirect
 	github.com/hashicorp/terraform-plugin-go v0.5.0 // indirect
-	github.com/hashicorp/terraform-plugin-log v0.2.0 // indirect
 	github.com/hashicorp/terraform-registry-address v0.0.0-20210412075316-9b2996cce896 // indirect
 	github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734 // indirect
 	github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d // indirect

--- a/go.sum
+++ b/go.sum
@@ -96,8 +96,6 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/exoscale/egoscale v0.90.1 h1:G/Uyz3Yjdvo3H2oOFS5DhnzEZARLh77IhN58xHHFOpI=
 github.com/exoscale/egoscale v0.90.1/go.mod h1:NDhQbdGNKwnLVC2YGTB6ds9WIPw+V5ckvEEV8ho7pFE=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
-github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
-github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/getkin/kin-openapi v0.87.0/go.mod h1:660oXbgy5JFMKreazJaQTw7o+X00qeSyhcnluiMv+Xg=


### PR DESCRIPTION
This PR adds support for Elastic IPv6 in both data source and resource.

New attributes are:

- `address_family` (set to `inet6` for IPv6)
- `cidr` (computed)

Argument `ip_address` can now be either IPv4 or IPv6.

Change is backward compatible, if argument `address_family` is not set it defaults to `inet4` (IPv4).