### PR TITLE
Implement filtering by tags on elastic_ip data source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.44.0 (NOT YET RELEASED)
+
+BUG FIX:
+
+- `datasource_elastic_ip`: Labels are now correctly returned (#233)
+
+FEATURES:
+
+- `datasource_elastic_ip`: Added support for filtering by labels (#233)
+
 ## 0.43.0 (January 6, 2023)
 
 FEATURES:
@@ -12,7 +22,6 @@ BUG FIXES:
 
 IMPROVEMENTS:
 - Extends the acceptance tests timeout from 60 minutes to 90 minutes
-
 
 ## 0.42.0 (November 24, 2022)
 

--- a/docs/data-sources/elastic_ip.md
+++ b/docs/data-sources/elastic_ip.md
@@ -6,7 +6,7 @@ description: |-
 
 # exoscale\_elastic\_ip
 
-Fetch Exoscale [Elastic IPs (EIO)](https://community.exoscale.com/documentation/compute/eip/) data.
+Fetch Exoscale [Elastic IPs (EIP)](https://community.exoscale.com/documentation/compute/eip/) data.
 
 Corresponding resource: [exoscale_elastic_ip](../resources/elastic_ip.md).
 

--- a/docs/data-sources/elastic_ip.md
+++ b/docs/data-sources/elastic_ip.md
@@ -34,9 +34,9 @@ directory for complete configuration examples.
 
 * `zone` - (Required) The Exocale [Zone][zone] name.
 
-* `id` - The Elastic IP (EIP) ID to match (conflicts with `ip_address`).
-* `ip_address` - The EIP IPv4 or IPv6 address to match (conflicts with `id`).
-
+* `id` - The Elastic IP (EIP) ID to match (conflicts with `ip_address` and `labels`).
+* `ip_address` - The EIP IPv4 or IPv6 address to match (conflicts with `id` and `labels`).
+* `labels` - The EIP labels to match (conflicts with `ip_address` and `id`).
 
 ## Attributes Reference
 
@@ -47,8 +47,8 @@ In addition to the arguments listed above, the following attributes are exported
 * `address_family` - The Elastic IP (EIP) address family (`inet4` or `inet6`).
 * `cidr` - The Elastic IP (EIP) CIDR.
 * `labels` - A map of key/value labels.
-* `reverse_dns` - Domain name for reverse DNS record.
 * `healthcheck` - (Block) The *managed* EIP healthcheck configuration. Structure is documented below.
+* `reverse_dns` - Domain name for reverse DNS record.
 
 ### `healthcheck` block
 

--- a/exoscale/datasource_exoscale_elastic_ip.go
+++ b/exoscale/datasource_exoscale_elastic_ip.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"strings"
+	"fmt"
 
+	egoscale "github.com/exoscale/egoscale/v2"
 	exoapi "github.com/exoscale/egoscale/v2/api"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -93,21 +95,22 @@ func dataSourceElasticIP() *schema.Resource {
 			dsElasticIPAttrID: {
 				Type:          schema.TypeString,
 				Optional:      true,
-				ConflictsWith: []string{dsElasticIPAttrIPAddress},
+				ConflictsWith: []string{dsElasticIPAttrIPAddress, dsElasticIPAttrLabels},
 			},
 			dsElasticIPAttrIPAddress: {
 				Type:          schema.TypeString,
 				Optional:      true,
-				ConflictsWith: []string{dsElasticIPAttrID},
+				ConflictsWith: []string{dsElasticIPAttrID, dsElasticIPAttrLabels},
 			},
 			dsElasticIPAttrReverseDNS: {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
 			dsElasticIPAttrLabels: {
-				Type:     schema.TypeMap,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Computed: true,
+				Type:          schema.TypeMap,
+				Elem:          &schema.Schema{Type: schema.TypeString},
+				Optional:      true,
+				ConflictsWith: []string{dsElasticIPAttrID, dsElasticIPAttrIPAddress},
 			},
 			dsElasticIPAttrZone: {
 				Type:     schema.TypeString,
@@ -132,27 +135,71 @@ func dataSourceElasticIPRead(ctx context.Context, d *schema.ResourceData, meta i
 
 	client := GetComputeClient(meta)
 
-	elasticIPID, byElasticIPID := d.GetOk(dsElasticIPAttrID)
-	elasticIPAddress, byElasticIPAddress := d.GetOk(dsElasticIPAttrIPAddress)
-	if !byElasticIPID && !byElasticIPAddress {
+	elasticIPID, searchByElasticIPID := d.GetOk(dsElasticIPAttrID)
+	elasticIPAddress, searchByElasticIPAddress := d.GetOk(dsElasticIPAttrIPAddress)
+	elasticIPLabels, searchByElasticIPLabels := d.GetOk(dsElasticIPAttrLabels)
+	if !searchByElasticIPID && !searchByElasticIPAddress && !searchByElasticIPLabels {
 		return diag.Errorf(
-			"either %s or %s must be specified",
+			"one of %s, %s or %s must be specified",
 			dsElasticIPAttrIPAddress,
 			dsElasticIPAttrID,
+			dsElasticIPAttrLabels,
 		)
 	}
 
-	elasticIP, err := client.FindElasticIP(
-		ctx,
-		zone, func() string {
-			if byElasticIPID {
-				return elasticIPID.(string)
+	// search by address by default
+	filterElasticIP := func(eip *egoscale.ElasticIP) bool {
+		if eip.IPAddress.String() == elasticIPAddress {
+			return true
+		}
+		return false
+	}
+
+	if searchByElasticIPID {
+		filterElasticIP = func(eip *egoscale.ElasticIP) bool {
+			if *eip.ID == elasticIPID {
+				return true
 			}
-			return elasticIPAddress.(string)
-		}(),
-	)
+			return false
+		}
+	}
+
+	if searchByElasticIPLabels {
+		searchLabels := make(map[string]string)
+		for k, v := range elasticIPLabels.(map[string]interface{}) {
+			searchLabels[k] = v.(string)
+		}
+
+		filterElasticIP = func(eip *egoscale.ElasticIP) bool {
+			if eip.Labels == nil {
+				return false
+			}
+
+			for searchKey, searchValue := range searchLabels {
+				if foundValue, ok := (*eip.Labels)[searchKey]; ok && foundValue == searchValue {
+					continue
+				}
+			}
+
+			return true
+		}
+	}
+
+	elasticIPs, err := client.ListElasticIPs(ctx, zone)
 	if err != nil {
 		return diag.FromErr(err)
+	}
+
+	var elasticIP *egoscale.ElasticIP
+	for _, eip := range elasticIPs {
+		if filterElasticIP(eip) {
+			elasticIP = eip
+			break
+		}
+	}
+
+	if elasticIP == nil {
+		return diag.FromErr(fmt.Errorf("Unable to find matching ElasticIP"))
 	}
 
 	d.SetId(*elasticIP.ID)
@@ -196,6 +243,10 @@ func dataSourceElasticIPRead(ctx context.Context, d *schema.ResourceData, meta i
 		return diag.Errorf("unable to retrieve instance reverse-dns: %s", err)
 	}
 	if err := d.Set(dsElasticIPAttrReverseDNS, strings.TrimSuffix(rdns, ".")); err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err := d.Set(dsElasticIPAttrLabels, elasticIP.Labels); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/exoscale/datasource_exoscale_elastic_ip.go
+++ b/exoscale/datasource_exoscale_elastic_ip.go
@@ -3,8 +3,8 @@ package exoscale
 import (
 	"context"
 	"errors"
-	"strings"
 	"fmt"
+	"strings"
 
 	egoscale "github.com/exoscale/egoscale/v2"
 	exoapi "github.com/exoscale/egoscale/v2/api"


### PR DESCRIPTION
Add the ability to search ElasticIPs by tags instead of address/id (and also fix the data source not returning tags at all)

```
…/terraform-provider-exoscale [ pchepy/sc-39633/elastic-ip-tags-filtering][$!][🐹 v1.19]⏱ 16s
➜ TF_LOG=debug TF_ACC=true go test -timeout 600s -run ^TestAccDataSourceElasticIP$ github.com/exoscale/terraform-provider-exoscale/exoscale
ok      github.com/exoscale/terraform-provider-exoscale/exoscale        16.748s
```
