### PR TITLE
compute_instance: fix anti_affinity_group_ids (ForceNew)

### DIFF
--- a/exoscale/resource_exoscale_compute_instance.go
+++ b/exoscale/resource_exoscale_compute_instance.go
@@ -49,6 +49,7 @@ func resourceComputeInstance() *schema.Resource {
 			Optional: true,
 			Set:      schema.HashString,
 			Elem:     &schema.Schema{Type: schema.TypeString},
+			ForceNew: true,
 		},
 		resComputeInstanceAttrCreatedAt: {
 			Type:     schema.TypeString,


### PR DESCRIPTION
Set `ForceNew:true` on `anti_affinity_group_ids`  to recreate an instance when the attribute is updated (without it, the modifications had no effect but were stored in TF state)  