### PR TITLE
Fix datasource_elastic_ip label filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+
+BUG FIX:
+
+- `datasource_elastic_ip`: Fix label filtering (#242)
+
 ## 0.44.0 (January 31, 2023)
 
 BUG FIX:

--- a/exoscale/datasource_exoscale_elastic_ip.go
+++ b/exoscale/datasource_exoscale_elastic_ip.go
@@ -165,19 +165,15 @@ func dataSourceElasticIPRead(ctx context.Context, d *schema.ResourceData, meta i
 	}
 
 	if searchByElasticIPLabels {
-		searchLabels := make(map[string]string)
-		for k, v := range elasticIPLabels.(map[string]interface{}) {
-			searchLabels[k] = v.(string)
-		}
-
 		filterElasticIP = func(eip *egoscale.ElasticIP) bool {
 			if eip.Labels == nil {
 				return false
 			}
 
-			for searchKey, searchValue := range searchLabels {
-				if foundValue, ok := (*eip.Labels)[searchKey]; ok && foundValue == searchValue {
-					continue
+			for searchKey, searchValue := range elasticIPLabels.(map[string]interface{}) {
+				v, ok := (*eip.Labels)[searchKey]
+				if !ok || v != searchValue {
+					return false
 				}
 			}
 


### PR DESCRIPTION
The current filtering code doesn't return false if the label doesn't match or doesn't exists.
This issue makes the datasource return a random EIP instead of the one with the required labels.
