### PR TITLE
Migrate logging to tflog library

### DIFF
--- a/exoscale/datasource_exoscale_anti_affinity_group.go
+++ b/exoscale/datasource_exoscale_anti_affinity_group.go
@@ -2,9 +2,9 @@ package exoscale
 
 import (
 	"context"
-	"log"
 
 	exoapi "github.com/exoscale/egoscale/v2/api"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -41,7 +41,9 @@ func dataSourceAntiAffinityGroup() *schema.Resource {
 }
 
 func dataSourceAntiAffinityGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] %s: beginning read", resourceAntiAffinityGroupIDString(d))
+	tflog.Debug(ctx, "beginning read", map[string]interface{}{
+		"id": resourceAntiAffinityGroupIDString(d),
+	})
 
 	zone := defaultZone
 
@@ -91,7 +93,9 @@ func dataSourceAntiAffinityGroupRead(ctx context.Context, d *schema.ResourceData
 		return diag.FromErr(err)
 	}
 
-	log.Printf("[DEBUG] %s: read finished successfully", resourceAntiAffinityGroupIDString(d))
+	tflog.Debug(ctx, "read finished successfully", map[string]interface{}{
+		"id": resourceAntiAffinityGroupIDString(d),
+	})
 
 	return nil
 }

--- a/exoscale/datasource_exoscale_compute_instance.go
+++ b/exoscale/datasource_exoscale_compute_instance.go
@@ -3,11 +3,11 @@ package exoscale
 import (
 	"context"
 	"fmt"
-	"log"
 	"strings"
 
 	exo "github.com/exoscale/egoscale/v2"
 	exoapi "github.com/exoscale/egoscale/v2/api"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -150,7 +150,9 @@ func dataSourceComputeInstance() *schema.Resource {
 }
 
 func dataSourceComputeInstanceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] %s: beginning read", resourceComputeInstanceIDString(d))
+	tflog.Debug(ctx, "beginning read", map[string]interface{}{
+		"id": resourceComputeInstanceIDString(d),
+	})
 
 	zone := d.Get(dsComputeInstanceAttrZone).(string)
 
@@ -212,7 +214,9 @@ func dataSourceComputeInstanceRead(ctx context.Context, d *schema.ResourceData, 
 		}
 	}
 
-	log.Printf("[DEBUG] %s: read finished successfully", resourceComputeInstanceIDString(d))
+	tflog.Debug(ctx, "read finished successfully", map[string]interface{}{
+		"id": resourceComputeInstanceIDString(d),
+	})
 
 	return nil
 }

--- a/exoscale/datasource_exoscale_compute_instance_list.go
+++ b/exoscale/datasource_exoscale_compute_instance_list.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"crypto/md5"
 	"fmt"
-	"log"
 	"sort"
 	"strings"
 
 	exoapi "github.com/exoscale/egoscale/v2/api"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -34,7 +34,9 @@ func dataSourceComputeInstanceList() *schema.Resource {
 }
 
 func dataSourceComputeInstanceListRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] %s: beginning read", resourceIDString(d, "exoscale_compute_instance_list"))
+	tflog.Debug(ctx, "beginning read", map[string]interface{}{
+		"id": resourceIDString(d, "exoscale_compute_instance_list"),
+	})
 
 	zone := d.Get(dsComputeInstanceAttrZone).(string)
 
@@ -113,7 +115,9 @@ func dataSourceComputeInstanceListRead(ctx context.Context, d *schema.ResourceDa
 
 	d.SetId(fmt.Sprintf("%x", md5.Sum([]byte(strings.Join(ids, "")))))
 
-	log.Printf("[DEBUG] %s: read finished successfully", resourceIDString(d, "exoscale_compute_instance_list"))
+	tflog.Debug(ctx, "read finished successfully", map[string]interface{}{
+		"id": resourceIDString(d, "exoscale_compute_instance_list"),
+	})
 
 	return nil
 }

--- a/exoscale/datasource_exoscale_domain.go
+++ b/exoscale/datasource_exoscale_domain.go
@@ -2,11 +2,11 @@ package exoscale
 
 import (
 	"context"
-	"log"
 
 	exo "github.com/exoscale/egoscale/v2"
 	exoapi "github.com/exoscale/egoscale/v2/api"
 
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -25,7 +25,9 @@ func dataSourceDomain() *schema.Resource {
 }
 
 func dataSourceDomainRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] %s: beginning read", resourceIDString(d, "exoscale_domain"))
+	tflog.Debug(ctx, "beginning read", map[string]interface{}{
+		"id": resourceIDString(d, "exoscale_domain"),
+	})
 
 	ctx, cancel := context.WithTimeout(ctx, d.Timeout(schema.TimeoutRead))
 	ctx = exoapi.WithEndpoint(ctx, exoapi.NewReqEndpoint(getEnvironment(meta), defaultZone))
@@ -60,7 +62,9 @@ func dataSourceDomainRead(ctx context.Context, d *schema.ResourceData, meta inte
 		return diag.FromErr(err)
 	}
 
-	log.Printf("[DEBUG] %s: read finished successfully", resourceIDString(d, "exoscale_domain"))
+	tflog.Debug(ctx, "read finished successfully", map[string]interface{}{
+		"id": resourceIDString(d, "exoscale_domain"),
+	})
 
 	return nil
 }

--- a/exoscale/datasource_exoscale_domain_record.go
+++ b/exoscale/datasource_exoscale_domain_record.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"crypto/md5"
 	"fmt"
-	"log"
 	"regexp"
 	"strings"
 
 	exo "github.com/exoscale/egoscale/v2"
 	exoapi "github.com/exoscale/egoscale/v2/api"
 
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -104,7 +104,9 @@ func dataSourceDomainRecord() *schema.Resource {
 }
 
 func dataSourceDomainRecordRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] %s: beginning read", resourceIDString(d, "exoscale_domain"))
+	tflog.Debug(ctx, "beginning read", map[string]interface{}{
+		"id": resourceIDString(d, "exoscale_domain"),
+	})
 
 	ctx, cancel := context.WithTimeout(ctx, d.Timeout(schema.TimeoutRead))
 	ctx = exoapi.WithEndpoint(ctx, exoapi.NewReqEndpoint(getEnvironment(meta), defaultZone))

--- a/exoscale/datasource_exoscale_elastic_ip.go
+++ b/exoscale/datasource_exoscale_elastic_ip.go
@@ -2,9 +2,9 @@ package exoscale
 
 import (
 	"context"
-	"log"
 
 	exoapi "github.com/exoscale/egoscale/v2/api"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -97,7 +97,9 @@ func dataSourceElasticIP() *schema.Resource {
 }
 
 func dataSourceElasticIPRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] %s: beginning read", resourceElasticIPIDString(d))
+	tflog.Debug(ctx, "beginning read", map[string]interface{}{
+		"id": resourceElasticIPIDString(d),
+	})
 
 	zone := d.Get(dsElasticIPAttrZone).(string)
 
@@ -160,7 +162,9 @@ func dataSourceElasticIPRead(ctx context.Context, d *schema.ResourceData, meta i
 		}
 	}
 
-	log.Printf("[DEBUG] %s: read finished successfully", resourceElasticIPIDString(d))
+	tflog.Debug(ctx, "read finished successfully", map[string]interface{}{
+		"id": resourceElasticIPIDString(d),
+	})
 
 	return nil
 }

--- a/exoscale/datasource_exoscale_instance_pool.go
+++ b/exoscale/datasource_exoscale_instance_pool.go
@@ -3,11 +3,11 @@ package exoscale
 import (
 	"context"
 	"fmt"
-	"log"
 	"strings"
 
 	exo "github.com/exoscale/egoscale/v2"
 	exoapi "github.com/exoscale/egoscale/v2/api"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -169,7 +169,9 @@ func dataSourceInstancePool() *schema.Resource {
 }
 
 func dataSourceInstancePoolRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] %s: beginning read", resourceInstancePoolIDString(d))
+	tflog.Debug(ctx, "beginning read", map[string]interface{}{
+		"id": resourceInstancePoolIDString(d),
+	})
 
 	zone := d.Get(dsInstancePoolAttrZone).(string)
 
@@ -258,7 +260,9 @@ func dataSourceInstancePoolRead(ctx context.Context, d *schema.ResourceData, met
 		}
 	}
 
-	log.Printf("[DEBUG] %s: read finished successfully", resourceInstancePoolIDString(d))
+	tflog.Debug(ctx, "read finished successfully", map[string]interface{}{
+		"id": resourceInstancePoolIDString(d),
+	})
 
 	return nil
 }

--- a/exoscale/datasource_exoscale_instance_pool_list.go
+++ b/exoscale/datasource_exoscale_instance_pool_list.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"crypto/md5"
 	"fmt"
-	"log"
 	"sort"
 	"strings"
 
 	exoapi "github.com/exoscale/egoscale/v2/api"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -34,7 +34,9 @@ func dataSourceInstancePoolList() *schema.Resource {
 }
 
 func dataSourceInstancePoolListRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] %s: beginning read", resourceIDString(d, "exoscale_instance_pool_list"))
+	tflog.Debug(ctx, "beginning read", map[string]interface{}{
+		"id": resourceIDString(d, "exoscale_instance_pool_list"),
+	})
 
 	zone := d.Get(dsInstancePoolAttrZone).(string)
 
@@ -140,7 +142,9 @@ func dataSourceInstancePoolListRead(ctx context.Context, d *schema.ResourceData,
 
 	d.SetId(fmt.Sprintf("%x", md5.Sum([]byte(strings.Join(ids, "")))))
 
-	log.Printf("[DEBUG] %s: read finished successfully", resourceIDString(d, "exoscale_instance_pool_list"))
+	tflog.Debug(ctx, "read finished successfully", map[string]interface{}{
+		"id": resourceIDString(d, "exoscale_instance_pool_list"),
+	})
 
 	return nil
 }

--- a/exoscale/datasource_exoscale_private_network.go
+++ b/exoscale/datasource_exoscale_private_network.go
@@ -2,9 +2,9 @@ package exoscale
 
 import (
 	"context"
-	"log"
 
 	exoapi "github.com/exoscale/egoscale/v2/api"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -59,7 +59,9 @@ func dataSourcePrivateNetwork() *schema.Resource {
 }
 
 func dataSourcePrivateNetworkRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] %s: beginning read", resourcePrivateNetworkIDString(d))
+	tflog.Debug(ctx, "beginning read", map[string]interface{}{
+		"id": resourcePrivateNetworkIDString(d),
+	})
 
 	zone := d.Get(dsPrivateNetworkAttrZone).(string)
 
@@ -120,7 +122,9 @@ func dataSourcePrivateNetworkRead(ctx context.Context, d *schema.ResourceData, m
 		}
 	}
 
-	log.Printf("[DEBUG] %s: read finished successfully", resourcePrivateNetworkIDString(d))
+	tflog.Debug(ctx, "read finished successfully", map[string]interface{}{
+		"id": resourcePrivateNetworkIDString(d),
+	})
 
 	return nil
 }

