### PR TITLE
Datasource template (replaces compute_template)

### DIFF
--- a/docs/data-sources/template.md
+++ b/docs/data-sources/template.md
@@ -1,27 +1,24 @@
 ---
-page_title: "Exoscale: exoscale_compute_template"
-subcategory: "Deprecated"
+page_title: "Exoscale: exoscale_template"
 description: |-
   Fetch Exoscale Compute Instance Templates data.
 ---
 
-# exoscale\_compute\_template
+# exoscale\_template
 
 Fetch Exoscale [Compute Instance Templates](https://community.exoscale.com/documentation/compute/custom-templates/) data.
-
-!> **WARNING:** This data source is **DEPRECATED** and will be removed in the next major version. Please use [exoscale_template](./template.md) instead.
 
 
 ## Usage
 
 ```hcl
-data "exoscale_compute_template" "my_template" {
+data "exoscale_template" "my_template" {
   zone = "ch-gva-2"
   name = "Linux Ubuntu 22.04 LTS 64-bit"
 }
 
 output "my_template_id" {
-  value = data.exoscale_compute_template.my_template.id
+  value = data.exoscale_template.my_template.id
 }
 ```
 
@@ -36,15 +33,14 @@ directory for complete configuration examples.
 * `zone` - (Required) The Exoscale [Zone][zone] name.
 
 * `id` - The compute instance template ID to match (conflicts with `name`).
-* `name` - The template name to match (conflicts with `id`).
-* `filter` - A template category filter (default: `featured`); among:
-  - `featured` - official Exoscale templates
-  - `community` - community-contributed templates
-  - `mine` - custom templates private to my organization
+* `name` - The template name to match (conflicts with `id`) (when multiple templates have the same name, the newest one will be returned).
+* `visibility` - A template category filter (default: `public`); among:
+  - `public` - official Exoscale templates
+  - `private` - custom templates private to my organization
 
 
 ## Attributes Reference
 
 In addition to the arguments listed above, the following attributes are exported:
 
-* `username` - Username to use to log into a compute instance based on this template
+* `default_user` - Username to use to log into a compute instance based on this template

--- a/exoscale/datasource_exoscale_compute_template_test.go
+++ b/exoscale/datasource_exoscale_compute_template_test.go
@@ -13,7 +13,7 @@ var (
 	testAccDataSourceComputeTemplateName     = testInstanceTemplateName
 	testAccDataSourceComputeTemplateUsername = testInstanceTemplateUsername
 	testAccDataSourceComputeTemplateFilter   = testInstanceTemplateFilter
-	testAccDataSourceTemplateZone            = testZoneName
+	testAccDataSourceComputeTemplateZone     = testZoneName
 )
 
 func TestAccDataSourceComputeTemplate(t *testing.T) {
@@ -26,7 +26,7 @@ func TestAccDataSourceComputeTemplate(t *testing.T) {
 data "exoscale_compute_template" "test" {
   zone = "%s"
 }`,
-					testAccDataSourceTemplateZone),
+					testAccDataSourceComputeTemplateZone),
 				ExpectError: regexp.MustCompile("either name or id must be specified"),
 			},
 			{
@@ -43,7 +43,7 @@ data "exoscale_compute_template" "by_id" {
   filter = data.exoscale_compute_template.by_name.filter
 }
 `,
-					testAccDataSourceTemplateZone,
+					testAccDataSourceComputeTemplateZone,
 					testAccDataSourceComputeTemplateName,
 					testAccDataSourceComputeTemplateFilter,
 				),

--- a/exoscale/datasource_exoscale_template.go
+++ b/exoscale/datasource_exoscale_template.go
@@ -1,0 +1,114 @@
+package exoscale
+
+import (
+	"context"
+	"regexp"
+
+	v2 "github.com/exoscale/egoscale/v2"
+	exoapi "github.com/exoscale/egoscale/v2/api"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+const (
+	dsTemplateAttrDefaultUser = "default_user"
+	dsTemplateAttrID          = "id"
+	dsTemplateAttrName        = "name"
+	dsTemplateAttrVisibility  = "visibility"
+	dsTemplateAttrZone        = "zone"
+)
+
+func dataSourceTemplate() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			dsTemplateAttrZone: {
+				Type:        schema.TypeString,
+				Description: "Name of the zone",
+				Required:    true,
+			},
+			dsTemplateAttrName: {
+				Type:          schema.TypeString,
+				Description:   "Name of the template",
+				Optional:      true,
+				ConflictsWith: []string{"id"},
+			},
+			dsTemplateAttrID: {
+				Type:          schema.TypeString,
+				Description:   "ID of the template",
+				Optional:      true,
+				ConflictsWith: []string{"name"},
+			},
+			dsTemplateAttrVisibility: {
+				Type:        schema.TypeString,
+				Description: "template visibility (public|private)",
+				ValidateFunc: validation.StringMatch(regexp.MustCompile("(?:public|private)"),
+					`must be either "public" or "private"`),
+				Optional: true,
+				Default:  "public",
+			},
+			dsTemplateAttrDefaultUser: {
+				Type:        schema.TypeString,
+				Description: "Template default user",
+				Computed:    true,
+			},
+		},
+
+		ReadContext: dataSourceTemplateRead,
+	}
+}
+
+func dataSourceTemplateRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	tflog.Debug(ctx, "beginning read", map[string]interface{}{
+		"id": resourceIDString(d, "exoscale_template"),
+	})
+
+	zone := d.Get(dsTemplateAttrZone).(string)
+
+	ctx, cancel := context.WithTimeout(ctx, d.Timeout(schema.TimeoutRead))
+	ctx = exoapi.WithEndpoint(ctx, exoapi.NewReqEndpoint(getEnvironment(meta), zone))
+	defer cancel()
+
+	client := GetComputeClient(meta)
+
+	templateID, byTemplateID := d.GetOk(dsTemplateAttrID)
+	templateName, byTemplateName := d.GetOk(dsTemplateAttrName)
+	if !byTemplateID && !byTemplateName {
+		return diag.Errorf(
+			"either %s or %s must be specified",
+			dsTemplateAttrID,
+			dsTemplateAttrName,
+		)
+	}
+	visibility := d.Get(dsTemplateAttrVisibility).(string)
+
+	var template *v2.Template
+	var err error
+	if byTemplateID {
+		template, err = client.GetTemplate(ctx, zone, templateID.(string))
+
+	} else {
+
+		template, err = client.GetTemplateByName(ctx, zone, templateName.(string), visibility)
+	}
+
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(*template.ID)
+
+	if err := d.Set(dsTemplateAttrName, defaultString(template.Name, "")); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set(dsTemplateAttrDefaultUser, defaultString(template.DefaultUser, "")); err != nil {
+		return diag.FromErr(err)
+	}
+
+	tflog.Debug(ctx, "read finished successfully", map[string]interface{}{
+		"id": resourceIDString(d, "exoscale_template"),
+	})
+
+	return nil
+}

