### PR TITLE
Fix missing ID in datasource_exoscale_compute_instance_list

### DIFF
--- a/exoscale/datasource_exoscale_compute_instance.go
+++ b/exoscale/datasource_exoscale_compute_instance.go
@@ -227,6 +227,7 @@ func dataSourceComputeInstanceBuildData(instance *exo.Instance) (map[string]inte
 
 	data[dsComputeInstanceAttrDeployTargetID] = instance.DeployTargetID
 	data[dsComputeInstanceAttrDiskSize] = instance.DiskSize
+	data[dsComputeInstanceAttrID] = instance.ID
 	data[dsComputeInstanceAttrName] = instance.Name
 	data[dsComputeInstanceAttrSSHKey] = instance.SSHKey
 	data[dsComputeInstanceAttrState] = instance.State

--- a/exoscale/datasource_exoscale_compute_instance_list_test.go
+++ b/exoscale/datasource_exoscale_compute_instance_list_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
@@ -76,6 +77,7 @@ data "exoscale_compute_instance_list" "test" {
 				Check: resource.ComposeTestCheckFunc(
 					testAccDataSourceComputeInstanceListAttributes("data.exoscale_compute_instance_list.test", testAttrs{
 						"instances.#":         validateString("1"),
+						"instances.0.id":      validation.ToDiagFunc(validation.NoZeroValues),
 						"instances.0.name":    validateString(testAccDataSourceComputeInstanceListName),
 						"instances.0.type":    validateString(testAccDataSourceComputeInstanceListType),
 						"instances.0.ssh_key": validateString(testAccDataSourceComputeInstanceListSSHKeyName),

--- a/exoscale/datasource_exoscale_instance_pool_list_test.go
+++ b/exoscale/datasource_exoscale_instance_pool_list_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
@@ -76,7 +77,9 @@ data "exoscale_instance_pool_list" "test" {
 				Check: resource.ComposeTestCheckFunc(
 					testAccDataSourceInstancePoolListAttributes("data.exoscale_instance_pool_list.test", testAttrs{
 						"pools.#":             validateString("2"),
+						"pools.0.id":          validation.ToDiagFunc(validation.NoZeroValues),
 						"pools.0.instances.#": validateString("1"),
+						"pools.1.id":          validation.ToDiagFunc(validation.NoZeroValues),
 						"pools.1.instances.#": validateString("1"),
 					}),
 				),


### PR DESCRIPTION
Adds the missing `id` in compute instances list.