--- a/exoscale/datasource_exoscale_security_group.go
+++ b/exoscale/datasource_exoscale_security_group.go
@@ -2,9 +2,9 @@ package exoscale
 
 import (
 	"context"
-	"log"
 
 	exoapi "github.com/exoscale/egoscale/v2/api"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -34,7 +34,9 @@ func dataSourceSecurityGroup() *schema.Resource {
 }
 
 func dataSourceSecurityGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] %s: beginning read", resourceSecurityGroupIDString(d))
+	tflog.Debug(ctx, "beginning read", map[string]interface{}{
+		"id": resourceSecurityGroupIDString(d),
+	})
 
 	zone := defaultZone
 
@@ -73,7 +75,9 @@ func dataSourceSecurityGroupRead(ctx context.Context, d *schema.ResourceData, me
 		return diag.FromErr(err)
 	}
 
-	log.Printf("[DEBUG] %s: read finished successfully", resourceSecurityGroupIDString(d))
+	tflog.Debug(ctx, "read finished successfully", map[string]interface{}{
+		"id": resourceSecurityGroupIDString(d),
+	})
 
 	return nil
 }

--- a/exoscale/resource_exoscale_affinity.go
+++ b/exoscale/resource_exoscale_affinity.go
@@ -2,9 +2,9 @@ package exoscale
 
 import (
 	"context"
-	"log"
 
 	"github.com/exoscale/egoscale"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -59,7 +59,9 @@ func resourceAffinity() *schema.Resource {
 }
 
 func resourceAffinityCreate(d *schema.ResourceData, meta interface{}) error {
-	log.Printf("[DEBUG] %s: beginning create", resourceAffinityIDString(d))
+	tflog.Debug(context.Background(), "beginning create", map[string]interface{}{
+		"id": resourceAffinityIDString(d),
+	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutCreate))
 	defer cancel()
@@ -80,7 +82,9 @@ func resourceAffinityCreate(d *schema.ResourceData, meta interface{}) error {
 	ag := resp.(*egoscale.AffinityGroup)
 	d.SetId(ag.ID.String())
 
-	log.Printf("[DEBUG] %s: create finished successfully", resourceAffinityIDString(d))
+	tflog.Debug(context.Background(), "create finished successfully", map[string]interface{}{
+		"id": resourceAffinityIDString(d),
+	})
 
 	return resourceAffinityRead(d, meta)
 }
@@ -107,7 +111,9 @@ func resourceAffinityExists(d *schema.ResourceData, meta interface{}) (bool, err
 }
 
 func resourceAffinityRead(d *schema.ResourceData, meta interface{}) error {
-	log.Printf("[DEBUG] %s: beginning read", resourceAffinityIDString(d))
+	tflog.Debug(context.Background(), "beginning read", map[string]interface{}{
+		"id": resourceAffinityIDString(d),
+	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutRead))
 	defer cancel()
@@ -126,13 +132,17 @@ func resourceAffinityRead(d *schema.ResourceData, meta interface{}) error {
 		return handleNotFound(d, err)
 	}
 
-	log.Printf("[DEBUG] %s: read finished successfully", resourceAffinityIDString(d))
+	tflog.Debug(context.Background(), "read finished successfully", map[string]interface{}{
+		"id": resourceAffinityIDString(d),
+	})
 
 	return resourceAffinityApply(d, resp.(*egoscale.AffinityGroup))
 }
 
 func resourceAffinityDelete(d *schema.ResourceData, meta interface{}) error {
-	log.Printf("[DEBUG] %s: beginning delete", resourceAffinityIDString(d))
+	tflog.Debug(context.Background(), "beginning delete", map[string]interface{}{
+		"id": resourceAffinityIDString(d),
+	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutDelete))
 	defer cancel()
@@ -150,7 +160,9 @@ func resourceAffinityDelete(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	log.Printf("[DEBUG] %s: delete finished successfully", resourceAffinityIDString(d))
+	tflog.Debug(context.Background(), "delete finished successfully", map[string]interface{}{
+		"id": resourceAffinityIDString(d),
+	})
 
 	return nil
 }

--- a/exoscale/resource_exoscale_anti_affinity_group.go
+++ b/exoscale/resource_exoscale_anti_affinity_group.go
@@ -3,10 +3,10 @@ package exoscale
 import (
 	"context"
 	"errors"
-	"log"
 
 	egoscale "github.com/exoscale/egoscale/v2"
 	exoapi "github.com/exoscale/egoscale/v2/api"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -52,7 +52,9 @@ func resourceAntiAffinityGroup() *schema.Resource {
 }
 
 func resourceAntiAffinityGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] %s: beginning create", resourceAntiAffinityGroupIDString(d))
+	tflog.Debug(ctx, "beginning create", map[string]interface{}{
+		"id": resourceAntiAffinityGroupIDString(d),
+	})
 
 	zone := defaultZone
 
@@ -72,13 +74,17 @@ func resourceAntiAffinityGroupCreate(ctx context.Context, d *schema.ResourceData
 
 	d.SetId(*antiAffinityGroup.ID)
 
-	log.Printf("[DEBUG] %s: create finished successfully", resourceAntiAffinityGroupIDString(d))
+	tflog.Debug(ctx, "create finished successfully", map[string]interface{}{
+		"id": resourceAntiAffinityGroupIDString(d),
+	})
 
 	return resourceAntiAffinityGroupRead(ctx, d, meta)
 }
 
 func resourceAntiAffinityGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] %s: beginning read", resourceAntiAffinityGroupIDString(d))
+	tflog.Debug(ctx, "beginning read", map[string]interface{}{
+		"id": resourceAntiAffinityGroupIDString(d),
+	})
 
 	zone := defaultZone
 
@@ -98,13 +104,17 @@ func resourceAntiAffinityGroupRead(ctx context.Context, d *schema.ResourceData, 
 		return diag.FromErr(err)
 	}
 
-	log.Printf("[DEBUG] %s: read finished successfully", resourceAntiAffinityGroupIDString(d))
+	tflog.Debug(ctx, "read finished successfully", map[string]interface{}{
+		"id": resourceAntiAffinityGroupIDString(d),
+	})
 
 	return diag.FromErr(resourceAntiAffinityGroupApply(ctx, d, antiAffinityGroup))
 }
 
 func resourceAntiAffinityGroupDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] %s: beginning delete", resourceAntiAffinityGroupIDString(d))
+	tflog.Debug(ctx, "beginning delete", map[string]interface{}{
+		"id": resourceAntiAffinityGroupIDString(d),
+	})
 
 	zone := defaultZone
 
@@ -119,7 +129,9 @@ func resourceAntiAffinityGroupDelete(ctx context.Context, d *schema.ResourceData
 		return diag.FromErr(err)
 	}
 
-	log.Printf("[DEBUG] %s: delete finished successfully", resourceAntiAffinityGroupIDString(d))
+	tflog.Debug(ctx, "delete finished successfully", map[string]interface{}{
+		"id": resourceAntiAffinityGroupIDString(d),
+	})
 
 	return nil
 }

--- a/exoscale/resource_exoscale_compute_instance.go
+++ b/exoscale/resource_exoscale_compute_instance.go
@@ -5,12 +5,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"net"
 	"strings"
 
 	egoscale "github.com/exoscale/egoscale/v2"
 	exoapi "github.com/exoscale/egoscale/v2/api"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -190,7 +190,7 @@ func newInstanceNetworkInterfaceFromInterface(rawStatePart interface{}) (*instan
 
 	networkInterface := instanceNetworkInterface{}
 	if err := json.Unmarshal(serializedRule, &networkInterface); err != nil {
-		log.Printf("[WARNING] %s", err)
+		tflog.Warn(context.Background(), err.Error())
 		return nil, err
 	}
 
@@ -212,7 +212,9 @@ func (n instanceNetworkInterface) toInterface() (map[string]interface{}, error) 
 }
 
 func resourceComputeInstanceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] %s: beginning create", resourceComputeInstanceIDString(d))
+	tflog.Debug(ctx, "beginning create", map[string]interface{}{
+		"id": resourceComputeInstanceIDString(d),
+	})
 
 	zone := d.Get(resComputeInstanceAttrZone).(string)
 
@@ -349,13 +351,17 @@ func resourceComputeInstanceCreate(ctx context.Context, d *schema.ResourceData, 
 
 	d.SetId(*computeInstance.ID)
 
-	log.Printf("[DEBUG] %s: create finished successfully", resourceComputeInstanceIDString(d))
+	tflog.Debug(ctx, "create finished successfully", map[string]interface{}{
+		"id": resourceComputeInstanceIDString(d),
+	})
 
 	return resourceComputeInstanceRead(ctx, d, meta)
 }
 
 func resourceComputeInstanceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] %s: beginning read", resourceComputeInstanceIDString(d))
+	tflog.Debug(ctx, "beginning read", map[string]interface{}{
+		"id": resourceComputeInstanceIDString(d),
+	})
 
 	zone := d.Get(resComputeInstanceAttrZone).(string)
 
@@ -375,13 +381,17 @@ func resourceComputeInstanceRead(ctx context.Context, d *schema.ResourceData, me
 		return diag.FromErr(err)
 	}
 
-	log.Printf("[DEBUG] %s: read finished successfully", resourceComputeInstanceIDString(d))
+	tflog.Debug(ctx, "read finished successfully", map[string]interface{}{
+		"id": resourceComputeInstanceIDString(d),
+	})
 
 	return resourceComputeInstanceApply(ctx, GetComputeClient(meta).Client, d, computeInstance)
 }
 
 func resourceComputeInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] %s: beginning update", resourceComputeInstanceIDString(d))
+	tflog.Debug(ctx, "beginning update", map[string]interface{}{
+		"id": resourceComputeInstanceIDString(d),
+	})
 
 	zone := d.Get(resComputeInstanceAttrZone).(string)
 
@@ -582,13 +592,17 @@ func resourceComputeInstanceUpdate(ctx context.Context, d *schema.ResourceData, 
 		}
 	}
 
-	log.Printf("[DEBUG] %s: update finished successfully", resourceComputeInstanceIDString(d))
+	tflog.Debug(ctx, "update finished successfully", map[string]interface{}{
+		"id": resourceComputeInstanceIDString(d),
+	})
 
 	return resourceComputeInstanceRead(ctx, d, meta)
 }
 
 func resourceComputeInstanceDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] %s: beginning delete", resourceComputeInstanceIDString(d))
+	tflog.Debug(ctx, "beginning delete", map[string]interface{}{
+		"id": resourceComputeInstanceIDString(d),
+	})
 
 	zone := d.Get(resComputeInstanceAttrZone).(string)
 
@@ -603,7 +617,9 @@ func resourceComputeInstanceDelete(ctx context.Context, d *schema.ResourceData, 
 		return diag.FromErr(err)
 	}
 
-	log.Printf("[DEBUG] %s: delete finished successfully", resourceComputeInstanceIDString(d))
+	tflog.Debug(ctx, "delete finished successfully", map[string]interface{}{
+		"id": resourceComputeInstanceIDString(d),
+	})
 
 	return nil
 }

