### PR TITLE
Raise SKS nodepool delete operation timeout

### DIFF
--- a/exoscale/resource_exoscale_sks_nodepool.go
+++ b/exoscale/resource_exoscale_sks_nodepool.go
@@ -171,7 +171,7 @@ func resourceSKSNodepool() *schema.Resource {
 			Create: schema.DefaultTimeout(defaultTimeout),
 			Read:   schema.DefaultTimeout(defaultTimeout),
 			Update: schema.DefaultTimeout(defaultTimeout),
-			Delete: schema.DefaultTimeout(defaultTimeout),
+			Delete: schema.DefaultTimeout(2 * defaultTimeout),
 		},
 	}
 }


### PR DESCRIPTION
This PR raises timeout value for SKS nodepool delete operation (from 5m to 10m).
This operation is expected to take longer to complete, a lot of acceptance test runs failed recently due to timeout (`context deadline exceeded`).