--- a/exoscale/datasource_exoscale_template_test.go
+++ b/exoscale/datasource_exoscale_template_test.go
@@ -1,0 +1,68 @@
+package exoscale
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+var (
+	testAccDataSourceTemplateName        = testInstanceTemplateName
+	testAccDataSourceTemplateDefaultUser = testInstanceTemplateUsername
+	testAccDataSourceTemplateVisibility  = testInstanceTemplateVisibility
+	testAccDataSourceTemplateZone        = testZoneName
+	testAccDataSourceTemplateConfig      = fmt.Sprintf(`
+locals {
+  zone = "%s"
+}
+data "exoscale_template" "test" {
+	zone = local.zone
+	name = "%s"
+}
+`,
+		testAccDataSourceTemplateZone,
+		testAccDataSourceTemplateName,
+	)
+)
+
+func TestAccDataSourceTemplate(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      ` data "exoscale_template" "test" { zone = "lolnope" }`,
+				ExpectError: regexp.MustCompile("either id or name must be specified"),
+			},
+			{
+				Config: testAccDataSourceTemplateConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceTemplateAttributes("data.exoscale_template.test", testAttrs{
+						dsTemplateAttrDefaultUser: validateString(testAccDataSourceTemplateDefaultUser),
+						dsTemplateAttrID:          validation.ToDiagFunc(validation.IsUUID),
+						dsTemplateAttrName:        validateString(testAccDataSourceTemplateName),
+						dsTemplateAttrVisibility:  validateString(testAccDataSourceTemplateVisibility),
+						dsTemplateAttrZone:        validateString(testAccDataSourceTemplateZone),
+					}),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceTemplateAttributes(ds string, expected testAttrs) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		for name, res := range s.RootModule().Resources {
+			if name == ds {
+				return checkResourceAttributes(expected, res.Primary.Attributes)
+			}
+		}
+
+		return errors.New("exoscale_template data source not found in the state")
+	}
+}