--- a/exoscale/resource_exoscale_database.go
+++ b/exoscale/resource_exoscale_database.go
@@ -5,12 +5,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"strconv"
 	"strings"
 
 	egoscale "github.com/exoscale/egoscale/v2"
 	exoapi "github.com/exoscale/egoscale/v2/api"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -160,7 +160,9 @@ func resourceDatabase() *schema.Resource {
 }
 
 func resourceDatabaseCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] %s: beginning create", resourceDatabaseIDString(d))
+	tflog.Debug(ctx, "beginning create", map[string]interface{}{
+		"id": resourceDatabaseIDString(d),
+	})
 
 	zone := d.Get(resDatabaseAttrZone).(string)
 
@@ -188,13 +190,17 @@ func resourceDatabaseCreate(ctx context.Context, d *schema.ResourceData, meta in
 		return diags
 	}
 
-	log.Printf("[DEBUG] %s: create finished successfully", resourceDatabaseIDString(d))
+	tflog.Debug(ctx, "create finished successfully", map[string]interface{}{
+		"id": resourceDatabaseIDString(d),
+	})
 
 	return resourceDatabaseRead(ctx, d, meta)
 }
 
 func resourceDatabaseRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] %s: beginning read", resourceDatabaseIDString(d))
+	tflog.Debug(ctx, "beginning read", map[string]interface{}{
+		"id": resourceDatabaseIDString(d),
+	})
 
 	zone := d.Get(resDatabaseAttrZone).(string)
 
@@ -254,13 +260,17 @@ func resourceDatabaseRead(ctx context.Context, d *schema.ResourceData, meta inte
 		return diag.FromErr(err)
 	}
 
-	log.Printf("[DEBUG] %s: read finished successfully", resourceDatabaseIDString(d))
+	tflog.Debug(ctx, "read finished successfully", map[string]interface{}{
+		"id": resourceDatabaseIDString(d),
+	})
 
 	return nil
 }
 
 func resourceDatabaseUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] %s: beginning update", resourceDatabaseIDString(d))
+	tflog.Debug(ctx, "beginning update", map[string]interface{}{
+		"id": resourceDatabaseIDString(d),
+	})
 
 	zone := d.Get(resDatabaseAttrZone).(string)
 
@@ -288,13 +298,17 @@ func resourceDatabaseUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		return diags
 	}
 
-	log.Printf("[DEBUG] %s: update finished successfully", resourceDatabaseIDString(d))
+	tflog.Debug(ctx, "update finished successfully", map[string]interface{}{
+		"id": resourceDatabaseIDString(d),
+	})
 
 	return resourceDatabaseRead(ctx, d, meta)
 }
 
 func resourceDatabaseDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] %s: beginning delete", resourceDatabaseIDString(d))
+	tflog.Debug(ctx, "beginning delete", map[string]interface{}{
+		"id": resourceDatabaseIDString(d),
+	})
 
 	zone := d.Get(resDatabaseAttrZone).(string)
 
@@ -310,7 +324,9 @@ func resourceDatabaseDelete(ctx context.Context, d *schema.ResourceData, meta in
 		return diag.FromErr(err)
 	}
 
-	log.Printf("[DEBUG] %s: delete finished successfully", resourceDatabaseIDString(d))
+	tflog.Debug(ctx, "delete finished successfully", map[string]interface{}{
+		"id": resourceDatabaseIDString(d),
+	})
 
 	return nil
 }

--- a/exoscale/resource_exoscale_domain.go
+++ b/exoscale/resource_exoscale_domain.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 
 	exo "github.com/exoscale/egoscale/v2"
 	exoapi "github.com/exoscale/egoscale/v2/api"
 
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -107,7 +107,9 @@ func resourceDomainStateUpgradeV0(
 }
 
 func resourceDomainCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] %s: beginning create", resourceDomainIDString(d))
+	tflog.Debug(ctx, "beginning create", map[string]interface{}{
+		"id": resourceDomainIDString(d),
+	})
 
 	ctx, cancel := context.WithTimeout(ctx, d.Timeout(schema.TimeoutRead))
 	ctx = exoapi.WithEndpoint(ctx, exoapi.NewReqEndpoint(getEnvironment(meta), defaultZone))
@@ -123,7 +125,9 @@ func resourceDomainCreate(ctx context.Context, d *schema.ResourceData, meta inte
 
 	d.SetId(*domain.ID)
 
-	log.Printf("[DEBUG] %s: create finished successfully", resourceDomainIDString(d))
+	tflog.Debug(ctx, "create finished successfully", map[string]interface{}{
+		"id": resourceDomainIDString(d),
+	})
 
 	err = resourceDomainApply(d, domain)
 	if err != nil {
@@ -152,7 +156,9 @@ func resourceDomainExists(d *schema.ResourceData, meta interface{}) (bool, error
 }
 
 func resourceDomainRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] %s: beginning read", resourceDomainIDString(d))
+	tflog.Debug(ctx, "beginning read", map[string]interface{}{
+		"id": resourceDomainIDString(d),
+	})
 
 	ctx, cancel := context.WithTimeout(ctx, d.Timeout(schema.TimeoutRead))
 	ctx = exoapi.WithEndpoint(ctx, exoapi.NewReqEndpoint(getEnvironment(meta), defaultZone))
@@ -165,7 +171,9 @@ func resourceDomainRead(ctx context.Context, d *schema.ResourceData, meta interf
 		return diag.Errorf("error retrieving domain: %s", err)
 	}
 
-	log.Printf("[DEBUG] %s: read finished successfully", resourceDomainIDString(d))
+	tflog.Debug(ctx, "read finished successfully", map[string]interface{}{
+		"id": resourceDomainIDString(d),
+	})
 
 	err = resourceDomainApply(d, domain)
 	if err != nil {
@@ -176,7 +184,9 @@ func resourceDomainRead(ctx context.Context, d *schema.ResourceData, meta interf
 }
 
 func resourceDomainDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] %s: beginning delete", resourceDomainIDString(d))
+	tflog.Debug(ctx, "beginning delete", map[string]interface{}{
+		"id": resourceDomainIDString(d),
+	})
 
 	ctx, cancel := context.WithTimeout(ctx, d.Timeout(schema.TimeoutRead))
 	ctx = exoapi.WithEndpoint(ctx, exoapi.NewReqEndpoint(getEnvironment(meta), defaultZone))
@@ -194,7 +204,9 @@ func resourceDomainDelete(ctx context.Context, d *schema.ResourceData, meta inte
 		return diag.Errorf("error deleting domain: %s", err)
 	}
 
-	log.Printf("[DEBUG] %s: delete finished successfully", resourceDomainIDString(d))
+	tflog.Debug(ctx, "delete finished successfully", map[string]interface{}{
+		"id": resourceDomainIDString(d),
+	})
 
 	return nil
 }

--- a/exoscale/resource_exoscale_elastic_ip.go
+++ b/exoscale/resource_exoscale_elastic_ip.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"regexp"
 	"time"
 
 	egoscale "github.com/exoscale/egoscale/v2"
 	exoapi "github.com/exoscale/egoscale/v2/api"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -131,7 +131,9 @@ func resourceElasticIP() *schema.Resource {
 }
 
 func resourceElasticIPCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] %s: beginning create", resourceElasticIPIDString(d))
+	tflog.Debug(ctx, "beginning create", map[string]interface{}{
+		"id": resourceElasticIPIDString(d),
+	})
 
 	zone := d.Get(resElasticIPAttrZone).(string)
 
@@ -200,13 +202,17 @@ func resourceElasticIPCreate(ctx context.Context, d *schema.ResourceData, meta i
 
 	d.SetId(*elasticIP.ID)
 
-	log.Printf("[DEBUG] %s: create finished successfully", resourceElasticIPIDString(d))
+	tflog.Debug(ctx, "create finished successfully", map[string]interface{}{
+		"id": resourceElasticIPIDString(d),
+	})
 
 	return resourceElasticIPRead(ctx, d, meta)
 }
 
 func resourceElasticIPRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] %s: beginning read", resourceElasticIPIDString(d))
+	tflog.Debug(ctx, "beginning read", map[string]interface{}{
+		"id": resourceElasticIPIDString(d),
+	})
 
 	zone := d.Get(resElasticIPAttrZone).(string)
 
@@ -226,13 +232,17 @@ func resourceElasticIPRead(ctx context.Context, d *schema.ResourceData, meta int
 		return diag.FromErr(err)
 	}
 
-	log.Printf("[DEBUG] %s: read finished successfully", resourceElasticIPIDString(d))
+	tflog.Debug(ctx, "read finished successfully", map[string]interface{}{
+		"id": resourceElasticIPIDString(d),
+	})
 
 	return diag.FromErr(resourceElasticIPApply(ctx, d, elasticIP))
 }
 
 func resourceElasticIPUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] %s: beginning update", resourceElasticIPIDString(d))
+	tflog.Debug(ctx, "beginning update", map[string]interface{}{
+		"id": resourceElasticIPIDString(d),
+	})
 
 	zone := d.Get(resElasticIPAttrZone).(string)
 
@@ -261,13 +271,17 @@ func resourceElasticIPUpdate(ctx context.Context, d *schema.ResourceData, meta i
 		}
 	}
 
-	log.Printf("[DEBUG] %s: update finished successfully", resourceElasticIPIDString(d))
+	tflog.Debug(ctx, "update finished successfully", map[string]interface{}{
+		"id": resourceElasticIPIDString(d),
+	})
 
 	return resourceElasticIPRead(ctx, d, meta)
 }
 
 func resourceElasticIPDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] %s: beginning delete", resourceElasticIPIDString(d))
+	tflog.Debug(ctx, "beginning delete", map[string]interface{}{
+		"id": resourceElasticIPIDString(d),
+	})
 
 	zone := d.Get(resElasticIPAttrZone).(string)
 
@@ -282,7 +296,9 @@ func resourceElasticIPDelete(ctx context.Context, d *schema.ResourceData, meta i
 		return diag.FromErr(err)
 	}
 
-	log.Printf("[DEBUG] %s: delete finished successfully", resourceElasticIPIDString(d))
+	tflog.Debug(ctx, "delete finished successfully", map[string]interface{}{
+		"id": resourceDomainIDString(d),
+	})
 
 	return nil
 }

--- a/exoscale/resource_exoscale_iam_access_key.go
+++ b/exoscale/resource_exoscale_iam_access_key.go
@@ -3,10 +3,10 @@ package exoscale
 import (
 	"context"
 	"fmt"
-	"log"
 
 	egoscale "github.com/exoscale/egoscale/v2"
 	exoapi "github.com/exoscale/egoscale/v2/api"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -142,7 +142,9 @@ func resourceIAMAccessKey() *schema.Resource {
 }
 
 func resourceIAMAccessKeyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] %s: beginning create", resourceIAMAccessKeyIDString(d))
+	tflog.Debug(ctx, "beginning create", map[string]interface{}{
+		"id": resourceIAMAccessKeyIDString(d),
+	})
 
 	name := d.Get(resIAMAccessKeyAttrName).(string)
 	zone := defaultZone
