### PR TITLE
database: fix backup schedule update bug

### DIFF
--- a/exoscale/resource_exoscale_database_mysql.go
+++ b/exoscale/resource_exoscale_database_mysql.go
@@ -229,6 +229,7 @@ func resourceDatabaseUpdateMysql(
 				BackupHour:   &bh,
 				BackupMinute: &bm,
 			}
+			updated = true
 		}
 
 		if d.HasChange(resDatabaseAttrMysql(resDatabaseAttrMysqlIPFilter)) {

--- a/exoscale/resource_exoscale_database_pg.go
+++ b/exoscale/resource_exoscale_database_pg.go
@@ -257,6 +257,7 @@ func resourceDatabaseUpdatePg(
 				BackupHour:   &bh,
 				BackupMinute: &bm,
 			}
+			updated = true
 		}
 
 		if d.HasChange(resDatabaseAttrPg(resDatabaseAttrPgIPFilter)) {


### PR DESCRIPTION
This PR fixes the issue with `backup_schedule` update in `exoscale_database` resource not applying changes upstream.