### PR TITLE
Disable instance pool acc test for tf provider

### DIFF
--- a/exoscale/resource_exoscale_instance_pool_test.go
+++ b/exoscale/resource_exoscale_instance_pool_test.go
@@ -1,5 +1,6 @@
 // NOTE: remove build tag once 53111 is fixed
 //go:build ignore
+// +build ignore
 
 package exoscale
 

--- a/exoscale/resource_exoscale_instance_pool_test.go
+++ b/exoscale/resource_exoscale_instance_pool_test.go
@@ -1,3 +1,6 @@
+// NOTE: remove build tag once 53111 is fixed
+//go:build ignore
+
 package exoscale
 
 import (


### PR DESCRIPTION
[Upstream bug](https://app.shortcut.com/exoscale/story/53111/instance-pool-update-failure) breaks the `TestAccResourceInstancePool` test. To unblock our PRs that are unrelated to the particular resource, this PR disables problematic test.

Change will be reverted as soon as upstream bug is fixed.