@@ -200,13 +202,17 @@ func resourceIAMAccessKeyCreate(ctx context.Context, d *schema.ResourceData, met
 		return diag.FromErr(err)
 	}
 
-	log.Printf("[DEBUG] %s: create finished successfully", resourceIAMAccessKeyIDString(d))
+	tflog.Debug(ctx, "create finished successfully", map[string]interface{}{
+		"id": resourceIAMAccessKeyIDString(d),
+	})
 
 	return resourceIAMAccessKeyRead(ctx, d, meta)
 }
 
 func resourceIAMAccessKeyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] %s: beginning read", resourceIAMAccessKeyIDString(d))
+	tflog.Debug(ctx, "beginning read", map[string]interface{}{
+		"id": resourceIAMAccessKeyIDString(d),
+	})
 
 	zone := defaultZone
 
@@ -226,13 +232,17 @@ func resourceIAMAccessKeyRead(ctx context.Context, d *schema.ResourceData, meta 
 		return diag.FromErr(err)
 	}
 
-	log.Printf("[DEBUG] %s: read finished successfully", resourceIAMAccessKeyIDString(d))
+	tflog.Debug(ctx, "read finished successfully", map[string]interface{}{
+		"id": resourceIAMAccessKeyIDString(d),
+	})
 
 	return diag.FromErr(resourceIAMAccessKeyApply(ctx, d, *accessKey, operations))
 }
 
 func resourceIAMAccessKeyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] %s: beginning delete", resourceIAMAccessKeyIDString(d))
+	tflog.Debug(ctx, "beginning delete", map[string]interface{}{
+		"id": resourceIAMAccessKeyIDString(d),
+	})
 
 	zone := defaultZone
 
@@ -247,7 +257,9 @@ func resourceIAMAccessKeyDelete(ctx context.Context, d *schema.ResourceData, met
 		return diag.FromErr(err)
 	}
 
-	log.Printf("[DEBUG] %s: delete finished successfully", resourceIAMAccessKeyIDString(d))
+	tflog.Debug(ctx, "delete finished successfully", map[string]interface{}{
+		"id": resourceIAMAccessKeyIDString(d),
+	})
 	return nil
 }
 

--- a/exoscale/resource_exoscale_instance_pool.go
+++ b/exoscale/resource_exoscale_instance_pool.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"strings"
 
 	egoscale "github.com/exoscale/egoscale/v2"
 	exoapi "github.com/exoscale/egoscale/v2/api"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -212,7 +212,9 @@ func resourceInstancePool() *schema.Resource {
 }
 
 func resourceInstancePoolCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] %s: beginning create", resourceInstancePoolIDString(d))
+	tflog.Debug(ctx, "beginning create", map[string]interface{}{
+		"id": resourceInstancePoolIDString(d),
+	})
 
 	zone := d.Get(resInstancePoolAttrZone).(string)
 
@@ -369,13 +371,17 @@ func resourceInstancePoolCreate(ctx context.Context, d *schema.ResourceData, met
 		return diag.FromErr(err)
 	}
 
-	log.Printf("[DEBUG] %s: create finished successfully", resourceInstancePoolIDString(d))
+	tflog.Debug(ctx, "create finished successfully", map[string]interface{}{
+		"id": resourceInstancePoolIDString(d),
+	})
 
 	return resourceInstancePoolRead(ctx, d, meta)
 }
 
 func resourceInstancePoolRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] %s: beginning read", resourceInstancePoolIDString(d))
+	tflog.Debug(ctx, "beginning read", map[string]interface{}{
+		"id": resourceInstancePoolIDString(d),
+	})
 
 	zone := d.Get(resInstancePoolAttrZone).(string)
 
@@ -395,13 +401,17 @@ func resourceInstancePoolRead(ctx context.Context, d *schema.ResourceData, meta 
 		return diag.FromErr(err)
 	}
 
-	log.Printf("[DEBUG] %s: read finished successfully", resourceInstancePoolIDString(d))
+	tflog.Debug(ctx, "read finished successfully", map[string]interface{}{
+		"id": resourceInstancePoolIDString(d),
+	})
 
 	return resourceInstancePoolApply(ctx, GetComputeClient(meta).Client, d, instancePool)
 }
 
 func resourceInstancePoolUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] %s: beginning update", resourceInstancePoolIDString(d))
+	tflog.Debug(ctx, "beginning update", map[string]interface{}{
+		"id": resourceInstancePoolIDString(d),
+	})
 
 	zone := d.Get(resInstancePoolAttrZone).(string)
 
@@ -562,13 +572,17 @@ func resourceInstancePoolUpdate(ctx context.Context, d *schema.ResourceData, met
 		return diag.FromErr(err)
 	}
 
-	log.Printf("[DEBUG] %s: update finished successfully", resourceInstancePoolIDString(d))
+	tflog.Debug(ctx, "update finished successfully", map[string]interface{}{
+		"id": resourceInstancePoolIDString(d),
+	})
 
 	return resourceInstancePoolRead(ctx, d, meta)
 }
 
 func resourceInstancePoolDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] %s: beginning delete", resourceInstancePoolIDString(d))
+	tflog.Debug(ctx, "beginning delete", map[string]interface{}{
+		"id": resourceInstancePoolIDString(d),
+	})
 
 	zone := d.Get(resInstancePoolAttrZone).(string)
 
@@ -584,7 +598,9 @@ func resourceInstancePoolDelete(ctx context.Context, d *schema.ResourceData, met
 		return diag.FromErr(err)
 	}
 
-	log.Printf("[DEBUG] %s: delete finished successfully", resourceInstancePoolIDString(d))
+	tflog.Debug(ctx, "delete finished successfully", map[string]interface{}{
+		"id": resourceInstancePoolIDString(d),
+	})
 
 	return nil
 }

--- a/exoscale/resource_exoscale_ipaddress.go
+++ b/exoscale/resource_exoscale_ipaddress.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"net"
 	"regexp"
 
 	"github.com/exoscale/egoscale"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -117,7 +117,9 @@ func resourceIPAddress() *schema.Resource {
 }
 
 func resourceIPAddressCreate(d *schema.ResourceData, meta interface{}) error {
-	log.Printf("[DEBUG] %s: beginning create", resourceIPAddressIDString(d))
+	tflog.Debug(context.Background(), "beginning create", map[string]interface{}{
+		"id": resourceIPAddressIDString(d),
+	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutCreate))
 	defer cancel()
@@ -222,14 +224,18 @@ func resourceIPAddressCreate(d *schema.ResourceData, meta interface{}) error {
 			})
 
 			if e != nil {
-				log.Printf("[WARNING] Failure to create the tags, but the ip address was created. %v", e)
+				tflog.Warn(ctx, "failure to create the tags, but the ip address was created", map[string]interface{}{
+					"api_error": e.Error(),
+				})
 			}
 
 			return err
 		}
 	}
 
-	log.Printf("[DEBUG] %s: create finished successfully", resourceIPAddressIDString(d))
+	tflog.Debug(ctx, "create finished successfully", map[string]interface{}{
+		"id": resourceIPAddressIDString(d),
+	})
 
 	return resourceIPAddressRead(d, meta)
 }
@@ -263,7 +269,9 @@ func resourceIPAddressExists(d *schema.ResourceData, meta interface{}) (bool, er
 }
 
 func resourceIPAddressRead(d *schema.ResourceData, meta interface{}) error {
-	log.Printf("[DEBUG] %s: beginning read", resourceIPAddressIDString(d))
+	tflog.Debug(context.Background(), "beginning read", map[string]interface{}{
+		"id": resourceIPAddressIDString(d),
+	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutRead))
 	defer cancel()
@@ -290,13 +298,17 @@ func resourceIPAddressRead(d *schema.ResourceData, meta interface{}) error {
 		return handleNotFound(d, err)
 	}
 
-	log.Printf("[DEBUG] %s: read finished successfully", resourceIPAddressIDString(d))
+	tflog.Debug(ctx, "read finished successfully", map[string]interface{}{
+		"id": resourceIPAddressIDString(d),
+	})
 
 	return resourceIPAddressApply(d, resp.(*egoscale.IPAddress), client)
 }
 
 func resourceIPAddressUpdate(d *schema.ResourceData, meta interface{}) error {
-	log.Printf("[DEBUG] %s: beginning update", resourceIPAddressIDString(d))
+	tflog.Debug(context.Background(), "beginning update", map[string]interface{}{
+		"id": resourceIPAddressIDString(d),
+	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutUpdate))
 	defer cancel()
@@ -436,13 +448,17 @@ func resourceIPAddressUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	log.Printf("[DEBUG] %s: update finished successfully", resourceIPAddressIDString(d))
+	tflog.Debug(ctx, "update finished successfully", map[string]interface{}{
+		"id": resourceIPAddressIDString(d),
+	})
 
 	return resourceIPAddressRead(d, meta)
 }
 
 func resourceIPAddressDelete(d *schema.ResourceData, meta interface{}) error {
-	log.Printf("[DEBUG] %s: beginning delete", resourceIPAddressIDString(d))
+	tflog.Debug(context.Background(), "beginning delete", map[string]interface{}{
+		"id": resourceIPAddressIDString(d),
+	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutDelete))
 	defer cancel()
@@ -460,7 +476,9 @@ func resourceIPAddressDelete(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	log.Printf("[DEBUG] %s: delete finished successfully", resourceIPAddressIDString(d))
+	tflog.Debug(ctx, "delete finished successfully", map[string]interface{}{
+		"id": resourceIPAddressIDString(d),
+	})
 
 	return nil
 }

--- a/exoscale/resource_exoscale_network.go
+++ b/exoscale/resource_exoscale_network.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"net"
 
 	"github.com/exoscale/egoscale"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -79,7 +79,9 @@ func resourceNetwork() *schema.Resource {
 }
 
 func resourceNetworkCreate(d *schema.ResourceData, meta interface{}) error {
-	log.Printf("[DEBUG] %s: beginning create", resourceNetworkIDString(d))
+	tflog.Debug(context.Background(), "beginning create", map[string]interface{}{
+		"id": resourceNetworkIDString(d),
+	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutCreate))
 	defer cancel()
@@ -136,20 +138,26 @@ func resourceNetworkCreate(d *schema.ResourceData, meta interface{}) error {
 			})
 
 			if e != nil {
-				log.Printf("[WARNING] Failure to create the tags, but the network was created. %v", e)
+				tflog.Warn(ctx, "failure to create the tags, but the network was created", map[string]interface{}{
+					"api_error": e.Error(),
+				})
 			}
 
 			return err
 		}
 	}
 