--- a/exoscale/provider.go
+++ b/exoscale/provider.go
@@ -153,6 +153,7 @@ func Provider() *schema.Provider {
 			"exoscale_nlb":                   dataSourceNLB(),
 			"exoscale_private_network":       dataSourcePrivateNetwork(),
 			"exoscale_security_group":        dataSourceSecurityGroup(),
+			"exoscale_template":              dataSourceTemplate(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{

--- a/exoscale/provider_test.go
+++ b/exoscale/provider_test.go
@@ -17,12 +17,13 @@ import (
 
 // Common test environment information
 const (
-	testPrefix                   = "test-terraform-exoscale"
-	testDescription              = "Created by the terraform-exoscale provider"
-	testZoneName                 = "ch-dk-2"
-	testInstanceTemplateName     = "Linux Ubuntu 20.04 LTS 64-bit"
-	testInstanceTemplateUsername = "ubuntu"
-	testInstanceTemplateFilter   = "featured"
+	testPrefix                     = "test-terraform-exoscale"
+	testDescription                = "Created by the terraform-exoscale provider"
+	testZoneName                   = "ch-dk-2"
+	testInstanceTemplateName       = "Linux Ubuntu 20.04 LTS 64-bit"
+	testInstanceTemplateUsername   = "ubuntu"
+	testInstanceTemplateFilter     = "featured"
+	testInstanceTemplateVisibility = "public"
 
 	testInstanceTypeIDTiny   = "b6cd1ff5-3a2f-4e9d-a4d1-8988c1191fe8"
 	testInstanceTypeIDSmall  = "21624abb-764e-4def-81d7-9fc54b5957fb"

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/exoscale/terraform-provider-exoscale
 
 require (
-	github.com/exoscale/egoscale v0.91.0
+	github.com/exoscale/egoscale v0.94.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/go-retryablehttp v0.7.1

--- a/go.sum
+++ b/go.sum
@@ -48,6 +48,8 @@ github.com/envoyproxy/go-control-plane v0.10.2-0.20220325020618-49ff273808a1/go.
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/exoscale/egoscale v0.91.0 h1:paq7Eap+SzuI+ml/CwwgEPq5mFmOA9fVF/YUParo6Bs=
 github.com/exoscale/egoscale v0.91.0/go.mod h1:BAb9p4rmyU+Wl400CJZO5270H2sXtdsZjLcm5xMKkz4=
+github.com/exoscale/egoscale v0.94.0 h1:ZkOnt+J9k3DB/1NFOIoq2Bp6b259fMrahnrYwauFyjk=
+github.com/exoscale/egoscale v0.94.0/go.mod h1:BAb9p4rmyU+Wl400CJZO5270H2sXtdsZjLcm5xMKkz4=
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=

--- a/vendor/github.com/exoscale/egoscale/CHANGELOG.md
+++ b/vendor/github.com/exoscale/egoscale/CHANGELOG.md
@@ -1,6 +1,22 @@
 Changelog
 =========
 
+0.94.0
+------
+
+- feature: v2: add `Client.GetTemplateByName()` method
+- feature: v2: implement sort.Interface for []*Template by CreatedAt or by Nane
+
+0.93.0
+------
+
+- feature: v2: implement publicIpAssignment for Instances
+
+0.92.0
+------
+
+- feature: v2: implement reverse DNS management
+
 0.91.0
 ------
 

--- a/vendor/github.com/exoscale/egoscale/v2/client_mock.go
+++ b/vendor/github.com/exoscale/egoscale/v2/client_mock.go
@@ -1101,3 +1101,59 @@ func (m *oapiClientMock) UpdateDnsDomainRecordWithResponse(
 	args := m.Called(ctx, domainId, recordId, body, reqEditors)
 	return args.Get(0).(*oapi.UpdateDnsDomainRecordResponse), args.Error(1)
 }
+
+func (m *oapiClientMock) GetReverseDnsInstanceWithResponse(
+	ctx context.Context,
+	id string,
+	reqEditors ...oapi.RequestEditorFn,
+) (*oapi.GetReverseDnsInstanceResponse, error) {
+	args := m.Called(ctx, id, reqEditors)
+	return args.Get(0).(*oapi.GetReverseDnsInstanceResponse), args.Error(1)
+}
+
+func (m *oapiClientMock) DeleteReverseDnsInstanceWithResponse(
+	ctx context.Context,
+	id string,
+	reqEditors ...oapi.RequestEditorFn,
+) (*oapi.DeleteReverseDnsInstanceResponse, error) {
+	args := m.Called(ctx, id, reqEditors)
+	return args.Get(0).(*oapi.DeleteReverseDnsInstanceResponse), args.Error(1)
+}
+
+func (m *oapiClientMock) UpdateReverseDnsInstanceWithResponse(
+	ctx context.Context,
+	id string,
+	body oapi.UpdateReverseDnsInstanceJSONRequestBody,
+	reqEditors ...oapi.RequestEditorFn,
+) (*oapi.UpdateReverseDnsInstanceResponse, error) {
+	args := m.Called(ctx, id, body, reqEditors)
+	return args.Get(0).(*oapi.UpdateReverseDnsInstanceResponse), args.Error(1)
+}
+
+func (m *oapiClientMock) GetReverseDnsElasticIpWithResponse(
+	ctx context.Context,
+	id string,
+	reqEditors ...oapi.RequestEditorFn,
+) (*oapi.GetReverseDnsElasticIpResponse, error) {
+	args := m.Called(ctx, id, reqEditors)
+	return args.Get(0).(*oapi.GetReverseDnsElasticIpResponse), args.Error(1)
+}
+
+func (m *oapiClientMock) DeleteReverseDnsElasticIpWithResponse(
+	ctx context.Context,
+	id string,
+	reqEditors ...oapi.RequestEditorFn,
+) (*oapi.DeleteReverseDnsElasticIpResponse, error) {
+	args := m.Called(ctx, id, reqEditors)
+	return args.Get(0).(*oapi.DeleteReverseDnsElasticIpResponse), args.Error(1)
+}
+
+func (m *oapiClientMock) UpdateReverseDnsElasticIpWithResponse(
+	ctx context.Context,
+	id string,
+	body oapi.UpdateReverseDnsElasticIpJSONRequestBody,
+	reqEditors ...oapi.RequestEditorFn,
+) (*oapi.UpdateReverseDnsElasticIpResponse, error) {
+	args := m.Called(ctx, id, body, reqEditors)
+	return args.Get(0).(*oapi.UpdateReverseDnsElasticIpResponse), args.Error(1)
+}

--- a/vendor/github.com/exoscale/egoscale/v2/instance.go
+++ b/vendor/github.com/exoscale/egoscale/v2/instance.go
@@ -31,6 +31,7 @@ type Instance struct {
 	Name                 *string `req-for:"create"`
 	PrivateNetworkIDs    *[]string
 	PublicIPAddress      *net.IP
+	PublicIPAssignment   *string
 	SSHKey               *string
 	SecurityGroupIDs     *[]string
 	SnapshotIDs          *[]string
@@ -187,6 +188,7 @@ func instanceFromAPI(i *oapi.Instance, zone string) *Instance {
 			}
 			return
 		}(),
+		PublicIPAssignment: (*string)(i.PublicIpAssignment),
 		SSHKey: func() (v *string) {
 			if i.SshKey != nil {
 				v = i.SshKey.Name
@@ -359,7 +361,8 @@ func (c *Client) CreateInstance(ctx context.Context, zone string, instance *Inst
 				}
 				return
 			}(),
-			Name: instance.Name,
+			Name:               instance.Name,
+			PublicIpAssignment: (*oapi.PublicIpAssignment)(instance.PublicIPAssignment),
 			SecurityGroups: func() (v *[]oapi.SecurityGroup) {
 				if instance.SecurityGroupIDs != nil {
 					ids := make([]oapi.SecurityGroup, len(*instance.SecurityGroupIDs))
@@ -813,6 +816,62 @@ func (c *Client) UpdateInstance(ctx context.Context, zone string, instance *Inst
 			Name:     instance.Name,
 			UserData: instance.UserData,
 		})
+	if err != nil {
+		return err
+	}
+
+	_, err = oapi.NewPoller().
+		WithTimeout(c.timeout).
+		WithInterval(c.pollInterval).
+		Poll(ctx, oapi.OperationPoller(c, zone, *resp.JSON200.Id))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// GetInstanceReverseDNS returns the Reverse DNS record corresponding to the specified Instance ID.
+func (c *Client) GetInstanceReverseDNS(ctx context.Context, zone, id string) (string, error) {
+	resp, err := c.GetReverseDnsInstanceWithResponse(apiv2.WithZone(ctx, zone), id)
+	if err != nil {
+		return "", err
+	}
+
+	if resp.JSON200 == nil || resp.JSON200.DomainName == nil {
+		return "", apiv2.ErrNotFound
+	}
+
+	return string(*resp.JSON200.DomainName), nil
+}
+
+// DeleteInstanceReverseDNS deletes a Reverse DNS record of a Compute Instance.
+func (c *Client) DeleteInstanceReverseDNS(ctx context.Context, zone string, id string) error {
+	resp, err := c.DeleteReverseDnsInstanceWithResponse(apiv2.WithZone(ctx, zone), id)
+	if err != nil {
+		return err
+	}
+
+	_, err = oapi.NewPoller().
+		WithTimeout(c.timeout).
+		WithInterval(c.pollInterval).
+		Poll(ctx, oapi.OperationPoller(c, zone, *resp.JSON200.Id))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// UpdateInstanceReverseDNS updates a Reverse DNS record for a Compute Instance.
+func (c *Client) UpdateInstanceReverseDNS(ctx context.Context, zone, id, domain string) error {
+	resp, err := c.UpdateReverseDnsInstanceWithResponse(
+		apiv2.WithZone(ctx, zone),
+		id,
+		oapi.UpdateReverseDnsInstanceJSONRequestBody{
+			DomainName: &domain,
+		},
+	)
 	if err != nil {
 		return err
 	}

--- a/vendor/github.com/exoscale/egoscale/version/version.go
+++ b/vendor/github.com/exoscale/egoscale/version/version.go
@@ -2,4 +2,4 @@
 package version
 
 // Version represents the current egoscale version.
-const Version = "0.90.2"
+const Version = "0.94.0"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -14,7 +14,7 @@ github.com/davecgh/go-spew/spew
 ## explicit; go 1.16
 github.com/deepmap/oapi-codegen/pkg/runtime
 github.com/deepmap/oapi-codegen/pkg/types
-# github.com/exoscale/egoscale v0.91.0
+# github.com/exoscale/egoscale v0.94.0
 ## explicit; go 1.17
 github.com/exoscale/egoscale
 github.com/exoscale/egoscale/v2


### PR DESCRIPTION
- Deprecate datasource `exoscale_compute_template` in favor of `exoscale_template` (APIv2)

exoscale_template
```
make GO_TEST_EXTRA_ARGS="-v -run ^TestAccDataSourceTemplate$" test-acc
TF_ACC=1 /usr/local/goroots/go/bin/go test                      \
        -race                   \
        -timeout=60m            \
        -tags=testacc           \
        -v -run ^TestAccDataSourceTemplate$   \
        github.com/exoscale/terraform-provider-exoscale/exoscale
=== RUN   TestAccDataSourceTemplate
--- PASS: TestAccDataSourceTemplate (2.29s)
PASS
ok      github.com/exoscale/terraform-provider-exoscale/exoscale        2.342s

```
exoscale_compute_template
```
make GO_TEST_EXTRA_ARGS="-v -run ^TestAccDataSourceComputeTemplate$" test-acc
TF_ACC=1 /usr/local/goroots/go/bin/go test                      \
        -race                   \
        -timeout=60m            \
        -tags=testacc           \
        -v -run ^TestAccDataSourceComputeTemplate$   \
        github.com/exoscale/terraform-provider-exoscale/exoscale
=== RUN   TestAccDataSourceComputeTemplate
--- PASS: TestAccDataSourceComputeTemplate (5.00s)
PASS
ok      github.com/exoscale/terraform-provider-exoscale/exoscale        5.056s


```