### PR TITLE
acc-test: extends the acceptance tests timeout from 60 minutes to 90 …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ test-acc: GO_TEST_EXTRA_ARGS=-v $(EXTRA_ARGS)
 test-acc: ## Runs acceptance tests (requires valid Exoscale API credentials)
 	TF_ACC=1 $(GO) test			\
 		-race                   \
-		-timeout=60m            \
+		-timeout=90m            \
 		-tags=testacc           \
 		$(GO_TEST_EXTRA_ARGS)   \
 		$(GO_TEST_PKGS)


### PR DESCRIPTION
Extends the acceptance tests timeout from 60 minutes to 90 minutes