-	log.Printf("[DEBUG] %s: create finished successfully", resourceNetworkIDString(d))
+	tflog.Debug(ctx, "create finished successfully", map[string]interface{}{
+		"id": resourceNetworkIDString(d),
+	})
 
 	return resourceNetworkRead(d, meta)
 }
 
 func resourceNetworkRead(d *schema.ResourceData, meta interface{}) error {
-	log.Printf("[DEBUG] %s: beginning read", resourceNetworkIDString(d))
+	tflog.Debug(context.Background(), "beginning read", map[string]interface{}{
+		"id": resourceNetworkIDString(d),
+	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutRead))
 	defer cancel()
@@ -164,7 +172,9 @@ func resourceNetworkRead(d *schema.ResourceData, meta interface{}) error {
 
 	network := networks.Network[0]
 
-	log.Printf("[DEBUG] %s: read finished successfully", resourceNetworkIDString(d))
+	tflog.Debug(ctx, "read finished successfully", map[string]interface{}{
+		"id": resourceNetworkIDString(d),
+	})
 
 	return resourceNetworkApply(d, &network)
 }
@@ -220,7 +230,9 @@ func resourceNetworkExists(d *schema.ResourceData, meta interface{}) (bool, erro
 }
 
 func resourceNetworkUpdate(d *schema.ResourceData, meta interface{}) error {
-	log.Printf("[DEBUG] %s: beginning update", resourceNetworkIDString(d))
+	tflog.Debug(context.Background(), "beginning update", map[string]interface{}{
+		"id": resourceNetworkIDString(d),
+	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutUpdate))
 	defer cancel()
@@ -266,13 +278,17 @@ func resourceNetworkUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	log.Printf("[DEBUG] %s: update finished successfully", resourceNetworkIDString(d))
+	tflog.Debug(ctx, "update finished successfully", map[string]interface{}{
+		"id": resourceNetworkIDString(d),
+	})
 
 	return resourceNetworkRead(d, meta)
 }
 
 func resourceNetworkDelete(d *schema.ResourceData, meta interface{}) error {
-	log.Printf("[DEBUG] %s: beginning delete", resourceNetworkIDString(d))
+	tflog.Debug(context.Background(), "beginning delete", map[string]interface{}{
+		"id": resourceNetworkIDString(d),
+	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutDelete))
 	defer cancel()
@@ -290,7 +306,9 @@ func resourceNetworkDelete(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	log.Printf("[DEBUG] %s: delete finished successfully", resourceNetworkIDString(d))
+	tflog.Debug(ctx, "delete finished successfully", map[string]interface{}{
+		"id": resourceNetworkIDString(d),
+	})
 
 	return nil
 }

--- a/exoscale/resource_exoscale_nic.go
+++ b/exoscale/resource_exoscale_nic.go
@@ -3,10 +3,10 @@ package exoscale
 import (
 	"context"
 	"fmt"
-	"log"
 	"net"
 
 	"github.com/exoscale/egoscale"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -65,7 +65,9 @@ func resourceNIC() *schema.Resource {
 }
 
 func resourceNICCreate(d *schema.ResourceData, meta interface{}) error {
-	log.Printf("[DEBUG] %s: beginning create", resourceNICIDString(d))
+	tflog.Debug(context.Background(), "beginning create", map[string]interface{}{
+		"id": resourceNICIDString(d),
+	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutCreate))
 	defer cancel()
@@ -104,13 +106,17 @@ func resourceNICCreate(d *schema.ResourceData, meta interface{}) error {
 
 	d.SetId(nic.ID.String())
 
-	log.Printf("[DEBUG] %s: create finished successfully", resourceNICIDString(d))
+	tflog.Debug(ctx, "create finished successfully", map[string]interface{}{
+		"id": resourceNICIDString(d),
+	})
 
 	return resourceNICRead(d, meta)
 }
 
 func resourceNICRead(d *schema.ResourceData, meta interface{}) error {
-	log.Printf("[DEBUG] %s: beginning read", resourceNICIDString(d))
+	tflog.Debug(context.Background(), "beginning read", map[string]interface{}{
+		"id": resourceNICIDString(d),
+	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutRead))
 	defer cancel()
@@ -131,7 +137,9 @@ func resourceNICRead(d *schema.ResourceData, meta interface{}) error {
 
 	n := resp.(*egoscale.Nic)
 
-	log.Printf("[DEBUG] %s: read finished successfully", resourceNICIDString(d))
+	tflog.Debug(ctx, "read finished successfully", map[string]interface{}{
+		"id": resourceNICIDString(d),
+	})
 
 	return resourceNICApply(d, *n)
 }
@@ -159,7 +167,9 @@ func resourceNICExists(d *schema.ResourceData, meta interface{}) (bool, error) {
 }
 
 func resourceNICUpdate(d *schema.ResourceData, meta interface{}) error {
-	log.Printf("[DEBUG] %s: beginning update", resourceNICIDString(d))
+	tflog.Debug(context.Background(), "beginning update", map[string]interface{}{
+		"id": resourceNICIDString(d),
+	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutUpdate))
 	defer cancel()
@@ -190,13 +200,17 @@ func resourceNICUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	log.Printf("[DEBUG] %s: update finished successfully", resourceNICIDString(d))
+	tflog.Debug(ctx, "update finished successfully", map[string]interface{}{
+		"id": resourceNICIDString(d),
+	})
 
 	return resourceNICRead(d, meta)
 }
 
 func resourceNICDelete(d *schema.ResourceData, meta interface{}) error {
-	log.Printf("[DEBUG] %s: beginning delete", resourceNICIDString(d))
+	tflog.Debug(context.Background(), "beginning delete", map[string]interface{}{
+		"id": resourceNICIDString(d),
+	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutDelete))
 	defer cancel()
@@ -232,7 +246,9 @@ func resourceNICDelete(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("failed to remove NIC %s from instance %s", d.Id(), vm.ID)
 	}
 
-	log.Printf("[DEBUG] %s: delete finished successfully", resourceNICIDString(d))
+	tflog.Debug(ctx, "delete finished successfully", map[string]interface{}{
+		"id": resourceNICIDString(d),
+	})
 
 	return nil
 }

--- a/exoscale/resource_exoscale_nlb.go
+++ b/exoscale/resource_exoscale_nlb.go
@@ -3,10 +3,10 @@ package exoscale
 import (
 	"context"
 	"errors"
-	"log"
 
 	egoscale "github.com/exoscale/egoscale/v2"
 	exoapi "github.com/exoscale/egoscale/v2/api"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -89,7 +89,9 @@ func resourceNLB() *schema.Resource {
 }
 
 func resourceNLBCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] %s: beginning create", resourceNLBIDString(d))
+	tflog.Debug(ctx, "beginning create", map[string]interface{}{
+		"id": resourceNLBIDString(d),
+	})
 
 	zone := d.Get(resNLBAttrZone).(string)
 
@@ -124,13 +126,17 @@ func resourceNLBCreate(ctx context.Context, d *schema.ResourceData, meta interfa
 
 	d.SetId(*nlb.ID)
 
-	log.Printf("[DEBUG] %s: create finished successfully", resourceNLBIDString(d))
+	tflog.Debug(ctx, "create finished successfully", map[string]interface{}{
+		"id": resourceNLBIDString(d),
+	})
 
 	return resourceNLBRead(ctx, d, meta)
 }
 
 func resourceNLBRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] %s: beginning read", resourceNLBIDString(d))
+	tflog.Debug(ctx, "beginning read", map[string]interface{}{
+		"id": resourceNLBIDString(d),
+	})
 
 	zone := d.Get(resNLBAttrZone).(string)
 
@@ -150,13 +156,17 @@ func resourceNLBRead(ctx context.Context, d *schema.ResourceData, meta interface
 		return diag.FromErr(err)
 	}
 
-	log.Printf("[DEBUG] %s: read finished successfully", resourceNLBIDString(d))
+	tflog.Debug(ctx, "read finished successfully", map[string]interface{}{
+		"id": resourceNLBIDString(d),
+	})
 
 	return diag.FromErr(resourceNLBApply(ctx, d, nlb))
 }
 
 func resourceNLBUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] %s: beginning update", resourceNLBIDString(d))
+	tflog.Debug(ctx, "beginning update", map[string]interface{}{
+		"id": resourceNLBIDString(d),
+	})
 
 	zone := d.Get(resNLBAttrZone).(string)
 
@@ -200,13 +210,17 @@ func resourceNLBUpdate(ctx context.Context, d *schema.ResourceData, meta interfa
 		}
 	}
 
-	log.Printf("[DEBUG] %s: update finished successfully", resourceNLBIDString(d))
+	tflog.Debug(ctx, "update finished successfully", map[string]interface{}{
+		"id": resourceNLBIDString(d),
+	})
 
 	return resourceNLBRead(ctx, d, meta)
 }
 
 func resourceNLBDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] %s: beginning delete", resourceNLBIDString(d))
+	tflog.Debug(ctx, "beginning delete", map[string]interface{}{
+		"id": resourceNLBIDString(d),
+	})
 
 	zone := d.Get(resNLBAttrZone).(string)
 
@@ -222,7 +236,9 @@ func resourceNLBDelete(ctx context.Context, d *schema.ResourceData, meta interfa
 		return diag.FromErr(err)
 	}
 
-	log.Printf("[DEBUG] %s: delete finished successfully", resourceNLBIDString(d))
+	tflog.Debug(ctx, "delete finished successfully", map[string]interface{}{
+		"id": resourceNLBIDString(d),
+	})
 
 	return nil
 }

--- a/exoscale/resource_exoscale_nlb_service.go
+++ b/exoscale/resource_exoscale_nlb_service.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"strings"
 	"time"
 
 	egoscale "github.com/exoscale/egoscale/v2"
 	exoapi "github.com/exoscale/egoscale/v2/api"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -174,7 +174,9 @@ func resourceNLBService() *schema.Resource {
 }
 
 func resourceNLBServiceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] %s: beginning create", resourceNLBServiceIDString(d))
+	tflog.Debug(ctx, "beginning create", map[string]interface{}{
+		"id": resourceNLBServiceIDString(d),
+	})
 
 	zone := d.Get(resNLBServiceAttrZone).(string)
 
@@ -253,13 +255,17 @@ func resourceNLBServiceCreate(ctx context.Context, d *schema.ResourceData, meta 
 
 	d.SetId(*nlbService.ID)
 
-	log.Printf("[DEBUG] %s: create finished successfully", resourceNLBServiceIDString(d))
+	tflog.Debug(ctx, "create finished successfully", map[string]interface{}{
+		"id": resourceNLBServiceIDString(d),
+	})
 
 	return resourceNLBServiceRead(ctx, d, meta)
 }
 
 func resourceNLBServiceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] %s: beginning read", resourceNLBServiceIDString(d))
+	tflog.Debug(ctx, "beginning read", map[string]interface{}{
+		"id": resourceNLBServiceIDString(d),
+	})
 
 	zone := d.Get(resNLBServiceAttrZone).(string)
 
@@ -292,13 +298,17 @@ func resourceNLBServiceRead(ctx context.Context, d *schema.ResourceData, meta in
 		return nil
 	}
 
