### PR TITLE
Implement reverse DNS in v2 resources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ test-acc: GO_TEST_EXTRA_ARGS=-v $(EXTRA_ARGS)
 test-acc: ## Runs acceptance tests (requires valid Exoscale API credentials)
 	TF_ACC=1 $(GO) test			\
 		-race                   \
-		-timeout=60m            \
+		-timeout=90m            \
 		-tags=testacc           \
 		$(GO_TEST_EXTRA_ARGS)   \
 		$(GO_TEST_PKGS)

--- a/docs/data-sources/compute_instance.md
+++ b/docs/data-sources/compute_instance.md
@@ -53,6 +53,7 @@ In addition to the arguments listed above, the following attributes are exported
 * `manager_id` - The instance manager ID, if any.
 * `manager_type` - The instance manager type (instance pool, SKS node pool, etc.), if any.
 * `public_ip_address` - The instance (main network interface) IPv4 address.
+* `reverse_dns` - Domain name for reverse DNS record.
 * `ssh_key` - The [exoscale_ssh_key](../resources/ssh_key.md) (name) authorized on the instance.
 * `state` - The instance state.
 * `template_id` - The instance [exoscale_compute_template](./compute_template.md) ID.

--- a/docs/data-sources/elastic_ip.md
+++ b/docs/data-sources/elastic_ip.md
@@ -47,6 +47,7 @@ In addition to the arguments listed above, the following attributes are exported
 * `address_family` - The Elastic IP (EIP) address family (`inet4` or `inet6`).
 * `cidr` - The Elastic IP (EIP) CIDR.
 * `labels` - A map of key/value labels.
+* `reverse_dns` - Domain name for reverse DNS record.
 * `healthcheck` - (Block) The *managed* EIP healthcheck configuration. Structure is documented below.
 
 ### `healthcheck` block

--- a/docs/resources/compute_instance.md
+++ b/docs/resources/compute_instance.md
@@ -54,6 +54,7 @@ directory for complete configuration examples.
 
 * `anti_affinity_group_ids` - A list of [exoscale_anti_affinity_group](./anti_affinity_group.md) (IDs) to attach to the instance (may only be set at creation time).
 * `elastic_ip_ids` - A list of [exoscale_elastic_ip](./elastic_ip.md) (IDs) to attach to the instance.
+* `reverse_dns` - Domain name for reverse DNS record.
 * `security_group_ids` - A list of [exoscale_security_group](./security_group.md) (IDs) to attach to the instance.
 
 * `network_interface` - (Block) Private network interfaces (may be specified multiple times). Structure is documented below.

