### PR TITLE
Remove nested imports from resources domain and security group

### DIFF
--- a/docs/guides/migration-of-security-group-rules.md
+++ b/docs/guides/migration-of-security-group-rules.md
@@ -13,10 +13,9 @@ This page helps you migrate from an `exoscale_security_group_rules` resource (wh
 ~> **Note:** Before migrating `exoscale_security_group_rules` resources you need to ensure you use the latest version of Terraform and have a clean configuration.
 
 Before proceeding, please:
-- Upgrade Terraform to at least v1.1.x: allows us to easily refactor definitions thanks to `moved {}` blocks.
-- Upgrade the Exoscale provider to at least v0.31.3: allow us to run [`terraform import`](https://www.terraform.io/docs/commands/import.html) on `exoscale_security_group` resources. 
+- Upgrade the Exoscale provider to at least v0.31.3: allow us to run [`terraform import`](https://www.terraform.io/docs/commands/import.html) on `exoscale_security_group` and `exoscale_security_group_rule` resources. 
 - Ensure your configuration can be successfully applied: [`terraform plan`](https://www.terraform.io/docs/commands/plan.html) must NOT output errors, changes, or moves of resources
-- Have the [Exoscale cli](https://github.com/exoscale/cli/) to retrieve IDs of security groups (optional, as you can also retrieve this information from the [`Exoscale portal`](https://portal.exoscale.com/login)).
+- Have the [Exoscale cli](https://github.com/exoscale/cli/) to retrieve IDs of security groups and security group rules
 - Perform a backup of your state! We are going to manipulate it, and errors can always happen. Remote states can be retrieved with [`terraform state pull` and restored with `terraform state push`](https://www.terraform.io/cli/state/recover). If you keep your state as a single local file, a regular file copy can do the job.
 
 ## Example configuration
@@ -94,14 +93,7 @@ To achieve this migration, we have to remove from the state:
 - `exoscale_security_group.webapp`
 - **ALL rules** that belongs to `exoscale_security_group.webapp`. In our case: `exoscale_security_group_rules.webapp`
 
-After these resources are removed from the state, we will have to import `exoscale_security_group.webapp` back.
-The import process will also automatically import related security group rules as `exoscale_security_group_rule` resources.
-The name for rules will be the same as the security group, suffixed with a number except for the first one.
-In our case, we have 3 rules, and the security group has `webapp` as a name, so we will have `exoscale_security_group_rule` 
-resources imported as `webapp`, `webapp-1`, and `webapp-2`.
-
-Just after the import process, we will have to adjust the configuration to reflect the real infrastructure.
-Thanks to `moved {}` blocks we will be able to easily move `security_group_rule` resources to whatever name we want. 
+After these resources are removed from the state, we will have to import `exoscale_security_group.webapp` back as well as related security group rules as `exoscale_security_group_rule` resources.
 
 ## Applying the migration plan
 
@@ -123,155 +115,6 @@ terraform state rm exoscale_security_group.webapp
 ```
 
 Now, these resources are removed from the state.
-
-### Importing the security group and related rules into the state
-
-Using the [Exoscale cli](https://github.com/exoscale/cli/) or the [`Exoscale portal`](https://portal.exoscale.com/login), we can find the ID of the webapp security group:
-
-```bash
-exo compute sg list
-# [output]
-# ┼──────────────────────────────────────┼─────────┼
-# │                  ID                  │  NAME   │
-# ┼──────────────────────────────────────┼─────────┼
-# │ b83fe506-51e6-4933-8e70-205df6b640fa │ webapp  │
-# │ e1654b58-64f6-4efc-b8d9-7bbda86a83fa │ bastion │
-# │ a0191fd7-1275-4614-9fed-be6f19a770a0 │ default │
-# ┼──────────────────────────────────────┼─────────┼
-```
-
-In our case, it's `b83fe506-51e6-4933-8e70-205df6b640fa`. Let's import this resource:
-
-```bash
-terraform import exoscale_security_group.webapp b83fe506-51e6-4933-8e70-205df6b640fa
-# [output]
-# exoscale_security_group.webapp: Importing from ID "b83fe506-51e6-4933-8e70-205df6b640fa"...
-# exoscale_security_group.webapp: Import prepared!
-#   Prepared exoscale_security_group for import
-#   Prepared exoscale_security_group_rule for import
-#   Prepared exoscale_security_group_rule for import
-#   Prepared exoscale_security_group_rule for import
-# exoscale_security_group.webapp: Refreshing state... [id=b83fe506-51e6-4933-8e70-205df6b640fa]
-# exoscale_security_group_rule.webapp-1: Refreshing state... [id=e7bbda2b-3c93-4693-a54c-465ac28bda59]
-# exoscale_security_group_rule.webapp: Refreshing state... [id=5dafa58d-ba4d-4990-b66d-2996782ee3f3]
-# exoscale_security_group_rule.webapp-2: Refreshing state... [id=0a187bd0-b5dc-4a58-bab2-44bc7064b83b]
-#
-# Import successful!
-#
-# The resources that were imported are shown above. These resources are now in
-# your Terraform state and will henceforth be managed by Terraform.
-```
-
-As you can see, and as expected, the import process imported not only `exoscale_security_group.webapp` but also related rules as `exoscale_security_group_rule` resources: `webapp`, `webapp-1`, and `webapp-2`.
-In order to check this result and display details on newly imported rules, we have to run [`terraform plan`](https://www.terraform.io/docs/commands/plan.html):
-
-```bash
-terraform plan
-# [output]                                                                      
-# exoscale_security_group.bastion: Refreshing state... [id=e1654b58-64f6-4efc-b8d9-7bbda86a83fa]
-# exoscale_security_group.webapp: Refreshing state... [id=b83fe506-51e6-4933-8e70-205df6b640fa]
-# exoscale_security_group_rule.webapp-1: Refreshing state... [id=e7bbda2b-3c93-4693-a54c-465ac28bda59]
-# exoscale_security_group_rule.webapp: Refreshing state... [id=5dafa58d-ba4d-4990-b66d-2996782ee3f3]
-# exoscale_security_group_rule.webapp-2: Refreshing state... [id=0a187bd0-b5dc-4a58-bab2-44bc7064b83b]
-#
-# Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
-#   + create
-#   - destroy
-#
-# Terraform will perform the following actions:
-#
-#   # exoscale_security_group_rule.webapp will be destroyed
-#   # (because exoscale_security_group_rule.webapp is not in configuration)
-#   - resource "exoscale_security_group_rule" "webapp" {
-#       - end_port               = 22 -> null
-#       - id                     = "5dafa58d-ba4d-4990-b66d-2996782ee3f3" -> null
-#       - protocol               = "TCP" -> null
-#       - security_group         = "webapp" -> null
-#       - security_group_id      = "b83fe506-51e6-4933-8e70-205df6b640fa" -> null
-#       - start_port             = 22 -> null
-#       - type                   = "INGRESS" -> null
-#       - user_security_group    = "bastion" -> null
-#       - user_security_group_id = "e1654b58-64f6-4efc-b8d9-7bbda86a83fa" -> null
-#
-#       - timeouts {}
-#     }
-#
-#   # exoscale_security_group_rule.webapp-1 will be destroyed
-#   # (because exoscale_security_group_rule.webapp-1 is not in configuration)
-#   - resource "exoscale_security_group_rule" "webapp-1" {
-#       - cidr              = "0.0.0.0/0" -> null
-#       - end_port          = 443 -> null
-#       - id                = "e7bbda2b-3c93-4693-a54c-465ac28bda59" -> null
-#       - protocol          = "TCP" -> null
-#       - security_group    = "webapp" -> null
-#       - security_group_id = "b83fe506-51e6-4933-8e70-205df6b640fa" -> null
-#       - start_port        = 443 -> null
-#       - type              = "INGRESS" -> null
-#
-#       - timeouts {}
-#     }
-#
-#   # exoscale_security_group_rule.webapp-2 will be destroyed
-#   # (because exoscale_security_group_rule.webapp-2 is not in configuration)
-#   - resource "exoscale_security_group_rule" "webapp-2" {
-#       - cidr              = "0.0.0.0/0" -> null
-#       - end_port          = 80 -> null
-#       - id                = "0a187bd0-b5dc-4a58-bab2-44bc7064b83b" -> null
-#       - protocol          = "TCP" -> null
-#       - security_group    = "webapp" -> null
-#       - security_group_id = "b83fe506-51e6-4933-8e70-205df6b640fa" -> null
-#       - start_port        = 80 -> null
-#       - type              = "INGRESS" -> null
-#
-#       - timeouts {}
-#     }
-#
-#   # exoscale_security_group_rules.webapp will be created
-#   + resource "exoscale_security_group_rules" "webapp" {
-#       + id                = (known after apply)
-#       + security_group    = (known after apply)
-#       + security_group_id = "b83fe506-51e6-4933-8e70-205df6b640fa"
-#
-#       + ingress {
-#           + cidr_list                = [
-#               + "0.0.0.0/0",
-#             ]
-#           + ids                      = (known after apply)
-#           + ports                    = [
-#               + "443",
-#             ]
-#           + protocol                 = "TCP"
-#           + user_security_group_list = []
-#         }
-#       + ingress {
-#           + cidr_list                = [
-#               + "0.0.0.0/0",
-#             ]
-#           + ids                      = (known after apply)
-#           + ports                    = [
-#               + "80",
-#             ]
-#           + protocol                 = "TCP"
-#           + user_security_group_list = []
-#         }
-#       + ingress {
-#           + cidr_list                = []
-#           + ids                      = (known after apply)
-#           + ports                    = [
-#               + "22",
-#             ]
-#           + protocol                 = "TCP"
-#           + user_security_group_list = [
-#               + "bastion",
-#             ]
-#         }
-#     }
-#
-# Plan: 1 to add, 0 to change, 3 to destroy.
-```
-
-For the time being, terraform tries to remove imported `exoscale_security_group_rule` resources, and re-create the `exoscale_security_group_rules` resource.
-We have to update our definition in such a way that the code reflects the actual Terraform state.
 
 ### Update infrastructure definition
 
@@ -304,82 +147,101 @@ In our example we tried instead to follow the semantic behind each rule, and gro
 - `webapp_ssh` allows access to SSH through a bastion security group
 - `webapp_public` allows access to HTTP(S) services, on both port 80 and 443, leveraging the [`for_each` notation of Terraform](https://www.terraform.io/language/meta-arguments/for_each).
 
-### Move imported resources to match definitions
+### Importing the security group and related rules into the state
 
-At this moment, we still have some migration to do. Indeed, we defined `webapp_ssh`, and `webapp_public` but imported resources are `webapp`, `webapp-1` and `webapp-2`.
-We must tell Terraform how to match new definitions with resources that were imported into the state.
-
-We can use [`moved` blocks](https://www.terraform.io/language/modules/develop/refactoring#moved-block-syntax) for this purpose (see also [Hashicorp learn](https://learn.hashicorp.com/tutorials/terraform/move-config)).
-
-In the latest plan that we asked from Terraform (see above), we can see that:
-- `exoscale_security_group_rule` for port 22 was imported as `exoscale_security_group_rule.webapp` (instead of `exoscale_security_group_rule.webapp_ssh`)
-- `exoscale_security_group_rule` for port 80 was imported as `exoscale_security_group_rule.webapp-2` (instead of `exoscale_security_group_rule.webapp_public["80"]`)
-- `exoscale_security_group_rule` for port 443 was imported as `exoscale_security_group_rule.webapp-1` (instead of `exoscale_security_group_rule.webapp_public["443"]`)
-
-We have to add `moved {}` blocks to update the state according to these observations:
-
-```hcl
-moved {
-  from = exoscale_security_group_rule.webapp
-  to = exoscale_security_group_rule.webapp_ssh
-}
-
-moved {
-  from = exoscale_security_group_rule.webapp-1
-  to = exoscale_security_group_rule.webapp_public["443"]
-}
-
-moved {
-  from = exoscale_security_group_rule.webapp-2
-  to = exoscale_security_group_rule.webapp_public["80"]
-}
-```
-
-Once our definitions are updated, we can ask Terraform a new plan, to check what will be done:
+Using the [Exoscale cli](https://github.com/exoscale/cli/), we can find the ID of the webapp security group:
 
 ```bash
-terraform plan
+exo compute sg list
 # [output]
-# exoscale_security_group.webapp: Refreshing state... [id=b83fe506-51e6-4933-8e70-205df6b640fa]
-# exoscale_security_group.bastion: Refreshing state... [id=e1654b58-64f6-4efc-b8d9-7bbda86a83fa]
-# exoscale_security_group_rule.webapp_public["80"]: Refreshing state... [id=0a187bd0-b5dc-4a58-bab2-44bc7064b83b]
-# exoscale_security_group_rule.webapp_ssh: Refreshing state... [id=5dafa58d-ba4d-4990-b66d-2996782ee3f3]
-# exoscale_security_group_rule.webapp_public["443"]: Refreshing state... [id=e7bbda2b-3c93-4693-a54c-465ac28bda59]
-#
-# Terraform will perform the following actions:
-#
-#   # exoscale_security_group_rule.webapp-1 has moved to exoscale_security_group_rule.webapp_public["443"]
-#     resource "exoscale_security_group_rule" "webapp_public" {
-#         id                = "e7bbda2b-3c93-4693-a54c-465ac28bda59"
-#         # (7 unchanged attributes hidden)
-#
-#         # (1 unchanged block hidden)
-#     }
-#
-#   # exoscale_security_group_rule.webapp-2 has moved to exoscale_security_group_rule.webapp_public["80"]
-#     resource "exoscale_security_group_rule" "webapp_public" {
-#         id                = "0a187bd0-b5dc-4a58-bab2-44bc7064b83b"
-#         # (7 unchanged attributes hidden)
-#
-#         # (1 unchanged block hidden)
-#     }
-#
-#   # exoscale_security_group_rule.webapp has moved to exoscale_security_group_rule.webapp_ssh
-#     resource "exoscale_security_group_rule" "webapp_ssh" {
-#         id                     = "5dafa58d-ba4d-4990-b66d-2996782ee3f3"
-#         # (8 unchanged attributes hidden)
-#
-#         # (1 unchanged block hidden)
-#     }
-#
-# Plan: 0 to add, 0 to change, 0 to destroy.
-#
-# ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-#
-# Note: You didn't use the -out option to save this plan, so Terraform can't guarantee to take exactly these actions if you run "terraform apply" now.
+# ┼──────────────────────────────────────┼─────────┼
+# │                  ID                  │  NAME   │
+# ┼──────────────────────────────────────┼─────────┼
+# │ b83fe506-51e6-4933-8e70-205df6b640fa │ webapp  │
+# │ e1654b58-64f6-4efc-b8d9-7bbda86a83fa │ bastion │
+# │ a0191fd7-1275-4614-9fed-be6f19a770a0 │ default │
+# ┼──────────────────────────────────────┼─────────┼
 ```
 
-Here we can see that our configuration is matching the state: no resources will be created, only moves will occur. We can apply moves, using `terraform apply`:
+In our case, it's `b83fe506-51e6-4933-8e70-205df6b640fa`. Let's import this resource:
+
+```bash
+terraform import exoscale_security_group.webapp b83fe506-51e6-4933-8e70-205df6b640fa
+# [output]
+# exoscale_security_group.webapp: Importing from ID "b83fe506-51e6-4933-8e70-205df6b640fa"...
+# exoscale_security_group.webapp: Import prepared!
+#   Prepared exoscale_security_group for import
+# exoscale_security_group.webapp: Refreshing state... [id=b83fe506-51e6-4933-8e70-205df6b640fa]
+#
+# Import successful!
+#
+# The resources that were imported are shown above. These resources are now in
+# your Terraform state and will henceforth be managed by Terraform.
+```
+
+As you can see, and as expected, the import process imported `exoscale_security_group.webapp`.
+We also need to import related `exoscale_security_group_rule` resources. To find their IDs, we must use CLI again:
+
+```bash
+exo c security-group show b83fe506-51e6-4933-8e70-205df6b640fa
+┼──────────────────┼─────────────────────────────────────────────────────────────────────┼
+│  SECURITY GROUP  │                                                                     │
+┼──────────────────┼─────────────────────────────────────────────────────────────────────┼
+│ ID               │ b83fe506-51e6-4933-8e70-205df6b640fa                                │
+│ Name             │ webapp                                                              │
+│ Description      │                                                                     │
+│ Ingress Rules    │                                                                     │
+│                  │   5dafa58d-ba4d-4990-b66d-2996782ee3f3      TCP   0.0.0.0/0   22    │
+│                  │   e7bbda2b-3c93-4693-a54c-465ac28bda59      TCP   0.0.0.0/0   443   │
+│                  │   0a187bd0-b5dc-4a58-bab2-44bc7064b83b      TCP   0.0.0.0/0   80    │
+│                  │                                                                     │
+│ Egress Rules     │ -                                                                   │
+│ External Sources │ -                                                                   │
+┼──────────────────┼─────────────────────────────────────────────────────────────────────┼
+```
+
+Security group rule IDs can by found in `Ingress Rules`: `5dafa58d-ba4d-4990-b66d-2996782ee3f3`, `e7bbda2b-3c93-4693-a54c-465ac28bda59` and `0a187bd0-b5dc-4a58-bab2-44bc7064b83b`.
+Now we can import them one by one:
+
+```bash
+terraform import exoscale_security_group_rule.webapp_ssh b83fe506-51e6-4933-8e70-205df6b640fa/5dafa58d-ba4d-4990-b66d-2996782ee3f3
+# [output]
+# exoscale_security_group_rule.webapp_ssh: Importing from ID "b83fe506-51e6-4933-8e70-205df6b640fa/5dafa58d-ba4d-4990-b66d-2996782ee3f3"...
+# exoscale_security_group_rule.webapp_ssh: Import prepared!
+#   Prepared exoscale_security_group_rule for import
+# exoscale_security_group_rule.webapp_ssh: Refreshing state... [id=5dafa58d-ba4d-4990-b66d-2996782ee3f3]
+#
+# Import successful!
+#
+# The resources that were imported are shown above. These resources are now in
+# your Terraform state and will henceforth be managed by Terraform.
+
+terraform import 'exoscale_security_group_rule.webapp_public["443"]' b83fe506-51e6-4933-8e70-205df6b640fa/e7bbda2b-3c93-4693-a54c-465ac28bda59
+# [output]
+# exoscale_security_group_rule.webapp_public["443"]: Importing from ID "b83fe506-51e6-4933-8e70-205df6b640fa/e7bbda2b-3c93-4693-a54c-465ac28bda59"...
+# exoscale_security_group_rule.webapp_public["443"]: Import prepared!
+#   Prepared exoscale_security_group_rule for import
+# exoscale_security_group_rule.webapp_public["443"]: Refreshing state... [id=e7bbda2b-3c93-4693-a54c-465ac28bda59]
+#
+# Import successful!
+#
+# The resources that were imported are shown above. These resources are now in
+# your Terraform state and will henceforth be managed by Terraform.
+
+terraform import 'exoscale_security_group_rule.webapp_public["80"]' b83fe506-51e6-4933-8e70-205df6b640fa/0a187bd0-b5dc-4a58-bab2-44bc7064b83b
+# [output]
+# exoscale_security_group_rule.webapp_public["80"]: Importing from ID "b83fe506-51e6-4933-8e70-205df6b640fa/0a187bd0-b5dc-4a58-bab2-44bc7064b83b"...
+# exoscale_security_group.webapp_public["80"]: Import prepared!
+#   Prepared exoscale_security_group_rule for import
+# exoscale_security_group_rule.webapp_public["80"]: Refreshing state... [id=0a187bd0-b5dc-4a58-bab2-44bc7064b83b]
+#
+# Import successful!
+#
+# The resources that were imported are shown above. These resources are now in
+# your Terraform state and will henceforth be managed by Terraform.
+```
+
+In order to check this result and display details on newly imported rules, we have to run [`terraform plan`](https://www.terraform.io/docs/commands/plan.html):
 
 ```bash
 terraform apply
@@ -390,44 +252,11 @@ terraform apply
 # exoscale_security_group_rule.webapp_public["80"]: Refreshing state... [id=0a187bd0-b5dc-4a58-bab2-44bc7064b83b]
 # exoscale_security_group_rule.webapp_public["443"]: Refreshing state... [id=e7bbda2b-3c93-4693-a54c-465ac28bda59]
 #
-# Terraform will perform the following actions:
-#
-#   # exoscale_security_group_rule.webapp-1 has moved to exoscale_security_group_rule.webapp_public["443"]
-#     resource "exoscale_security_group_rule" "webapp_public" {
-#         id                = "e7bbda2b-3c93-4693-a54c-465ac28bda59"
-#         # (7 unchanged attributes hidden)
-#
-#         # (1 unchanged block hidden)
-#     }
-#
-#   # exoscale_security_group_rule.webapp-2 has moved to exoscale_security_group_rule.webapp_public["80"]
-#     resource "exoscale_security_group_rule" "webapp_public" {
-#         id                = "0a187bd0-b5dc-4a58-bab2-44bc7064b83b"
-#         # (7 unchanged attributes hidden)
-#
-#         # (1 unchanged block hidden)
-#     }
-#
-#   # exoscale_security_group_rule.webapp has moved to exoscale_security_group_rule.webapp_ssh
-#     resource "exoscale_security_group_rule" "webapp_ssh" {
-#         id                     = "5dafa58d-ba4d-4990-b66d-2996782ee3f3"
-#         # (8 unchanged attributes hidden)
-#
-#         # (1 unchanged block hidden)
-#     }
-#
-# Plan: 0 to add, 0 to change, 0 to destroy.
-#
-# Do you want to perform these actions?
-#   Terraform will perform the actions described above.
-#   Only 'yes' will be accepted to approve.
-#
-#   Enter a value: yes
-#
+# No changes. Your infrastructure matches the configuration.
 #
 # Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
 ```
 
+Here we can see that our configuration is matching the state: no resources will be changed.
 Now we have finished replacing `exoscale_security_group_rules` with a set of `exoscale_security_group_rule`.
-Our Terraform state matches the related configuration, so migration is completely done, and `moved {}`
-blocks can now be removed from the configuration.
+Our Terraform state matches the related configuration, so migration is completely done.

--- a/docs/resources/domain.md
+++ b/docs/resources/domain.md
@@ -42,12 +42,11 @@ In addition to the arguments listed above, the following attributes are exported
 
 ## Import
 
-An existing DNS domain may be imported by `<name>`:
+An existing DNS domain may be imported by `ID`:
 
 ```console
 $ terraform import \
   exoscale_domain.my_domain \
-  my.domain
+  89083a5c-b648-474a-0000-0000000f67bd
 ```
 
-~> **NOTE:** importing an `exoscale_domain` resource will also import all related `exoscale_domain_record` resources (except `NS` and `SOA`).

--- a/docs/resources/domain_record.md
+++ b/docs/resources/domain_record.md
@@ -65,4 +65,3 @@ $ terraform import \
   f81d4fae-7dec-11d0-a765-00a0c91e6bf6
 ```
 
-~> **NOTE:** importing an `exoscale_domain` resource will also import all related `exoscale_domain_record` resources (except `NS` and `SOA`).

--- a/docs/resources/security_group.md
+++ b/docs/resources/security_group.md
@@ -52,5 +52,3 @@ $ terraform import \
   exoscale_security_group.my_security_group \
   f81d4fae-7dec-11d0-a765-00a0c91e6bf6
 ```
-
-~> **NOTE:** Importing a `exoscale_security_group` resource also imports related `exoscale_security_group_rule` resources.

--- a/docs/resources/security_group_rule.md
+++ b/docs/resources/security_group_rule.md
@@ -62,5 +62,3 @@ $ terraform import \
   exoscale_security_group_rule.my_security_group_rule \
   f81d4fae-7dec-11d0-a765-00a0c91e6bf6/9ecc6b8b-73d4-4211-8ced-f7f29bb79524
 ```
-
-~> **NOTE:** This resource is automatically imported when importing an `exoscale_security_group` resource.

--- a/exoscale/resource_exoscale_domain.go
+++ b/exoscale/resource_exoscale_domain.go
@@ -230,31 +230,7 @@ func resourceDomainImport(ctx context.Context, d *schema.ResourceData, meta inte
 	resources := make([]*schema.ResourceData, 0, 1)
 	resources = append(resources, d)
 
-	records, err := client.ListDNSDomainRecords(ctx, defaultZone, d.Id())
-	if err != nil {
-		return nil, err
-	}
-
-	for _, record := range records {
-		// Ignore the default NS and SOA entries
-		if *record.Type == "NS" || *record.Type == "SOA" {
-			continue
-		}
-		resource := resourceDomainRecord()
-		data := resource.Data(nil)
-		data.SetType("exoscale_domain_record")
-		if err := data.Set("domain", d.Id()); err != nil {
-			return nil, err
-		}
-
-		if err := resourceDomainRecordApply(data, *domain.UnicodeName, &record); err != nil {
-			continue
-		}
-
-		resources = append(resources, data)
-	}
-
-	return resources, nil
+	return []*schema.ResourceData{d}, nil
 }
 
 func resourceDomainApply(d *schema.ResourceData, domain *exo.DNSDomain) error {

--- a/exoscale/resource_exoscale_domain.go
+++ b/exoscale/resource_exoscale_domain.go
@@ -227,9 +227,6 @@ func resourceDomainImport(ctx context.Context, d *schema.ResourceData, meta inte
 		return nil, err
 	}
 
-	resources := make([]*schema.ResourceData, 0, 1)
-	resources = append(resources, d)
-
 	return []*schema.ResourceData{d}, nil
 }
 

--- a/exoscale/resource_exoscale_security_group.go
+++ b/exoscale/resource_exoscale_security_group.go
@@ -276,27 +276,7 @@ func resourceSecurityGroupImport(
 		return nil, err
 	}
 
-	resources := make([]*schema.ResourceData, 0)
-	resources = append(resources, d)
-
-	for _, securityGroupRule := range securityGroup.Rules {
-		resource := resourceSecurityGroupRule()
-		rd := resource.Data(nil)
-		rd.SetType("exoscale_security_group_rule")
-		rd.SetId(*securityGroupRule.ID)
-
-		if err := rd.Set(resSecurityGroupRuleAttrFlowDirection, strings.ToUpper(*securityGroupRule.FlowDirection)); err != nil {
-			return nil, err
-		}
-
-		if err := resourceSecurityGroupRuleApply(ctx, rd, meta, securityGroup, securityGroupRule); err != nil {
-			return nil, err
-		}
-
-		resources = append(resources, rd)
-	}
-
-	return resources, nil
+	return []*schema.ResourceData{d}, nil
 }
 
 func resourceSecurityGroupApply(


### PR DESCRIPTION
This PR removes nested import feature from `exoscale_security_group` and `exoscale_domain` resources.
Nested import no longer works with terraform 1.3.2 and above. As feature is not straightforward to use anyhow (due to generated names for nested resources) i want to remove it instead of trying to fix it. Nested resources should be imported individually.