-	log.Printf("[DEBUG] %s: read finished successfully", resourceNLBServiceIDString(d))
+	tflog.Debug(ctx, "read finished successfully", map[string]interface{}{
+		"id": resourceNLBServiceIDString(d),
+	})
 
 	return diag.FromErr(resourceNLBServiceApply(ctx, d, nlbService))
 }
 
 func resourceNLBServiceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] %s: beginning update", resourceNLBServiceIDString(d))
+	tflog.Debug(ctx, "beginning update", map[string]interface{}{
+		"id": resourceNLBServiceIDString(d),
+	})
 
 	zone := d.Get(resNLBServiceAttrZone).(string)
 
@@ -406,13 +416,17 @@ func resourceNLBServiceUpdate(ctx context.Context, d *schema.ResourceData, meta 
 		}
 	}
 
-	log.Printf("[DEBUG] %s: update finished successfully", resourceNLBServiceIDString(d))
+	tflog.Debug(ctx, "update finished successfully", map[string]interface{}{
+		"id": resourceNLBServiceIDString(d),
+	})
 
 	return resourceNLBServiceRead(ctx, d, meta)
 }
 
 func resourceNLBServiceDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] %s: beginning delete", resourceNLBServiceIDString(d))
+	tflog.Debug(ctx, "beginning delete", map[string]interface{}{
+		"id": resourceNLBServiceIDString(d),
+	})
 
 	zone := d.Get(resNLBServiceAttrZone).(string)
 
@@ -433,7 +447,9 @@ func resourceNLBServiceDelete(ctx context.Context, d *schema.ResourceData, meta 
 		return diag.FromErr(err)
 	}
 
-	log.Printf("[DEBUG] %s: delete finished successfully", resourceNLBServiceIDString(d))
+	tflog.Debug(ctx, "delete finished successfully", map[string]interface{}{
+		"id": resourceNLBServiceIDString(d),
+	})
 
 	return nil
 }

--- a/exoscale/resource_exoscale_private_network.go
+++ b/exoscale/resource_exoscale_private_network.go
@@ -3,11 +3,11 @@ package exoscale
 import (
 	"context"
 	"errors"
-	"log"
 	"net"
 
 	egoscale "github.com/exoscale/egoscale/v2"
 	exoapi "github.com/exoscale/egoscale/v2/api"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -78,7 +78,9 @@ func resourcePrivateNetwork() *schema.Resource {
 }
 
 func resourcePrivateNetworkCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] %s: beginning create", resourcePrivateNetworkIDString(d))
+	tflog.Debug(ctx, "beginning create", map[string]interface{}{
+		"id": resourcePrivateNetworkIDString(d),
+	})
 
 	zone := d.Get(resPrivateNetworkAttrZone).(string)
 
@@ -118,13 +120,17 @@ func resourcePrivateNetworkCreate(ctx context.Context, d *schema.ResourceData, m
 
 	d.SetId(*privateNetwork.ID)
 
-	log.Printf("[DEBUG] %s: create finished successfully", resourcePrivateNetworkIDString(d))
+	tflog.Debug(ctx, "create finished successfully", map[string]interface{}{
+		"id": resourcePrivateNetworkIDString(d),
+	})
 
 	return resourcePrivateNetworkRead(ctx, d, meta)
 }
 
 func resourcePrivateNetworkRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] %s: beginning read", resourcePrivateNetworkIDString(d))
+	tflog.Debug(ctx, "beginning read", map[string]interface{}{
+		"id": resourcePrivateNetworkIDString(d),
+	})
 
 	zone := d.Get(resPrivateNetworkAttrZone).(string)
 
@@ -144,13 +150,17 @@ func resourcePrivateNetworkRead(ctx context.Context, d *schema.ResourceData, met
 		return diag.FromErr(err)
 	}
 
-	log.Printf("[DEBUG] %s: read finished successfully", resourcePrivateNetworkIDString(d))
+	tflog.Debug(ctx, "read finished successfully", map[string]interface{}{
+		"id": resourcePrivateNetworkIDString(d),
+	})
 
 	return diag.FromErr(resourcePrivateNetworkApply(ctx, d, privateNetwork))
 }
 
 func resourcePrivateNetworkUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] %s: beginning update", resourcePrivateNetworkIDString(d))
+	tflog.Debug(ctx, "beginning update", map[string]interface{}{
+		"id": resourcePrivateNetworkIDString(d),
+	})
 
 	zone := d.Get(resPrivateNetworkAttrZone).(string)
 
@@ -203,13 +213,17 @@ func resourcePrivateNetworkUpdate(ctx context.Context, d *schema.ResourceData, m
 		}
 	}
 
-	log.Printf("[DEBUG] %s: update finished successfully", resourcePrivateNetworkIDString(d))
+	tflog.Debug(ctx, "update finished successfully", map[string]interface{}{
+		"id": resourcePrivateNetworkIDString(d),
+	})
 
 	return resourcePrivateNetworkRead(ctx, d, meta)
 }
 
 func resourcePrivateNetworkDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] %s: beginning delete", resourcePrivateNetworkIDString(d))
+	tflog.Debug(ctx, "beginning delete", map[string]interface{}{
+		"id": resourcePrivateNetworkIDString(d),
+	})
 
 	zone := d.Get(resPrivateNetworkAttrZone).(string)
 
@@ -224,7 +238,9 @@ func resourcePrivateNetworkDelete(ctx context.Context, d *schema.ResourceData, m
 		return diag.FromErr(err)
 	}
 
-	log.Printf("[DEBUG] %s: delete finished successfully", resourcePrivateNetworkIDString(d))
+	tflog.Debug(ctx, "delete finished successfully", map[string]interface{}{
+		"id": resourcePrivateNetworkIDString(d),
+	})
 
 	return nil
 }

--- a/exoscale/resource_exoscale_secondary_ipaddress.go
+++ b/exoscale/resource_exoscale_secondary_ipaddress.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"net"
 	"strings"
 
 	"github.com/exoscale/egoscale"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -60,7 +60,9 @@ func resourceSecondaryIPAddress() *schema.Resource {
 }
 
 func resourceSecondaryIPAddressCreate(d *schema.ResourceData, meta interface{}) error {
-	log.Printf("[DEBUG] %s: beginning create", resourceSecondaryIPAddressIDString(d))
+	tflog.Debug(context.Background(), "beginning create", map[string]interface{}{
+		"id": resourceSecondaryIPAddressIDString(d),
+	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutCreate))
 	defer cancel()
@@ -111,7 +113,9 @@ func resourceSecondaryIPAddressCreate(d *schema.ResourceData, meta interface{}) 
 			return err
 		}
 
-		log.Printf("[DEBUG] %s: create finished successfully", resourceSecondaryIPAddressIDString(d))
+		tflog.Debug(ctx, "create finished successfully", map[string]interface{}{
+			"id": resourceSecondaryIPAddressIDString(d),
+		})
 
 		return resourceSecondaryIPAddressRead(d, meta)
 	}
@@ -130,7 +134,9 @@ func resourceSecondaryIPAddressExists(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourceSecondaryIPAddressRead(d *schema.ResourceData, meta interface{}) error {
-	log.Printf("[DEBUG] %s: beginning read", resourceSecondaryIPAddressIDString(d))
+	tflog.Debug(context.Background(), "beginning read", map[string]interface{}{
+		"id": resourceSecondaryIPAddressIDString(d),
+	})
 
 	ip, err := getSecondaryIP(d, meta)
 	if err != nil {
@@ -146,7 +152,9 @@ func resourceSecondaryIPAddressRead(d *schema.ResourceData, meta interface{}) er
 		d.SetId("")
 	}
 
-	log.Printf("[DEBUG] %s: read finished successfully", resourceSecondaryIPAddressIDString(d))
+	tflog.Debug(context.Background(), "read finished successfully", map[string]interface{}{
+		"id": resourceSecondaryIPAddressIDString(d),
+	})
 
 	return nil
 }
@@ -279,7 +287,9 @@ func getSecondaryIP(d *schema.ResourceData, meta interface{}) (*egoscale.NicSeco
 }
 
 func resourceSecondaryIPAddressDelete(d *schema.ResourceData, meta interface{}) error {
-	log.Printf("[DEBUG] %s: beginning delete", resourceSecondaryIPAddressIDString(d))
+	tflog.Debug(context.Background(), "beginning delete", map[string]interface{}{
+		"id": resourceSecondaryIPAddressIDString(d),
+	})
 
 	ip, err := getSecondaryIP(d, meta)
 	if err != nil {
@@ -300,7 +310,9 @@ func resourceSecondaryIPAddressDelete(d *schema.ResourceData, meta interface{}) 
 		return err
 	}
 
-	log.Printf("[DEBUG] %s: read finished successfully", resourceSecondaryIPAddressIDString(d))
+	tflog.Debug(context.Background(), "read finished successfully", map[string]interface{}{
+		"id": resourceSecondaryIPAddressIDString(d),
+	})
 
 	return nil
 }

--- a/exoscale/resource_exoscale_security_group.go
+++ b/exoscale/resource_exoscale_security_group.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"strings"
 
 	egoscale "github.com/exoscale/egoscale/v2"
 	exoapi "github.com/exoscale/egoscale/v2/api"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -88,23 +88,25 @@ func resourceSecurityGroupResourceV0() *schema.Resource {
 	}
 }
 
-func resourceSecurityGroupStateUpgradeV0(_ context.Context, rawState map[string]interface{}, _ interface{}) (map[string]interface{}, error) {
-	log.Printf("[DEBUG] beginning migration")
+func resourceSecurityGroupStateUpgradeV0(ctx context.Context, rawState map[string]interface{}, _ interface{}) (map[string]interface{}, error) {
+	tflog.Debug(ctx, "beginning migration")
 
 	// OpenAPI-v2 backend returns lowercase names, let's fix the state content
 	if name, ok := rawState["name"].(string); ok {
 		rawState["name"] = strings.ToLower(name)
-		log.Printf("[DEBUG] enforce lowercase on name: %+v", rawState["name"])
+		tflog.Debug(ctx, fmt.Sprintf("enforce lowercase on name: %+v", rawState["name"]))
 	} else {
 		return nil, fmt.Errorf("unable to get resource name during migration")
 	}
 
-	log.Printf("[DEBUG] done migration")
+	tflog.Debug(ctx, "done migration")
 	return rawState, nil
 }
 
 func resourceSecurityGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] %s: beginning create", resourceSecurityGroupIDString(d))
+	tflog.Debug(ctx, "beginning create", map[string]interface{}{
+		"id": resourceSecurityGroupIDString(d),
+	})
 
 	zone := defaultZone
 
@@ -132,13 +134,17 @@ func resourceSecurityGroupCreate(ctx context.Context, d *schema.ResourceData, me
 
 	d.SetId(*securityGroup.ID)
 
-	log.Printf("[DEBUG] %s: create finished successfully", resourceSecurityGroupIDString(d))
+	tflog.Debug(ctx, "create finished successfully", map[string]interface{}{
+		"id": resourceSecurityGroupIDString(d),
+	})
 
 	return resourceSecurityGroupRead(ctx, d, meta)
 }
 
 func resourceSecurityGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] %s: beginning read", resourceSecurityGroupIDString(d))