--- a/docs/resources/elastic_ip.md
+++ b/docs/resources/elastic_ip.md
@@ -27,6 +27,7 @@ resource "exoscale_elastic_ip" "my_elastic_ip" {
 resource "exoscale_elastic_ip" "my_managed_elastic_ip" {
   zone = "ch-gva-2"
   address_family = "inet6"
+  reverse_dns = "example.net"
 
   healthcheck {
     mode         = "https"
@@ -55,6 +56,7 @@ directory for complete configuration examples.
 
 * `address_family` - The Elastic IP (EIP) address family (`inet4` or `inet6`; default: `inet4`).
 * `labels` - A map of key/value labels.
+* `reverse_dns` - Domain name for reverse DNS record.
 * `healthcheck` - (Block) Healthcheck configuration for *managed* EIPs. Structure is documented below.
 
 ### `healthcheck` block

--- a/exoscale/datasource_exoscale_compute_instance.go
+++ b/exoscale/datasource_exoscale_compute_instance.go
@@ -2,6 +2,7 @@ package exoscale
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -27,6 +28,7 @@ const (
 	dsComputeInstanceAttrName                 = "name"
 	dsComputeInstanceAttrPrivateNetworkIDs    = "private_network_ids"
 	dsComputeInstanceAttrPublicIPAddress      = "public_ip_address"
+	dsComputeInstanceAttrReverseDNS           = "reverse_dns"
 	dsComputeInstanceAttrSSHKey               = "ssh_key"
 	dsComputeInstanceAttrSecurityGroupIDs     = "security_group_ids"
 	dsComputeInstanceAttrState                = "state"
@@ -99,6 +101,10 @@ func getDataSourceComputeInstanceSchema() map[string]*schema.Schema {
 			Elem:     &schema.Schema{Type: schema.TypeString},
 		},
 		dsComputeInstanceAttrPublicIPAddress: {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		dsComputeInstanceAttrReverseDNS: {
 			Type:     schema.TypeString,
 			Computed: true,
 		},
@@ -206,6 +212,12 @@ func dataSourceComputeInstanceRead(ctx context.Context, d *schema.ResourceData, 
 		strings.ToLower(*instanceType.Family),
 		strings.ToLower(*instanceType.Size),
 	)
+
+	rdns, err := client.GetInstanceReverseDNS(ctx, zone, *computeInstance.ID)
+	if err != nil && !errors.Is(err, exoapi.ErrNotFound) {
+		return diag.Errorf("unable to retrieve instance reverse-dns: %s", err)
+	}
+	data[dsComputeInstanceAttrReverseDNS] = rdns
 
 	for key, value := range data {
 		err := d.Set(key, value)

--- a/exoscale/datasource_exoscale_compute_instance.go
+++ b/exoscale/datasource_exoscale_compute_instance.go
@@ -217,7 +217,7 @@ func dataSourceComputeInstanceRead(ctx context.Context, d *schema.ResourceData, 
 	if err != nil && !errors.Is(err, exoapi.ErrNotFound) {
 		return diag.Errorf("unable to retrieve instance reverse-dns: %s", err)
 	}
-	data[dsComputeInstanceAttrReverseDNS] = rdns
+	data[dsComputeInstanceAttrReverseDNS] = strings.TrimSuffix(rdns, ".")
 
 	for key, value := range data {
 		err := d.Set(key, value)

--- a/exoscale/datasource_exoscale_compute_instance_list.go
+++ b/exoscale/datasource_exoscale_compute_instance_list.go
@@ -3,6 +3,7 @@ package exoscale
 import (
 	"context"
 	"crypto/md5"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -79,6 +80,12 @@ func dataSourceComputeInstanceListRead(ctx context.Context, d *schema.ResourceDa
 		if err != nil {
 			return diag.FromErr(err)
 		}
+
+		rdns, err := client.GetInstanceReverseDNS(ctx, zone, *instance.ID)
+		if err != nil && !errors.Is(err, exoapi.ErrNotFound) {
+			return diag.Errorf("unable to retrieve instance reverse-dns: %s", err)
+		}
+		instanceData[dsComputeInstanceAttrReverseDNS] = rdns
 
 		if instance.InstanceTypeID != nil {
 			tid := *instance.InstanceTypeID

--- a/exoscale/datasource_exoscale_compute_instance_test.go
+++ b/exoscale/datasource_exoscale_compute_instance_test.go
@@ -19,6 +19,7 @@ var (
 	testAccDataSourceComputeInstanceName                        = acctest.RandomWithPrefix(testPrefix)
 	testAccDataSourceComputeInstancePrivateNetworkName          = acctest.RandomWithPrefix(testPrefix)
 	testAccDataSourceComputeInstanceSSHKeyName                  = acctest.RandomWithPrefix(testPrefix)
+	testAccDataSourceComputeInstanceReverseDNS                  = "tf-provider-rdns-test.exoscale.com"
 	testAccDataSourceComputeInstanceSecurityGroupName           = acctest.RandomWithPrefix(testPrefix)
 	testAccDataSourceComputeInstanceType                        = "standard.tiny"
 	testAccDataSourceComputeInstanceUserData                    = acctest.RandString(10)
@@ -67,9 +68,10 @@ resource "exoscale_compute_instance" "test" {
   elastic_ip_ids          = [exoscale_elastic_ip.test.id]
   user_data               = "%s"
   ssh_key                 = exoscale_ssh_key.test.name
+	reverse_dns             = "%s"
 
   network_interface {
-	network_id = exoscale_private_network.test.id
+    network_id = exoscale_private_network.test.id
   }
 
   labels = {
@@ -90,6 +92,7 @@ resource "exoscale_compute_instance" "test" {
 		testAccDataSourceComputeInstanceType,
 		testAccDataSourceComputeInstanceDiskSize,
 		testAccDataSourceComputeInstanceUserData,
+		testAccDataSourceComputeInstanceReverseDNS,
 		testAccDataSourceComputeInstanceLabelValue,
 	)
 )
@@ -134,8 +137,9 @@ data "exoscale_compute_instance" "by-name" {
 				),
 				Check: resource.ComposeTestCheckFunc(
 					testAccDataSourceComputeInstanceAttributes("data.exoscale_compute_instance.by-name", testAttrs{
-						dsComputeInstanceAttrID:   validation.ToDiagFunc(validation.IsUUID),
-						dsComputeInstanceAttrName: validateString(testAccDataSourceComputeInstanceName),
+						dsComputeInstanceAttrID:         validation.ToDiagFunc(validation.IsUUID),
+						dsComputeInstanceAttrName:       validateString(testAccDataSourceComputeInstanceName),
+						dsComputeInstanceAttrReverseDNS: validateString(testAccDataSourceComputeInstanceReverseDNS),
 					}),
 				),
 			},

--- a/exoscale/datasource_exoscale_elastic_ip.go
+++ b/exoscale/datasource_exoscale_elastic_ip.go
@@ -3,6 +3,7 @@ package exoscale
 import (
 	"context"
 	"errors"
+	"strings"
 
 	exoapi "github.com/exoscale/egoscale/v2/api"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -194,7 +195,7 @@ func dataSourceElasticIPRead(ctx context.Context, d *schema.ResourceData, meta i
 	if err != nil && !errors.Is(err, exoapi.ErrNotFound) {
 		return diag.Errorf("unable to retrieve instance reverse-dns: %s", err)
 	}
-	if err := d.Set(dsElasticIPAttrReverseDNS, rdns); err != nil {
+	if err := d.Set(dsElasticIPAttrReverseDNS, strings.TrimSuffix(rdns, ".")); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/exoscale/datasource_exoscale_elastic_ip_test.go
+++ b/exoscale/datasource_exoscale_elastic_ip_test.go
@@ -25,6 +25,7 @@ var (
 	testAccDataSourceElasticIPHealthcheckTimeout     int64  = 3
 	testAccDataSourceElasticIPHealthcheckURI                = "/health"
 	testAccDataSourceElasticIPLabelValue                    = acctest.RandomWithPrefix(testPrefix)
+	testAccDataSourceElasticIPReverseDNS                    = "tf-provider-rdns-test.exoscale.com"
 
 	testAccDataSourceElasticIPConfig4 = fmt.Sprintf(`
 locals {
@@ -34,6 +35,8 @@ locals {
 resource "exoscale_elastic_ip" "test4" {
   zone        = local.zone
   description = "%s"
+	
+	reverse_dns     = "%s"
 
   healthcheck {
     mode            = "%s"
@@ -54,6 +57,7 @@ resource "exoscale_elastic_ip" "test4" {
 `,
 		testZoneName,
 		testAccDataSourceElasticIPDescription,
+		testAccDataSourceElasticIPReverseDNS,
 		testAccDataSourceElasticIPHealthcheckMode,
 		testAccDataSourceElasticIPHealthcheckPort,
 		testAccDataSourceElasticIPHealthcheckURI,
@@ -75,6 +79,8 @@ resource "exoscale_elastic_ip" "test6" {
   description = "%s"
 	address_family = "%s"
 
+	reverse_dns     = "%s"
+
   healthcheck {
     mode            = "%s"
     port            = %d
@@ -95,6 +101,7 @@ resource "exoscale_elastic_ip" "test6" {
 		testZoneName,
 		testAccDataSourceElasticIPDescription,
 		testAccDataSourceElasticIPAddressFamily6,
+		testAccDataSourceElasticIPReverseDNS,
 		testAccDataSourceElasticIPHealthcheckMode,
 		testAccDataSourceElasticIPHealthcheckPort,
 		testAccDataSourceElasticIPHealthcheckURI,
@@ -132,6 +139,7 @@ data "exoscale_elastic_ip" "by-ip4-address" {
 						dsElasticIPAttrCIDR:          validation.ToDiagFunc(validation.IsCIDR),
 						dsElasticIPAttrDescription:   validateString(testAccDataSourceElasticIPDescription),
 						dsElasticIPAttrID:            validation.ToDiagFunc(validation.IsUUID),
+						dsElasticIPAttrReverseDNS:    validateString(testAccDataSourceElasticIPReverseDNS),
 						resElasticIPAttrIPAddress:    validation.ToDiagFunc(validation.IsIPv4Address),
 						resElasticIPAttrHealthcheck(dsElasticIPAttrHealthcheckInterval):    validateString(fmt.Sprint(testAccDataSourceElasticIPHealthcheckInterval)),
 						resElasticIPAttrHealthcheck(dsElasticIPAttrHealthcheckMode):        validateString(testAccDataSourceElasticIPHealthcheckMode),
@@ -159,6 +167,7 @@ data "exoscale_elastic_ip" "by-id" {
 						dsElasticIPAttrCIDR:          validation.ToDiagFunc(validation.IsCIDR),
 						dsElasticIPAttrDescription:   validateString(testAccDataSourceElasticIPDescription),
 						dsElasticIPAttrID:            validation.ToDiagFunc(validation.IsUUID),
+						dsElasticIPAttrReverseDNS:    validateString(testAccDataSourceElasticIPReverseDNS),
 						resElasticIPAttrIPAddress:    validation.ToDiagFunc(validation.IsIPv4Address),
 						resElasticIPAttrHealthcheck(dsElasticIPAttrHealthcheckInterval):    validateString(fmt.Sprint(testAccDataSourceElasticIPHealthcheckInterval)),
 						resElasticIPAttrHealthcheck(dsElasticIPAttrHealthcheckMode):        validateString(testAccDataSourceElasticIPHealthcheckMode),
@@ -186,6 +195,7 @@ data "exoscale_elastic_ip" "by-ip6-address" {
 						dsElasticIPAttrCIDR:          validation.ToDiagFunc(validation.IsCIDR),
 						dsElasticIPAttrDescription:   validateString(testAccDataSourceElasticIPDescription),
 						dsElasticIPAttrID:            validation.ToDiagFunc(validation.IsUUID),
+						dsElasticIPAttrReverseDNS:    validateString(testAccDataSourceElasticIPReverseDNS),
 						resElasticIPAttrIPAddress:    validation.ToDiagFunc(validation.IsIPv6Address),
 						resElasticIPAttrHealthcheck(dsElasticIPAttrHealthcheckInterval):    validateString(fmt.Sprint(testAccDataSourceElasticIPHealthcheckInterval)),
 						resElasticIPAttrHealthcheck(dsElasticIPAttrHealthcheckMode):        validateString(testAccDataSourceElasticIPHealthcheckMode),

--- a/exoscale/resource_exoscale_compute_instance.go
+++ b/exoscale/resource_exoscale_compute_instance.go
@@ -652,7 +652,9 @@ func resourceComputeInstanceDelete(ctx context.Context, d *schema.ResourceData, 
 	defer cancel()
 
 	client := GetComputeClient(meta)
-
+	if err := client.DeleteInstanceReverseDNS(ctx, zone, d.Id()); err != nil && !errors.Is(err, exoapi.ErrNotFound) {
+		return diag.FromErr(err)
+	}
 	err := client.DeleteInstance(ctx, zone, &egoscale.Instance{ID: nonEmptyStringPtr(d.Id())})
 	if err != nil {
 		return diag.FromErr(err)

--- a/exoscale/resource_exoscale_compute_instance_test.go
+++ b/exoscale/resource_exoscale_compute_instance_test.go
@@ -31,6 +31,8 @@ var (
 	testAccResourceComputeInstanceStateRunning                = "running"
 	testAccResourceComputeInstanceType                        = "standard.tiny"
 	testAccResourceComputeInstanceTypeUpdated                 = "standard.small"
+	testAccResourceComputeInstranceReverseDNS                 = "tf-provider-test.exoscale.com"
+	testAccResourceComputeInstranceReverseDNSUpdated          = "tf-provider-updated-test.exoscale.com"
 	testAccResourceComputeInstanceUserData                    = acctest.RandString(10)
 	testAccResourceComputeInstanceUserDataUpdated             = testAccResourceComputeInstanceUserData + "-updated"
 
@@ -87,6 +89,7 @@ resource "exoscale_compute_instance" "test" {
   user_data               = "%s"
   ssh_key                 = exoscale_ssh_key.test.name
 	state                   = "%s"
+	reverse_dns             = "%s"
 
   network_interface {
 	network_id = exoscale_private_network.test.id
@@ -111,6 +114,7 @@ resource "exoscale_compute_instance" "test" {
 		testAccResourceComputeInstanceDiskSize,
 		testAccResourceComputeInstanceUserData,
 		testAccResourceComputeInstanceStateStopped,
+		testAccResourceComputeInstranceReverseDNS,
 		testAccResourceComputeInstanceLabelValue,
 	)
 
@@ -164,6 +168,7 @@ resource "exoscale_compute_instance" "test" {
   user_data               = "%s"
   ssh_key                 = exoscale_ssh_key.test.name
 	state                   = "%s"
+  reverse_dns             = "%s"
 
   labels = {
     test = "%s"
@@ -184,6 +189,7 @@ resource "exoscale_compute_instance" "test" {
 		testAccResourceComputeInstanceDiskSizeUpdated,
 		testAccResourceComputeInstanceUserDataUpdated,
 		testAccResourceComputeInstanceStateStopped,
+		testAccResourceComputeInstranceReverseDNSUpdated,
 		testAccResourceComputeInstanceLabelValueUpdated,
 	)
 
@@ -237,6 +243,7 @@ resource "exoscale_compute_instance" "test" {
   user_data               = "%s"
   ssh_key                 = exoscale_ssh_key.test.name
 	state                   = "%s"
+  reverse_dns             = ""
 
   labels = {
     test = "%s"
@@ -408,6 +415,7 @@ func TestAccResourceComputeInstance(t *testing.T) {
 						resComputeInstanceAttrSSHKey:                      validateString(testAccResourceComputeInstanceSSHKeyName),
 						resComputeInstanceAttrSecurityGroupIDs + ".#":     validateString("2"),
 						resComputeInstanceAttrState:                       validateString("stopped"),
+						resComputeInstanceAttrReverseDNS:                  validateString(testAccResourceComputeInstranceReverseDNS),
 						resComputeInstanceAttrTemplateID:                  validation.ToDiagFunc(validation.IsUUID),
 						resComputeInstanceAttrType:                        validateString(testAccResourceComputeInstanceType),
 						resComputeInstanceAttrUserData:                    validateString(testAccResourceComputeInstanceUserData),
@@ -452,6 +460,7 @@ func TestAccResourceComputeInstance(t *testing.T) {
 						resComputeInstanceAttrName:                    validateString(testAccResourceComputeInstanceNameUpdated),
 						resComputeInstanceAttrSecurityGroupIDs + ".#": validateString("1"),
 						resComputeInstanceAttrState:                   validateString("stopped"),
+						resComputeInstanceAttrReverseDNS:              validateString(testAccResourceComputeInstranceReverseDNSUpdated),
 						resComputeInstanceAttrType:                    validateString(testAccResourceComputeInstanceTypeUpdated),
 						resComputeInstanceAttrUserData:                validateString(testAccResourceComputeInstanceUserDataUpdated),
 					})),
@@ -496,6 +505,7 @@ func TestAccResourceComputeInstance(t *testing.T) {
 						resComputeInstanceAttrName:                    validateString(testAccResourceComputeInstanceNameUpdated),
 						resComputeInstanceAttrSecurityGroupIDs + ".#": validateString("1"),
 						resComputeInstanceAttrState:                   validateString("running"),
+						resComputeInstanceAttrReverseDNS:              validation.ToDiagFunc(validation.StringIsEmpty),
 						resComputeInstanceAttrType:                    validateString(testAccResourceComputeInstanceTypeUpdated),
 						resComputeInstanceAttrUserData:                validateString(testAccResourceComputeInstanceUserDataUpdated),
 					})),
@@ -540,6 +550,7 @@ func TestAccResourceComputeInstance(t *testing.T) {
 						resComputeInstanceAttrName:                    validateString(testAccResourceComputeInstanceNameUpdated),
 						resComputeInstanceAttrSecurityGroupIDs + ".#": validateString("1"),
 						resComputeInstanceAttrState:                   validateString("running"),
+						resElasticIPAttrReverseDNS:                    validation.ToDiagFunc(validation.StringIsEmpty),
 						resComputeInstanceAttrType:                    validateString(testAccResourceComputeInstanceTypeUpdated),
 						resComputeInstanceAttrUserData:                validateString(testAccResourceComputeInstanceUserDataUpdated),
 					})),

--- a/exoscale/resource_exoscale_elastic_ip.go
+++ b/exoscale/resource_exoscale_elastic_ip.go
@@ -384,6 +384,9 @@ func resourceElasticIPDelete(ctx context.Context, d *schema.ResourceData, meta i
 	client := GetComputeClient(meta)
 
 	elasticIPID := d.Id()
+	if err := client.DeleteElasticIPReverseDNS(ctx, zone, elasticIPID); err != nil && !errors.Is(err, exoapi.ErrNotFound) {
+		return diag.FromErr(err)
+	}
 	if err := client.DeleteElasticIP(ctx, zone, &egoscale.ElasticIP{ID: &elasticIPID}); err != nil {
 		return diag.FromErr(err)
 	}

--- a/exoscale/resource_exoscale_elastic_ip.go
+++ b/exoscale/resource_exoscale_elastic_ip.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strings"
 	"time"
 
 	egoscale "github.com/exoscale/egoscale/v2"
@@ -29,6 +30,7 @@ const (
 	resElasticIPAttrHealthcheckTimeout       = "timeout"
 	resElasticIPAttrHealthcheckURI           = "uri"
 	resElasticIPAttrIPAddress                = "ip_address"
+	resElasticIPAttrReverseDNS               = "reverse_dns"
 	resElasticIPAttrLabels                   = "labels"
 	resElasticIPAttrZone                     = "zone"
 )
@@ -118,6 +120,10 @@ func resourceElasticIP() *schema.Resource {
 			resElasticIPAttrIPAddress: {
 				Type:     schema.TypeString,
 				Computed: true,
+			},
+			resElasticIPAttrReverseDNS: {
+				Type:     schema.TypeString,
+				Optional: true,
 			},
 			resElasticIPAttrLabels: {
 				Type:     schema.TypeMap,
@@ -236,6 +242,19 @@ func resourceElasticIPCreate(ctx context.Context, d *schema.ResourceData, meta i
 
 	d.SetId(*elasticIP.ID)
 
+	if v, ok := d.GetOk(resElasticIPAttrReverseDNS); ok {
+		rdns := v.(string)
+		err := client.UpdateElasticIPReverseDNS(
+			ctx,
+			zone,
+			*elasticIP.ID,
+			rdns,
+		)
+		if err != nil {
+			return diag.Errorf("unable to create Reverse DNS record: %s", err)
+		}
+	}
+
 	tflog.Debug(ctx, "create finished successfully", map[string]interface{}{
 		"id": resourceElasticIPIDString(d),
 	})
@@ -270,7 +289,7 @@ func resourceElasticIPRead(ctx context.Context, d *schema.ResourceData, meta int
 		"id": resourceElasticIPIDString(d),
 	})
 
-	return diag.FromErr(resourceElasticIPApply(ctx, d, elasticIP))
+	return resourceElasticIPApply(ctx, client.Client, d, elasticIP)
 }
 
 func resourceElasticIPUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -323,6 +342,27 @@ func resourceElasticIPUpdate(ctx context.Context, d *schema.ResourceData, meta i
 		}
 	}
 
+	if d.HasChange(resElasticIPAttrReverseDNS) {
+		rdns := d.Get(resElasticIPAttrReverseDNS).(string)
+		if rdns == "" {
+			err = client.DeleteElasticIPReverseDNS(
+				ctx,
+				zone,
+				*elasticIP.ID,
+			)
+		} else {
+			err = client.UpdateElasticIPReverseDNS(
+				ctx,
+				zone,
+				*elasticIP.ID,
+				rdns,
+			)
+		}
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
 	tflog.Debug(ctx, "update finished successfully", map[string]interface{}{
 		"id": resourceElasticIPIDString(d),
 	})
@@ -355,15 +395,20 @@ func resourceElasticIPDelete(ctx context.Context, d *schema.ResourceData, meta i
 	return nil
 }
 
-func resourceElasticIPApply(_ context.Context, d *schema.ResourceData, elasticIP *egoscale.ElasticIP) error {
+func resourceElasticIPApply(
+	ctx context.Context,
+	client *egoscale.Client,
+	d *schema.ResourceData,
+	elasticIP *egoscale.ElasticIP,
+) diag.Diagnostics {
 	if err := d.Set(resElasticIPAttrAddressFamily, defaultString(elasticIP.AddressFamily, "")); err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 	if err := d.Set(resElasticIPAttrCIDR, defaultString(elasticIP.CIDR, "")); err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 	if err := d.Set(resElasticIPAttrDescription, defaultString(elasticIP.Description, "")); err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	if elasticIP.Healthcheck != nil {
@@ -380,18 +425,30 @@ func resourceElasticIPApply(_ context.Context, d *schema.ResourceData, elasticIP
 		}
 
 		if err := d.Set("healthcheck", []interface{}{elasticIPHealthcheck}); err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 	}
 
 	if elasticIP.IPAddress != nil {
 		if err := d.Set(resElasticIPAttrIPAddress, elasticIP.IPAddress.String()); err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 	}
 
+	rdns, err := client.GetElasticIPReverseDNS(
+		ctx,
+		d.Get(resElasticIPAttrZone).(string),
+		*elasticIP.ID,
+	)
+	if err != nil && !errors.Is(err, exoapi.ErrNotFound) {
+		return diag.Errorf("unable to retrieve elasticIP reverse-dns: %s", err)
+	}
+	if err := d.Set(resElasticIPAttrReverseDNS, strings.TrimSuffix(rdns, ".")); err != nil {
+		return diag.FromErr(err)
+	}
+
 	if err := d.Set(resElasticIPAttrLabels, elasticIP.Labels); err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	return nil

--- a/exoscale/resource_exoscale_elastic_ip_test.go
+++ b/exoscale/resource_exoscale_elastic_ip_test.go
@@ -35,6 +35,7 @@ var (
 	testAccResourceElasticIPHealthcheckTimeoutUpdated            = testAccResourceElasticIPHealthcheckTimeout + 1
 	testAccResourceElasticIPHealthcheckURI                       = "/health"
 	testAccResourceElasticIPHealthcheckURIUpdated                = testAccResourceElasticIPHealthcheckURI + "-updated"
+	testAccResourceElasticIPReverseDNS                           = "tf-provider-test.exoscale.com"
 	testAccResourceElasticIPLabelValue                           = acctest.RandomWithPrefix(testPrefix)
 	testAccResourceElasticIPLabelValueUpdated                    = testAccResourceElasticIPLabelValue + "-updated"
 
@@ -87,6 +88,8 @@ resource "exoscale_elastic_ip" "test4" {
     tls_skip_verify = true
   }
 
+	reverse_dns = "%s"
+
   labels = {
     test = "%s"
   }
@@ -102,6 +105,7 @@ resource "exoscale_elastic_ip" "test4" {
 		testAccResourceElasticIPHealthcheckStrikesOKUpdated,
 		testAccResourceElasticIPHealthcheckStrikesFailUpdated,
 		testAccResourceElasticIPHealthcheckTLSSNI,
+		testAccResourceElasticIPReverseDNS,
 		testAccResourceElasticIPLabelValueUpdated,
 	)
 
@@ -121,6 +125,8 @@ resource "exoscale_elastic_ip" "test6" {
     strikes_fail = %d
   }
 
+	reverse_dns = "%s"
+
   labels = {
     test = "%s"
   }
@@ -136,6 +142,7 @@ resource "exoscale_elastic_ip" "test6" {
 		testAccResourceElasticIPHealthcheckTimeout,
 		testAccResourceElasticIPHealthcheckStrikesOK,
 		testAccResourceElasticIPHealthcheckStrikesFail,
+		testAccResourceElasticIPReverseDNS,
 		testAccResourceElasticIPLabelValue,
 	)
 
@@ -156,6 +163,8 @@ resource "exoscale_elastic_ip" "test6" {
     tls_sni         = "%s"
     tls_skip_verify = true
   }
+
+	reverse_dns = ""
 
   labels = {
     test = "%s"
@@ -179,34 +188,35 @@ resource "exoscale_elastic_ip" "test6" {
 
 func TestAccResourceElasticIP(t *testing.T) {
 	var (
-		r4        = "exoscale_elastic_ip.test4"
-		r6        = "exoscale_elastic_ip.test6"
-		elasticIP egoscale.ElasticIP
+		r4         = "exoscale_elastic_ip.test4"
+		r6         = "exoscale_elastic_ip.test6"
+		elasticIP4 egoscale.ElasticIP
+		elasticIP6 egoscale.ElasticIP
 	)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviders,
-		CheckDestroy:      testAccCheckResourceElasticIPDestroy(&elasticIP),
+		CheckDestroy:      testAccCheckResourceElasticIPDestroy(&elasticIP4),
 		Steps: []resource.TestStep{
 			{
 				// Create
 				Config: testAccResourceElasticIP4ConfigCreate,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckResourceElasticIPExists(r4, &elasticIP),
+					testAccCheckResourceElasticIPExists(r4, &elasticIP4),
 					func(s *terraform.State) error {
 						a := assert.New(t)
 
-						a.Equal(testAccResourceElasticIPAddressFamily4, *elasticIP.AddressFamily)
-						a.Equal(testAccResourceElasticIPDescription, *elasticIP.Description)
-						a.NotNil(elasticIP.Healthcheck)
-						a.Equal(testAccResourceElasticIPHealthcheckInterval, int64(elasticIP.Healthcheck.Interval.Seconds()))
-						a.Equal(testAccResourceElasticIPHealthcheckMode, *elasticIP.Healthcheck.Mode)
-						a.Equal(testAccResourceElasticIPHealthcheckPort, *elasticIP.Healthcheck.Port)
-						a.Equal(testAccResourceElasticIPHealthcheckStrikesFail, *elasticIP.Healthcheck.StrikesFail)
-						a.Equal(testAccResourceElasticIPHealthcheckStrikesOK, *elasticIP.Healthcheck.StrikesOK)
-						a.Equal(testAccResourceElasticIPHealthcheckTimeout, int64(elasticIP.Healthcheck.Timeout.Seconds()))
-						a.Equal(testAccResourceElasticIPHealthcheckURI, *elasticIP.Healthcheck.URI)
+						a.Equal(testAccResourceElasticIPAddressFamily4, *elasticIP4.AddressFamily)
+						a.Equal(testAccResourceElasticIPDescription, *elasticIP4.Description)
+						a.NotNil(elasticIP4.Healthcheck)
+						a.Equal(testAccResourceElasticIPHealthcheckInterval, int64(elasticIP4.Healthcheck.Interval.Seconds()))
+						a.Equal(testAccResourceElasticIPHealthcheckMode, *elasticIP4.Healthcheck.Mode)
+						a.Equal(testAccResourceElasticIPHealthcheckPort, *elasticIP4.Healthcheck.Port)
+						a.Equal(testAccResourceElasticIPHealthcheckStrikesFail, *elasticIP4.Healthcheck.StrikesFail)
+						a.Equal(testAccResourceElasticIPHealthcheckStrikesOK, *elasticIP4.Healthcheck.StrikesOK)
+						a.Equal(testAccResourceElasticIPHealthcheckTimeout, int64(elasticIP4.Healthcheck.Timeout.Seconds()))
+						a.Equal(testAccResourceElasticIPHealthcheckURI, *elasticIP4.Healthcheck.URI)
 
 						return nil
 					},
@@ -230,21 +240,21 @@ func TestAccResourceElasticIP(t *testing.T) {
 				// Update
 				Config: testAccResourceElasticIP4ConfigUpdate,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckResourceElasticIPExists(r4, &elasticIP),
+					testAccCheckResourceElasticIPExists(r4, &elasticIP4),
 					func(s *terraform.State) error {
 						a := assert.New(t)
 
-						a.Equal(testAccResourceElasticIPDescriptionUpdated, *elasticIP.Description)
-						a.NotNil(elasticIP.Healthcheck)
-						a.Equal(testAccResourceElasticIPHealthcheckIntervalUpdated, int64(elasticIP.Healthcheck.Interval.Seconds()))
-						a.Equal(testAccResourceElasticIPHealthcheckModeUpdated, *elasticIP.Healthcheck.Mode)
-						a.Equal(testAccResourceElasticIPHealthcheckPortUpdated, *elasticIP.Healthcheck.Port)
-						a.Equal(testAccResourceElasticIPHealthcheckStrikesFailUpdated, *elasticIP.Healthcheck.StrikesFail)
-						a.Equal(testAccResourceElasticIPHealthcheckStrikesOKUpdated, *elasticIP.Healthcheck.StrikesOK)
-						a.Equal(testAccResourceElasticIPHealthcheckTLSSNI, *elasticIP.Healthcheck.TLSSNI)
-						a.True(*elasticIP.Healthcheck.TLSSkipVerify)
-						a.Equal(testAccResourceElasticIPHealthcheckTimeoutUpdated, int64(elasticIP.Healthcheck.Timeout.Seconds()))
-						a.Equal(testAccResourceElasticIPHealthcheckURIUpdated, *elasticIP.Healthcheck.URI)
+						a.Equal(testAccResourceElasticIPDescriptionUpdated, *elasticIP4.Description)
+						a.NotNil(elasticIP4.Healthcheck)
+						a.Equal(testAccResourceElasticIPHealthcheckIntervalUpdated, int64(elasticIP4.Healthcheck.Interval.Seconds()))
+						a.Equal(testAccResourceElasticIPHealthcheckModeUpdated, *elasticIP4.Healthcheck.Mode)
+						a.Equal(testAccResourceElasticIPHealthcheckPortUpdated, *elasticIP4.Healthcheck.Port)
+						a.Equal(testAccResourceElasticIPHealthcheckStrikesFailUpdated, *elasticIP4.Healthcheck.StrikesFail)
+						a.Equal(testAccResourceElasticIPHealthcheckStrikesOKUpdated, *elasticIP4.Healthcheck.StrikesOK)
+						a.Equal(testAccResourceElasticIPHealthcheckTLSSNI, *elasticIP4.Healthcheck.TLSSNI)
+						a.True(*elasticIP4.Healthcheck.TLSSkipVerify)
+						a.Equal(testAccResourceElasticIPHealthcheckTimeoutUpdated, int64(elasticIP4.Healthcheck.Timeout.Seconds()))
+						a.Equal(testAccResourceElasticIPHealthcheckURIUpdated, *elasticIP4.Healthcheck.URI)
 
 						return nil
 					},
@@ -253,6 +263,7 @@ func TestAccResourceElasticIP(t *testing.T) {
 						resElasticIPAttrAddressFamily:                                         validateString(testAccResourceElasticIPAddressFamily4),
 						resElasticIPAttrCIDR:                                                  validation.ToDiagFunc(validation.IsCIDR),
 						resElasticIPAttrIPAddress:                                             validation.ToDiagFunc(validation.IsIPAddress),
+						resElasticIPAttrReverseDNS:                                            validateString(testAccResourceElasticIPReverseDNS),
 						resElasticIPAttrLabels + ".test":                                      validateString(testAccResourceElasticIPLabelValueUpdated),
 						resElasticIPAttrHealthcheck(resElasticIPAttrHealthcheckInterval):      validateString(fmt.Sprint(testAccResourceElasticIPHealthcheckIntervalUpdated)),
 						resElasticIPAttrHealthcheck(resElasticIPAttrHealthcheckMode):          validateString(testAccResourceElasticIPHealthcheckModeUpdated),
@@ -273,9 +284,9 @@ func TestAccResourceElasticIP(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateIdFunc: func(elasticIP *egoscale.ElasticIP) resource.ImportStateIdFunc {
 					return func(*terraform.State) (string, error) {
-						return fmt.Sprintf("%s@%s", *elasticIP.ID, testZoneName), nil
+						return fmt.Sprintf("%s@%s", *elasticIP4.ID, testZoneName), nil
 					}
-				}(&elasticIP),
+				}(&elasticIP4),
 				ImportStateCheck: func(s []*terraform.InstanceState) error {
 					return checkResourceAttributes(
 						testAttrs{
@@ -283,6 +294,7 @@ func TestAccResourceElasticIP(t *testing.T) {
 							resElasticIPAttrAddressFamily:                                         validateString(testAccResourceElasticIPAddressFamily4),
 							resElasticIPAttrCIDR:                                                  validation.ToDiagFunc(validation.IsCIDR),
 							resElasticIPAttrIPAddress:                                             validation.ToDiagFunc(validation.IsIPAddress),
+							resElasticIPAttrReverseDNS:                                            validateString(testAccResourceElasticIPReverseDNS),
 							resElasticIPAttrLabels + ".test":                                      validateString(testAccResourceElasticIPLabelValueUpdated),
 							resElasticIPAttrHealthcheck(resElasticIPAttrHealthcheckInterval):      validateString(fmt.Sprint(testAccResourceElasticIPHealthcheckIntervalUpdated)),
 							resElasticIPAttrHealthcheck(resElasticIPAttrHealthcheckMode):          validateString(testAccResourceElasticIPHealthcheckModeUpdated),
@@ -303,26 +315,26 @@ func TestAccResourceElasticIP(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviders,
-		CheckDestroy:      testAccCheckResourceElasticIPDestroy(&elasticIP),
+		CheckDestroy:      testAccCheckResourceElasticIPDestroy(&elasticIP6),
 		Steps: []resource.TestStep{
 			{
 				// Create
 				Config: testAccResourceElasticIP6ConfigCreate,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckResourceElasticIPExists(r6, &elasticIP),
+					testAccCheckResourceElasticIPExists(r6, &elasticIP6),
 					func(s *terraform.State) error {
 						a := assert.New(t)
 
-						a.Equal(testAccResourceElasticIPAddressFamily6, *elasticIP.AddressFamily)
-						a.Equal(testAccResourceElasticIPDescription, *elasticIP.Description)
-						a.NotNil(elasticIP.Healthcheck)
-						a.Equal(testAccResourceElasticIPHealthcheckInterval, int64(elasticIP.Healthcheck.Interval.Seconds()))
-						a.Equal(testAccResourceElasticIPHealthcheckMode, *elasticIP.Healthcheck.Mode)
-						a.Equal(testAccResourceElasticIPHealthcheckPort, *elasticIP.Healthcheck.Port)
-						a.Equal(testAccResourceElasticIPHealthcheckStrikesFail, *elasticIP.Healthcheck.StrikesFail)
-						a.Equal(testAccResourceElasticIPHealthcheckStrikesOK, *elasticIP.Healthcheck.StrikesOK)
-						a.Equal(testAccResourceElasticIPHealthcheckTimeout, int64(elasticIP.Healthcheck.Timeout.Seconds()))
-						a.Equal(testAccResourceElasticIPHealthcheckURI, *elasticIP.Healthcheck.URI)
+						a.Equal(testAccResourceElasticIPAddressFamily6, *elasticIP6.AddressFamily)
+						a.Equal(testAccResourceElasticIPDescription, *elasticIP6.Description)
+						a.NotNil(elasticIP6.Healthcheck)
+						a.Equal(testAccResourceElasticIPHealthcheckInterval, int64(elasticIP6.Healthcheck.Interval.Seconds()))
+						a.Equal(testAccResourceElasticIPHealthcheckMode, *elasticIP6.Healthcheck.Mode)
+						a.Equal(testAccResourceElasticIPHealthcheckPort, *elasticIP6.Healthcheck.Port)
+						a.Equal(testAccResourceElasticIPHealthcheckStrikesFail, *elasticIP6.Healthcheck.StrikesFail)
+						a.Equal(testAccResourceElasticIPHealthcheckStrikesOK, *elasticIP6.Healthcheck.StrikesOK)
+						a.Equal(testAccResourceElasticIPHealthcheckTimeout, int64(elasticIP6.Healthcheck.Timeout.Seconds()))
+						a.Equal(testAccResourceElasticIPHealthcheckURI, *elasticIP6.Healthcheck.URI)
 
 						return nil
 					},
@@ -331,6 +343,7 @@ func TestAccResourceElasticIP(t *testing.T) {
 						resElasticIPAttrAddressFamily:                                       validateString(testAccResourceElasticIPAddressFamily6),
 						resElasticIPAttrCIDR:                                                validation.ToDiagFunc(validation.IsCIDR),
 						resElasticIPAttrIPAddress:                                           validation.ToDiagFunc(validation.IsIPAddress),
+						resElasticIPAttrReverseDNS:                                          validateString(testAccResourceElasticIPReverseDNS),
 						resElasticIPAttrLabels + ".test":                                    validateString(testAccResourceElasticIPLabelValue),
 						resElasticIPAttrHealthcheck(resElasticIPAttrHealthcheckInterval):    validateString(fmt.Sprint(testAccResourceElasticIPHealthcheckInterval)),
 						resElasticIPAttrHealthcheck(resElasticIPAttrHealthcheckMode):        validateString(testAccResourceElasticIPHealthcheckMode),
@@ -346,30 +359,31 @@ func TestAccResourceElasticIP(t *testing.T) {
 				// Update
 				Config: testAccResourceElasticIP6ConfigUpdate,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckResourceElasticIPExists(r6, &elasticIP),
+					testAccCheckResourceElasticIPExists(r6, &elasticIP6),
 					func(s *terraform.State) error {
 						a := assert.New(t)
 
-						a.Equal(testAccResourceElasticIPDescriptionUpdated, *elasticIP.Description)
-						a.NotNil(elasticIP.Healthcheck)
-						a.Equal(testAccResourceElasticIPHealthcheckIntervalUpdated, int64(elasticIP.Healthcheck.Interval.Seconds()))
-						a.Equal(testAccResourceElasticIPHealthcheckModeUpdated, *elasticIP.Healthcheck.Mode)
-						a.Equal(testAccResourceElasticIPHealthcheckPortUpdated, *elasticIP.Healthcheck.Port)
-						a.Equal(testAccResourceElasticIPHealthcheckStrikesFailUpdated, *elasticIP.Healthcheck.StrikesFail)
-						a.Equal(testAccResourceElasticIPHealthcheckStrikesOKUpdated, *elasticIP.Healthcheck.StrikesOK)
-						a.Equal(testAccResourceElasticIPHealthcheckTLSSNI, *elasticIP.Healthcheck.TLSSNI)
-						a.True(*elasticIP.Healthcheck.TLSSkipVerify)
-						a.Equal(testAccResourceElasticIPHealthcheckTimeoutUpdated, int64(elasticIP.Healthcheck.Timeout.Seconds()))
-						a.Equal(testAccResourceElasticIPHealthcheckURIUpdated, *elasticIP.Healthcheck.URI)
+						a.Equal(testAccResourceElasticIPDescriptionUpdated, *elasticIP6.Description)
+						a.NotNil(elasticIP6.Healthcheck)
+						a.Equal(testAccResourceElasticIPHealthcheckIntervalUpdated, int64(elasticIP6.Healthcheck.Interval.Seconds()))
+						a.Equal(testAccResourceElasticIPHealthcheckModeUpdated, *elasticIP6.Healthcheck.Mode)
+						a.Equal(testAccResourceElasticIPHealthcheckPortUpdated, *elasticIP6.Healthcheck.Port)
+						a.Equal(testAccResourceElasticIPHealthcheckStrikesFailUpdated, *elasticIP6.Healthcheck.StrikesFail)
+						a.Equal(testAccResourceElasticIPHealthcheckStrikesOKUpdated, *elasticIP6.Healthcheck.StrikesOK)
+						a.Equal(testAccResourceElasticIPHealthcheckTLSSNI, *elasticIP6.Healthcheck.TLSSNI)
+						a.True(*elasticIP6.Healthcheck.TLSSkipVerify)
+						a.Equal(testAccResourceElasticIPHealthcheckTimeoutUpdated, int64(elasticIP6.Healthcheck.Timeout.Seconds()))
+						a.Equal(testAccResourceElasticIPHealthcheckURIUpdated, *elasticIP6.Healthcheck.URI)
 
 						return nil
 					},
 					checkResourceState(r6, checkResourceStateValidateAttributes(testAttrs{
-						resElasticIPAttrDescription:                                           validateString(testAccResourceElasticIPDescriptionUpdated),
-						resElasticIPAttrAddressFamily:                                         validateString(testAccResourceElasticIPAddressFamily6),
-						resElasticIPAttrCIDR:                                                  validation.ToDiagFunc(validation.IsCIDR),
-						resElasticIPAttrIPAddress:                                             validation.ToDiagFunc(validation.IsIPAddress),
-						resElasticIPAttrLabels + ".test":                                      validateString(testAccResourceElasticIPLabelValueUpdated),
+						resElasticIPAttrDescription:   validateString(testAccResourceElasticIPDescriptionUpdated),
+						resElasticIPAttrAddressFamily: validateString(testAccResourceElasticIPAddressFamily6),
+						//resElasticIPAttrReverseDNS:                                            validation.ToDiagFunc(validation.StringIsEmpty),
+						resElasticIPAttrCIDR:             validation.ToDiagFunc(validation.IsCIDR),
+						resElasticIPAttrIPAddress:        validation.ToDiagFunc(validation.IsIPAddress),
+						resElasticIPAttrLabels + ".test": validateString(testAccResourceElasticIPLabelValueUpdated),
 						resElasticIPAttrHealthcheck(resElasticIPAttrHealthcheckInterval):      validateString(fmt.Sprint(testAccResourceElasticIPHealthcheckIntervalUpdated)),
 						resElasticIPAttrHealthcheck(resElasticIPAttrHealthcheckMode):          validateString(testAccResourceElasticIPHealthcheckModeUpdated),
 						resElasticIPAttrHealthcheck(resElasticIPAttrHealthcheckPort):          validateString(fmt.Sprint(testAccResourceElasticIPHealthcheckPortUpdated)),
@@ -389,9 +403,9 @@ func TestAccResourceElasticIP(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateIdFunc: func(elasticIP *egoscale.ElasticIP) resource.ImportStateIdFunc {
 					return func(*terraform.State) (string, error) {
-						return fmt.Sprintf("%s@%s", *elasticIP.ID, testZoneName), nil
+						return fmt.Sprintf("%s@%s", *elasticIP6.ID, testZoneName), nil
 					}
-				}(&elasticIP),
+				}(&elasticIP6),
 				ImportStateCheck: func(s []*terraform.InstanceState) error {
 					return checkResourceAttributes(
 						testAttrs{
@@ -399,6 +413,7 @@ func TestAccResourceElasticIP(t *testing.T) {
 							resElasticIPAttrAddressFamily:                                         validateString(testAccResourceElasticIPAddressFamily6),
 							resElasticIPAttrCIDR:                                                  validation.ToDiagFunc(validation.IsCIDR),
 							resElasticIPAttrIPAddress:                                             validation.ToDiagFunc(validation.IsIPAddress),
+							resElasticIPAttrReverseDNS:                                            validation.ToDiagFunc(validation.StringIsEmpty),
 							resElasticIPAttrLabels + ".test":                                      validateString(testAccResourceElasticIPLabelValueUpdated),
 							resElasticIPAttrHealthcheck(resElasticIPAttrHealthcheckInterval):      validateString(fmt.Sprint(testAccResourceElasticIPHealthcheckIntervalUpdated)),
 							resElasticIPAttrHealthcheck(resElasticIPAttrHealthcheckMode):          validateString(testAccResourceElasticIPHealthcheckModeUpdated),

--- a/go.sum
+++ b/go.sum
@@ -46,8 +46,6 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/go-control-plane v0.10.2-0.20220325020618-49ff273808a1/go.mod h1:KJwIaB5Mv44NWtYuAOFCVOjcI94vtpEz2JU/D2v6IjE=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/exoscale/egoscale v0.91.0 h1:paq7Eap+SzuI+ml/CwwgEPq5mFmOA9fVF/YUParo6Bs=
-github.com/exoscale/egoscale v0.91.0/go.mod h1:BAb9p4rmyU+Wl400CJZO5270H2sXtdsZjLcm5xMKkz4=
 github.com/exoscale/egoscale v0.94.0 h1:ZkOnt+J9k3DB/1NFOIoq2Bp6b259fMrahnrYwauFyjk=
 github.com/exoscale/egoscale v0.94.0/go.mod h1:BAb9p4rmyU+Wl400CJZO5270H2sXtdsZjLcm5xMKkz4=
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=


### PR DESCRIPTION
This PR adds support for setting Reverse DNS in `exoscale_compute_instance` and `exoscale_elastic_ip` resources, as well as reading it in related data sources.

Also extends the acceptance tests timeout from 60 minutes to 90 minutes.