### PR TITLE
resource elastic_ip: healthcheck config could be updated

### DIFF
--- a/docs/resources/elastic_ip.md
+++ b/docs/resources/elastic_ip.md
@@ -57,7 +57,7 @@ directory for complete configuration examples.
 * `address_family` - The Elastic IP (EIP) address family (`inet4` or `inet6`; default: `inet4`).
 * `labels` - A map of key/value labels.
 * `reverse_dns` - Domain name for reverse DNS record.
-* `healthcheck` - (Block) Healthcheck configuration for *managed* EIPs. Structure is documented below.
+* `healthcheck` - (Block) Healthcheck configuration for *managed* EIPs. It can not be added to an existing *Unmanaged* EIP. Structure is documented below:
 
 ### `healthcheck` block
 

--- a/exoscale/resource_exoscale_elastic_ip.go
+++ b/exoscale/resource_exoscale_elastic_ip.go
@@ -56,7 +56,6 @@ func resourceElasticIP() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 				Optional: true,
-				ForceNew: true,
 			},
 			"healthcheck": {
 				Type:     schema.TypeList,
@@ -321,18 +320,63 @@ func resourceElasticIPUpdate(ctx context.Context, d *schema.ResourceData, meta i
 		updated = true
 	}
 
-	if d.HasChange(resElasticIPAttrAddressFamily) {
-		v := d.Get(resElasticIPAttrAddressFamily).(string)
-		if v != "" {
-			elasticIP.AddressFamily = &v
-		}
-		// note that nil value is also considered change
-		updated = true
-	}
-
 	if d.HasChange(resElasticIPAttrDescription) {
 		v := d.Get(resElasticIPAttrDescription).(string)
 		elasticIP.Description = &v
+		updated = true
+	}
+
+	if d.HasChange(resElasticIPAttrHealthcheck(resElasticIPAttrHealthcheckMode)) {
+		v := d.Get(resElasticIPAttrHealthcheck(resElasticIPAttrHealthcheckMode)).(string)
+		elasticIP.Healthcheck.Mode = &v
+		updated = true
+	}
+
+	if d.HasChange(resElasticIPAttrHealthcheck(resElasticIPAttrHealthcheckPort)) {
+		v := uint16(d.Get(resElasticIPAttrHealthcheck(resElasticIPAttrHealthcheckPort)).(int))
+		elasticIP.Healthcheck.Port = &v
+		updated = true
+	}
+
+	if d.HasChange(resElasticIPAttrHealthcheck(resElasticIPAttrHealthcheckInterval)) {
+		v := time.Duration(d.Get(resElasticIPAttrHealthcheck(resElasticIPAttrHealthcheckInterval)).(int)) * time.Second
+		elasticIP.Healthcheck.Interval = &v
+		updated = true
+	}
+
+	if d.HasChange(resElasticIPAttrHealthcheck(resElasticIPAttrHealthcheckStrikesFail)) {
+		v := int64(d.Get(resElasticIPAttrHealthcheck(resElasticIPAttrHealthcheckStrikesFail)).(int))
+		elasticIP.Healthcheck.StrikesFail = &v
+		updated = true
+	}
+
+	if d.HasChange(resElasticIPAttrHealthcheck(resElasticIPAttrHealthcheckStrikesOK)) {
+		v := int64(d.Get(resElasticIPAttrHealthcheck(resElasticIPAttrHealthcheckStrikesOK)).(int))
+		elasticIP.Healthcheck.StrikesOK = &v
+		updated = true
+	}
+
+	if d.HasChange(resElasticIPAttrHealthcheck(resElasticIPAttrHealthcheckTimeout)) {
+		v := time.Duration(d.Get(resElasticIPAttrHealthcheck(resElasticIPAttrHealthcheckTimeout)).(int)) * time.Second
+		elasticIP.Healthcheck.Timeout = &v
+		updated = true
+	}
+
+	if d.HasChange(resElasticIPAttrHealthcheck(resElasticIPAttrHealthcheckTLSSNI)) {
+		v := d.Get(resElasticIPAttrHealthcheck(resElasticIPAttrHealthcheckTLSSNI)).(string)
+		elasticIP.Healthcheck.TLSSNI = &v
+		updated = true
+	}
+
+	if d.HasChange(resElasticIPAttrHealthcheck(resElasticIPAttrHealthcheckTLSSkipVerify)) {
+		v := d.Get(resElasticIPAttrHealthcheck(resElasticIPAttrHealthcheckTLSSkipVerify)).(bool)
+		elasticIP.Healthcheck.TLSSkipVerify = &v
+		updated = true
+	}
+
+	if d.HasChange(resElasticIPAttrHealthcheck(resElasticIPAttrHealthcheckURI)) {
+		v := d.Get(resElasticIPAttrHealthcheck(resElasticIPAttrHealthcheckURI)).(string)
+		elasticIP.Healthcheck.URI = &v
 		updated = true
 	}
 

--- a/exoscale/resource_exoscale_elastic_ip_test.go
+++ b/exoscale/resource_exoscale_elastic_ip_test.go
@@ -108,7 +108,45 @@ resource "exoscale_elastic_ip" "test4" {
 		testAccResourceElasticIPReverseDNS,
 		testAccResourceElasticIPLabelValueUpdated,
 	)
+	// Change address_family (replace the existing resource)
+	testAccResourceElasticIP4ConfigUpdate2 = fmt.Sprintf(`
+resource "exoscale_elastic_ip" "test4" {
+  zone        = "%s"
+  description = "%s"
+  address_family = "%s"
+  healthcheck {
+    mode            = "%s"
+    port            = %d
+    uri             = "%s"
+    interval        = %d
+    timeout         = %d
+    strikes_ok      = %d
+    strikes_fail    = %d
+    tls_sni         = "%s"
+    tls_skip_verify = true
+  }
 
+	reverse_dns = "%s"
+
+  labels = {
+    test = "%s"
+  }
+}
+`,
+		testZoneName,
+		testAccResourceElasticIPDescriptionUpdated,
+		testAccResourceElasticIPAddressFamily6,
+		testAccResourceElasticIPHealthcheckModeUpdated,
+		testAccResourceElasticIPHealthcheckPortUpdated,
+		testAccResourceElasticIPHealthcheckURIUpdated,
+		testAccResourceElasticIPHealthcheckIntervalUpdated,
+		testAccResourceElasticIPHealthcheckTimeoutUpdated,
+		testAccResourceElasticIPHealthcheckStrikesOKUpdated,
+		testAccResourceElasticIPHealthcheckStrikesFailUpdated,
+		testAccResourceElasticIPHealthcheckTLSSNI,
+		testAccResourceElasticIPReverseDNS,
+		testAccResourceElasticIPLabelValueUpdated,
+	)
 	testAccResourceElasticIP6ConfigCreate = fmt.Sprintf(`
 resource "exoscale_elastic_ip" "test6" {
   zone        = "%s"
@@ -192,7 +230,7 @@ func TestAccResourceElasticIP(t *testing.T) {
 		r6          = "exoscale_elastic_ip.test6"
 		elasticIP4  egoscale.ElasticIP
 		elasticIP6  egoscale.ElasticIP
-		ElasticIPID string // After the update of healtcheck, ID must be the same
+		ElasticIPID string // After the update of healthcheck, ID must be the same
 	)
 
 	resource.Test(t, resource.TestCase{
@@ -239,7 +277,7 @@ func TestAccResourceElasticIP(t *testing.T) {
 				),
 			},
 			{
-				// Update
+				// Update Healthcheck and description (update the resource)
 				Config: testAccResourceElasticIP4ConfigUpdate,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceElasticIPExists(r4, &elasticIP4),
@@ -311,6 +349,48 @@ func TestAccResourceElasticIP(t *testing.T) {
 						},
 						s[0].Attributes)
 				},
+			},
+			{
+				// Update Address Family (new resource)
+				Config: testAccResourceElasticIP4ConfigUpdate2,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckResourceElasticIPExists(r4, &elasticIP6),
+					func(s *terraform.State) error {
+						a := assert.New(t)
+
+						a.Equal(testAccResourceElasticIPDescriptionUpdated, *elasticIP6.Description)
+						a.NotEqual(ElasticIPID, *elasticIP6.ID)
+						a.NotNil(elasticIP6.Healthcheck)
+						a.Equal(testAccResourceElasticIPHealthcheckIntervalUpdated, int64(elasticIP6.Healthcheck.Interval.Seconds()))
+						a.Equal(testAccResourceElasticIPHealthcheckModeUpdated, *elasticIP6.Healthcheck.Mode)
+						a.Equal(testAccResourceElasticIPHealthcheckPortUpdated, *elasticIP6.Healthcheck.Port)
+						a.Equal(testAccResourceElasticIPHealthcheckStrikesFailUpdated, *elasticIP6.Healthcheck.StrikesFail)
+						a.Equal(testAccResourceElasticIPHealthcheckStrikesOKUpdated, *elasticIP6.Healthcheck.StrikesOK)
+						a.Equal(testAccResourceElasticIPHealthcheckTLSSNI, *elasticIP6.Healthcheck.TLSSNI)
+						a.True(*elasticIP6.Healthcheck.TLSSkipVerify)
+						a.Equal(testAccResourceElasticIPHealthcheckTimeoutUpdated, int64(elasticIP6.Healthcheck.Timeout.Seconds()))
+						a.Equal(testAccResourceElasticIPHealthcheckURIUpdated, *elasticIP6.Healthcheck.URI)
+
+						return nil
+					},
+					checkResourceState(r4, checkResourceStateValidateAttributes(testAttrs{
+						resElasticIPAttrDescription:                                           validateString(testAccResourceElasticIPDescriptionUpdated),
+						resElasticIPAttrAddressFamily:                                         validateString(testAccResourceElasticIPAddressFamily6),
+						resElasticIPAttrCIDR:                                                  validation.ToDiagFunc(validation.IsCIDR),
+						resElasticIPAttrIPAddress:                                             validation.ToDiagFunc(validation.IsIPAddress),
+						resElasticIPAttrReverseDNS:                                            validateString(testAccResourceElasticIPReverseDNS),
+						resElasticIPAttrLabels + ".test":                                      validateString(testAccResourceElasticIPLabelValueUpdated),
+						resElasticIPAttrHealthcheck(resElasticIPAttrHealthcheckInterval):      validateString(fmt.Sprint(testAccResourceElasticIPHealthcheckIntervalUpdated)),
+						resElasticIPAttrHealthcheck(resElasticIPAttrHealthcheckMode):          validateString(testAccResourceElasticIPHealthcheckModeUpdated),
+						resElasticIPAttrHealthcheck(resElasticIPAttrHealthcheckPort):          validateString(fmt.Sprint(testAccResourceElasticIPHealthcheckPortUpdated)),
+						resElasticIPAttrHealthcheck(resElasticIPAttrHealthcheckStrikesFail):   validateString(fmt.Sprint(testAccResourceElasticIPHealthcheckStrikesFailUpdated)),
+						resElasticIPAttrHealthcheck(resElasticIPAttrHealthcheckStrikesOK):     validateString(fmt.Sprint(testAccResourceElasticIPHealthcheckStrikesOKUpdated)),
+						resElasticIPAttrHealthcheck(resElasticIPAttrHealthcheckTLSSNI):        validateString(testAccResourceElasticIPHealthcheckTLSSNI),
+						resElasticIPAttrHealthcheck(resElasticIPAttrHealthcheckTLSSkipVerify): validateString("true"),
+						resElasticIPAttrHealthcheck(resElasticIPAttrHealthcheckTimeout):       validateString(fmt.Sprint(testAccResourceElasticIPHealthcheckTimeoutUpdated)),
+						resElasticIPAttrHealthcheck(resElasticIPAttrHealthcheckURI):           validateString(testAccResourceElasticIPHealthcheckURIUpdated),
+					})),
+				),
 			},
 		},
 	})

--- a/exoscale/resource_exoscale_elastic_ip_test.go
+++ b/exoscale/resource_exoscale_elastic_ip_test.go
@@ -188,10 +188,11 @@ resource "exoscale_elastic_ip" "test6" {
 
 func TestAccResourceElasticIP(t *testing.T) {
 	var (
-		r4         = "exoscale_elastic_ip.test4"
-		r6         = "exoscale_elastic_ip.test6"
-		elasticIP4 egoscale.ElasticIP
-		elasticIP6 egoscale.ElasticIP
+		r4          = "exoscale_elastic_ip.test4"
+		r6          = "exoscale_elastic_ip.test6"
+		elasticIP4  egoscale.ElasticIP
+		elasticIP6  egoscale.ElasticIP
+		ElasticIPID string // After the update of healtcheck, ID must be the same
 	)
 
 	resource.Test(t, resource.TestCase{
@@ -217,6 +218,7 @@ func TestAccResourceElasticIP(t *testing.T) {
 						a.Equal(testAccResourceElasticIPHealthcheckStrikesOK, *elasticIP4.Healthcheck.StrikesOK)
 						a.Equal(testAccResourceElasticIPHealthcheckTimeout, int64(elasticIP4.Healthcheck.Timeout.Seconds()))
 						a.Equal(testAccResourceElasticIPHealthcheckURI, *elasticIP4.Healthcheck.URI)
+						ElasticIPID = *elasticIP4.ID
 
 						return nil
 					},
@@ -245,6 +247,7 @@ func TestAccResourceElasticIP(t *testing.T) {
 						a := assert.New(t)
 
 						a.Equal(testAccResourceElasticIPDescriptionUpdated, *elasticIP4.Description)
+						a.Equal(ElasticIPID, *elasticIP4.ID)
 						a.NotNil(elasticIP4.Healthcheck)
 						a.Equal(testAccResourceElasticIPHealthcheckIntervalUpdated, int64(elasticIP4.Healthcheck.Interval.Seconds()))
 						a.Equal(testAccResourceElasticIPHealthcheckModeUpdated, *elasticIP4.Healthcheck.Mode)


### PR DESCRIPTION
- description could be updated (it was replaced previously)
- address_family can not be updated (ForceNew=true)
- healtcheck attributes could be updated 
- update `elastic_ip` test to validate the update of the resource (we used to recreate it before because we changed the description)   

```
make GO_TEST_EXTRA_ARGS="-v -run ^TestAccResourceElasticIP$" test-acc
TF_ACC=1 /usr/local/goroots/go/bin/go test                      \
        -race                   \
        -timeout=90m            \
        -tags=testacc           \
        -v -run ^TestAccResourceElasticIP$   \
        github.com/exoscale/terraform-provider-exoscale/exoscale
=== RUN   TestAccResourceElasticIP
--- PASS: TestAccResourceElasticIP (41.70s)
PASS
ok      github.com/exoscale/terraform-provider-exoscale/exoscale        41.761s


```