+	tflog.Debug(ctx, "beginning read", map[string]interface{}{
+		"id": resourceSecurityGroupIDString(d),
+	})
 
 	zone := defaultZone
 
@@ -158,13 +164,17 @@ func resourceSecurityGroupRead(ctx context.Context, d *schema.ResourceData, meta
 		return diag.FromErr(err)
 	}
 
-	log.Printf("[DEBUG] %s: read finished successfully", resourceSecurityGroupIDString(d))
+	tflog.Debug(ctx, "read finished successfully", map[string]interface{}{
+		"id": resourceSecurityGroupIDString(d),
+	})
 
 	return diag.FromErr(resourceSecurityGroupApply(ctx, d, securityGroup))
 }
 
 func resourceSecurityGroupUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] %s: beginning update", resourceSecurityGroupIDString(d))
+	tflog.Debug(ctx, "beginning update", map[string]interface{}{
+		"id": resourceSecurityGroupIDString(d),
+	})
 
 	zone := defaultZone
 
@@ -211,13 +221,17 @@ func resourceSecurityGroupUpdate(ctx context.Context, d *schema.ResourceData, me
 		}
 	}
 
-	log.Printf("[DEBUG] %s: update finished successfully", resourceSecurityGroupIDString(d))
+	tflog.Debug(ctx, "update finished successfully", map[string]interface{}{
+		"id": resourceSecurityGroupIDString(d),
+	})
 
 	return resourceSecurityGroupRead(ctx, d, meta)
 }
 
 func resourceSecurityGroupDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] %s: beginning delete", resourceSecurityGroupIDString(d))
+	tflog.Debug(ctx, "beginning delete", map[string]interface{}{
+		"id": resourceSecurityGroupIDString(d),
+	})
 
 	zone := defaultZone
 
@@ -233,7 +247,9 @@ func resourceSecurityGroupDelete(ctx context.Context, d *schema.ResourceData, me
 		return diag.FromErr(err)
 	}
 
-	log.Printf("[DEBUG] %s: delete finished successfully", resourceSecurityGroupIDString(d))
+	tflog.Debug(ctx, "delete finished successfully", map[string]interface{}{
+		"id": resourceSecurityGroupIDString(d),
+	})
 
 	return nil
 }

--- a/exoscale/resource_exoscale_security_group_rule.go
+++ b/exoscale/resource_exoscale_security_group_rule.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"net"
 	"strings"
 
 	egoscale "github.com/exoscale/egoscale/v2"
 	exoapi "github.com/exoscale/egoscale/v2/api"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -183,7 +183,9 @@ func resourceSecurityGroupRule() *schema.Resource {
 }
 
 func resourceSecurityGroupRuleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] %s: beginning create", resourceSecurityGroupRuleIDString(d))
+	tflog.Debug(ctx, "beginning create", map[string]interface{}{
+		"id": resourceSecurityGroupRuleIDString(d),
+	})
 
 	zone := defaultZone
 
@@ -282,13 +284,17 @@ func resourceSecurityGroupRuleCreate(ctx context.Context, d *schema.ResourceData
 
 	d.SetId(*securityGroupRule.ID)
 
-	log.Printf("[DEBUG] %s: create finished successfully", resourceSecurityGroupRuleIDString(d))
+	tflog.Debug(ctx, "create finished successfully", map[string]interface{}{
+		"id": resourceSecurityGroupRuleIDString(d),
+	})
 
 	return resourceSecurityGroupRuleRead(ctx, d, meta)
 }
 
 func resourceSecurityGroupRuleRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] %s: beginning read", resourceSecurityGroupRuleIDString(d))
+	tflog.Debug(ctx, "beginning read", map[string]interface{}{
+		"id": resourceSecurityGroupRuleIDString(d),
+	})
 
 	zone := defaultZone
 
@@ -330,13 +336,17 @@ func resourceSecurityGroupRuleRead(ctx context.Context, d *schema.ResourceData, 
 		return nil
 	}
 
-	log.Printf("[DEBUG] %s: read finished successfully", resourceSecurityGroupRuleIDString(d))
+	tflog.Debug(ctx, "read finished successfully", map[string]interface{}{
+		"id": resourceSecurityGroupRuleIDString(d),
+	})
 
 	return diag.FromErr(resourceSecurityGroupRuleApply(ctx, d, meta, securityGroup, securityGroupRule))
 }
 
 func resourceSecurityGroupRuleDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] %s: beginning delete", resourceSecurityGroupRuleIDString(d))
+	tflog.Debug(ctx, "beginning delete", map[string]interface{}{
+		"id": resourceSecurityGroupRuleIDString(d),
+	})
 
 	zone := defaultZone
 
@@ -370,7 +380,9 @@ func resourceSecurityGroupRuleDelete(ctx context.Context, d *schema.ResourceData
 		return diag.FromErr(err)
 	}
 
-	log.Printf("[DEBUG] %s: delete finished successfully", resourceSecurityGroupRuleIDString(d))
+	tflog.Debug(ctx, "delete finished successfully", map[string]interface{}{
+		"id": resourceSecurityGroupRuleIDString(d),
+	})
 
 	return nil
 }

--- a/exoscale/resource_exoscale_sks_cluster.go
+++ b/exoscale/resource_exoscale_sks_cluster.go
@@ -5,10 +5,10 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"log"
 
 	egoscale "github.com/exoscale/egoscale/v2"
 	exoapi "github.com/exoscale/egoscale/v2/api"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -203,7 +203,9 @@ func resourceSKSCluster() *schema.Resource {
 }
 
 func resourceSKSClusterCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] %s: beginning create", resourceSKSClusterIDString(d))
+	tflog.Debug(ctx, "beginning create", map[string]interface{}{
+		"id": resourceSKSClusterIDString(d),
+	})
 
 	zone := d.Get(resSKSClusterAttrZone).(string)
 
@@ -324,13 +326,17 @@ func resourceSKSClusterCreate(ctx context.Context, d *schema.ResourceData, meta 
 
 	d.SetId(*sksCluster.ID)
 
-	log.Printf("[DEBUG] %s: create finished successfully", resourceSKSClusterIDString(d))
+	tflog.Debug(ctx, "create finished successfully", map[string]interface{}{
+		"id": resourceSKSClusterIDString(d),
+	})
 
 	return resourceSKSClusterRead(ctx, d, meta)
 }
 
 func resourceSKSClusterRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] %s: beginning read", resourceSKSClusterIDString(d))
+	tflog.Debug(ctx, "beginning read", map[string]interface{}{
+		"id": resourceSKSClusterIDString(d),
+	})
 
 	zone := d.Get(resSKSClusterAttrZone).(string)
 
@@ -350,7 +356,9 @@ func resourceSKSClusterRead(ctx context.Context, d *schema.ResourceData, meta in
 		return diag.FromErr(err)
 	}
 
-	log.Printf("[DEBUG] %s: read finished successfully", resourceSKSClusterIDString(d))
+	tflog.Debug(ctx, "read finished successfully", map[string]interface{}{
+		"id": resourceSKSClusterIDString(d),
+	})
 
 	certificates, err := readClusterCertificates(client.Client, ctx, zone, sksCluster)
 	if err != nil {
@@ -361,7 +369,9 @@ func resourceSKSClusterRead(ctx context.Context, d *schema.ResourceData, meta in
 }
 
 func resourceSKSClusterUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] %s: beginning update", resourceSKSClusterIDString(d))
+	tflog.Debug(ctx, "beginning update", map[string]interface{}{
+		"id": resourceSKSClusterIDString(d),
+	})
 
 	zone := d.Get(resSKSClusterAttrZone).(string)
 
@@ -411,13 +421,17 @@ func resourceSKSClusterUpdate(ctx context.Context, d *schema.ResourceData, meta 
 		}
 	}
 
-	log.Printf("[DEBUG] %s: update finished successfully", resourceSKSClusterIDString(d))
+	tflog.Debug(ctx, "update finished successfully", map[string]interface{}{
+		"id": resourceSKSClusterIDString(d),
+	})
 
 	return resourceSKSClusterRead(ctx, d, meta)
 }
 
 func resourceSKSClusterDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] %s: beginning delete", resourceSKSClusterIDString(d))
+	tflog.Debug(ctx, "beginning delete", map[string]interface{}{
+		"id": resourceSKSClusterIDString(d),
+	})
 
 	zone := d.Get(resSKSClusterAttrZone).(string)
 
@@ -433,7 +447,9 @@ func resourceSKSClusterDelete(ctx context.Context, d *schema.ResourceData, meta 
 		return diag.FromErr(err)
 	}
 
-	log.Printf("[DEBUG] %s: delete finished successfully", resourceSKSClusterIDString(d))
+	tflog.Debug(ctx, "delete finished successfully", map[string]interface{}{
+		"id": resourceSKSClusterIDString(d),
+	})
 
 	return nil
 }

--- a/exoscale/resource_exoscale_sks_kubeconfig.go
+++ b/exoscale/resource_exoscale_sks_kubeconfig.go
@@ -6,13 +6,13 @@ import (
 	"encoding/base64"
 	"encoding/pem"
 	"fmt"
-	"log"
 	"strings"
 	"time"
 
 	yaml "gopkg.in/yaml.v3"
 
 	exoapi "github.com/exoscale/egoscale/v2/api"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -98,7 +98,9 @@ func resourceSKSKubeconfig() *schema.Resource {
 }
 
 func resourceSKSKubeconfigCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] %s: beginning create", resourceSKSKubeconfigIDString(d))
+	tflog.Debug(ctx, "beginning create", map[string]interface{}{
+		"id": resourceSKSKubeconfigIDString(d),
+	})
 
 	zone := d.Get(resSKSKubeconfigAttrZone).(string)
 	ctx, cancel := context.WithTimeout(ctx, d.Timeout(schema.TimeoutCreate))
@@ -144,7 +146,9 @@ func resourceSKSKubeconfigCreate(ctx context.Context, d *schema.ResourceData, me
 
 	d.SetId(*id)
 
-	log.Printf("[DEBUG] %s: create finished successfully", resourceSKSKubeconfigIDString(d))
+	tflog.Debug(ctx, "create finished successfully", map[string]interface{}{
+		"id": resourceSKSKubeconfigIDString(d),
+	})
 
 	return resourceSKSKubeconfigRead(ctx, d, meta)
 }
@@ -158,13 +162,17 @@ func resourceSKSKubeconfigUpdate(ctx context.Context, d *schema.ResourceData, me
 }
 
 func resourceSKSKubeconfigDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] %s: beginning delete", resourceSKSKubeconfigIDString(d))
+	tflog.Debug(ctx, "beginning delete", map[string]interface{}{
+		"id": resourceSKSKubeconfigIDString(d),
+	})
 
 	// no revocation: we rely on client certificate expiration
 	// So let's just remove the kubeconfig from the state.
 	d.SetId("")
 
-	log.Printf("[DEBUG] %s: delete finished successfully", resourceSKSKubeconfigIDString(d))
+	tflog.Debug(ctx, "delete finished successfully", map[string]interface{}{
+		"id": resourceSKSKubeconfigIDString(d),
+	})
 	return nil
 }
 
@@ -263,7 +271,9 @@ func kubeconfigRawPEMDataToCertificate(b64PEMData string) (*x509.Certificate, er
 }
 
 func kubeconfigToID(kubeconfig string) (*string, error) {
-	log.Printf("[DEBUG] kubeconfigToID: kubeconfig= %s", kubeconfig)
+	tflog.Debug(context.Background(), "kubeconfigToID", map[string]interface{}{
+		"kubeconfig": kubeconfig,
+	})
 
 	clusterCertificates, clientCertificates, err := KubeconfigExtractCertificates(kubeconfig)
 	if err != nil {

--- a/exoscale/resource_exoscale_sks_nodepool.go
+++ b/exoscale/resource_exoscale_sks_nodepool.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"strings"
 
 	egoscale "github.com/exoscale/egoscale/v2"
 	exoapi "github.com/exoscale/egoscale/v2/api"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -177,7 +177,9 @@ func resourceSKSNodepool() *schema.Resource {
 }
 
 func resourceSKSNodepoolCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] %s: beginning create", resourceSKSNodepoolIDString(d))
+	tflog.Debug(ctx, "beginning create", map[string]interface{}{
+		"id": resourceSKSNodepoolIDString(d),
+	})
 
 	zone := d.Get(resSKSNodepoolAttrZone).(string)
 
@@ -296,13 +298,17 @@ func resourceSKSNodepoolCreate(ctx context.Context, d *schema.ResourceData, meta
 
 	d.SetId(*sksNodepool.ID)
 
-	log.Printf("[DEBUG] %s: create finished successfully", resourceSKSNodepoolIDString(d))
+	tflog.Debug(ctx, "create finished successfully", map[string]interface{}{
+		"id": resourceSKSNodepoolIDString(d),
+	})
 
 	return resourceSKSNodepoolRead(ctx, d, meta)
 }
 
 func resourceSKSNodepoolRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] %s: beginning read", resourceSKSNodepoolIDString(d))
+	tflog.Debug(ctx, "beginning read", map[string]interface{}{
+		"id": resourceSKSNodepoolIDString(d),
+	})
 
 	zone := d.Get(resSKSNodepoolAttrZone).(string)
 
@@ -335,13 +341,17 @@ func resourceSKSNodepoolRead(ctx context.Context, d *schema.ResourceData, meta i
 		return nil
 	}
 
-	log.Printf("[DEBUG] %s: read finished successfully", resourceSKSNodepoolIDString(d))
+	tflog.Debug(ctx, "read finished successfully", map[string]interface{}{
+		"id": resourceSKSNodepoolIDString(d),
+	})
 
 	return diag.FromErr(resourceSKSNodepoolApply(ctx, client.Client, d, sksNodepool))
 }
 
 func resourceSKSNodepoolUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] %s: beginning update", resourceSKSNodepoolIDString(d))
+	tflog.Debug(ctx, "beginning update", map[string]interface{}{
+		"id": resourceSKSNodepoolIDString(d),
+	})
 
 	zone := d.Get(resSKSNodepoolAttrZone).(string)
 
@@ -484,13 +494,17 @@ func resourceSKSNodepoolUpdate(ctx context.Context, d *schema.ResourceData, meta
 		}
 	}
 
-	log.Printf("[DEBUG] %s: update finished successfully", resourceSKSNodepoolIDString(d))
+	tflog.Debug(ctx, "update finished successfully", map[string]interface{}{
+		"id": resourceSKSNodepoolIDString(d),
+	})
 
 	return resourceSKSNodepoolRead(ctx, d, meta)
 }
 
 func resourceSKSNodepoolDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] %s: beginning delete", resourceSKSNodepoolIDString(d))
+	tflog.Debug(ctx, "beginning delete", map[string]interface{}{
+		"id": resourceSKSNodepoolIDString(d),
+	})
 
 	zone := d.Get(resSKSNodepoolAttrZone).(string)
 
@@ -510,7 +524,9 @@ func resourceSKSNodepoolDelete(ctx context.Context, d *schema.ResourceData, meta
 		return diag.FromErr(err)
 	}
 
-	log.Printf("[DEBUG] %s: delete finished successfully", resourceSKSNodepoolIDString(d))
+	tflog.Debug(ctx, "delete finished successfully", map[string]interface{}{
+		"id": resourceSKSNodepoolIDString(d),
+	})
 
 	return nil
 }

--- a/exoscale/resource_exoscale_ssh_key.go
+++ b/exoscale/resource_exoscale_ssh_key.go
@@ -3,10 +3,10 @@ package exoscale
 import (
 	"context"
 	"errors"
-	"log"
 
 	egoscale "github.com/exoscale/egoscale/v2"
 	exoapi "github.com/exoscale/egoscale/v2/api"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -58,7 +58,9 @@ func resourceSSHKey() *schema.Resource {
 }
 
 func resourceSSHKeyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] %s: beginning create", resourceSSHKeyIDString(d))
+	tflog.Debug(ctx, "beginning create", map[string]interface{}{
+		"id": resourceSSHKeyIDString(d),
+	})
 
 	zone := defaultZone
 
@@ -85,13 +87,17 @@ func resourceSSHKeyCreate(ctx context.Context, d *schema.ResourceData, meta inte
 
 	d.SetId(*sshKey.Name)
 
-	log.Printf("[DEBUG] %s: create finished successfully", resourceSSHKeyIDString(d))
+	tflog.Debug(ctx, "create finished successfully", map[string]interface{}{
+		"id": resourceSSHKeyIDString(d),
+	})
 
 	return resourceSSHKeyRead(ctx, d, meta)
 }
 
 func resourceSSHKeyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] %s: beginning read", resourceSSHKeyIDString(d))
+	tflog.Debug(ctx, "beginning read", map[string]interface{}{
+		"id": resourceSSHKeyIDString(d),
+	})
 
 	zone := defaultZone
 
@@ -111,13 +117,17 @@ func resourceSSHKeyRead(ctx context.Context, d *schema.ResourceData, meta interf
 		return diag.FromErr(err)
 	}
 
-	log.Printf("[DEBUG] %s: read finished successfully", resourceSSHKeyIDString(d))
+	tflog.Debug(ctx, "read finished successfully", map[string]interface{}{
+		"id": resourceSSHKeyIDString(d),
+	})
 
 	return diag.FromErr(resourceSSHKeyApply(ctx, d, securityGroup))
 }
 
 func resourceSSHKeyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] %s: beginning delete", resourceSSHKeyIDString(d))
+	tflog.Debug(ctx, "beginning delete", map[string]interface{}{
+		"id": resourceSSHKeyIDString(d),
+	})
 
 	zone := defaultZone
 
@@ -131,7 +141,9 @@ func resourceSSHKeyDelete(ctx context.Context, d *schema.ResourceData, meta inte
 		return diag.FromErr(err)
 	}
 
-	log.Printf("[DEBUG] %s: delete finished successfully", resourceSSHKeyIDString(d))
+	tflog.Debug(ctx, "delete finished successfully", map[string]interface{}{
+		"id": resourceSSHKeyIDString(d),
+	})
 
 	return nil
 }

--- a/exoscale/resource_exoscale_ssh_keypair.go
+++ b/exoscale/resource_exoscale_ssh_keypair.go
@@ -2,9 +2,9 @@ package exoscale
 
 import (
 	"context"
-	"log"
 
 	"github.com/exoscale/egoscale"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -56,7 +56,9 @@ func resourceSSHKeypair() *schema.Resource {
 func resourceSSHKeypairCreate(d *schema.ResourceData, meta interface{}) error {
 	var keypair *egoscale.SSHKeyPair
 
-	log.Printf("[DEBUG] %s: beginning create", resourceSSHKeypairIDString(d))
+	tflog.Debug(context.Background(), "beginning create", map[string]interface{}{
+		"id": resourceSSHKeypairIDString(d),
+	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutCreate))
 	defer cancel()
@@ -90,7 +92,9 @@ func resourceSSHKeypairCreate(d *schema.ResourceData, meta interface{}) error {
 
 	d.SetId(keypair.Name)
 
-	log.Printf("[DEBUG] %s: create finished successfully", resourceSSHKeypairIDString(d))
+	tflog.Debug(ctx, "create finished successfully", map[string]interface{}{
+		"id": resourceSSHKeypairIDString(d),
+	})
 
 	return resourceSSHKeypairRead(d, meta)
 }
@@ -115,7 +119,9 @@ func resourceSSHKeypairExists(d *schema.ResourceData, meta interface{}) (bool, e
 }
 
 func resourceSSHKeypairRead(d *schema.ResourceData, meta interface{}) error {
-	log.Printf("[DEBUG] %s: beginning read", resourceSSHKeypairIDString(d))
+	tflog.Debug(context.Background(), "beginning read", map[string]interface{}{
+		"id": resourceSSHKeypairIDString(d),
+	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutRead))
 	defer cancel()
@@ -129,13 +135,17 @@ func resourceSSHKeypairRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	log.Printf("[DEBUG] %s: read finished successfully", resourceSSHKeypairIDString(d))
+	tflog.Debug(ctx, "read finished successfully", map[string]interface{}{
+		"id": resourceSSHKeypairIDString(d),
+	})
 
 	return resourceSSHKeypairApply(d, resp.(*egoscale.SSHKeyPair))
 }
 
 func resourceSSHKeypairDelete(d *schema.ResourceData, meta interface{}) error {
-	log.Printf("[DEBUG] %s: beginning delete", resourceSSHKeypairIDString(d))
+	tflog.Debug(context.Background(), "beginning delete", map[string]interface{}{
+		"id": resourceSSHKeypairIDString(d),
+	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutDelete))
 	defer cancel()
@@ -148,7 +158,9 @@ func resourceSSHKeypairDelete(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	log.Printf("[DEBUG] %s: delete finished successfully", resourceSSHKeypairIDString(d))
+	tflog.Debug(ctx, "delete finished successfully", map[string]interface{}{
+		"id": resourceSSHKeypairIDString(d),
+	})
 
 	return nil
 }


### PR DESCRIPTION
This PR refactors all our code to use the recommended `tflog` library instead of a plain `stdlib.log`. New library provides more context data to each log message. Some advanced options we can use in the future are described [here](https://www.terraform.io/plugin/log/writing).

Example of new log structure:
```
2022-08-31T18:23:47.080+0200 [DEBUG] provider.terraform-provider-exoscale: read finished successfully: @caller=<redacted>/erraform-provider/exoscale/resource_exoscale_elastic_ip.go:235 tf_resource_type=exoscale_elastic_ip EXTRA_VALUE_AT_END="map[id:exoscale_elastic_ip (ID = 1a3a8124-216e-4dbd-b762-d57a08c1e198)]" tf_provider_addr=provider tf_req_id=01763bac-5987-55c6-da80-6c8d71bffe81 tf_rpc=ReadResource @module=provider timestamp=2022-08-31T18:23:47.080+0200
```

