### PR TITLE
Make opensearch ip-filter a set

### DIFF
--- a/exoscale/resource_data_getter.go
+++ b/exoscale/resource_data_getter.go
@@ -120,18 +120,18 @@ func (rdg resourceDataGetter) GetMapPtr(path string) *map[string]interface{} {
 }
 
 func (rdg resourceDataGetter) GetSet(path string) *[]string {
+	list := []string{}
+
 	v := rdg.Get(path)
-	if v == nil {
-		return nil
-	}
-
-	if l := v.(*schema.Set).Len(); l > 0 {
-		list := make([]string, l)
-		for i, j := range v.(*schema.Set).List() {
-			list[i] = j.(string)
+	if v != nil {
+		l := v.(*schema.Set).Len()
+		if l > 0 {
+			list = make([]string, l)
+			for i, j := range v.(*schema.Set).List() {
+				list[i] = j.(string)
+			}
 		}
-		return &list
 	}
 
-	return nil
+	return &list
 }

--- a/exoscale/resource_data_getter.go
+++ b/exoscale/resource_data_getter.go
@@ -118,3 +118,20 @@ func (rdg resourceDataGetter) GetMapPtr(path string) *map[string]interface{} {
 	r := v.(map[string]interface{})
 	return &r
 }
+
+func (rdg resourceDataGetter) GetSet(path string) *[]string {
+	v := rdg.Get(path)
+	if v == nil {
+		return nil
+	}
+
+	if l := v.(*schema.Set).Len(); l > 0 {
+		list := make([]string, l)
+		for i, j := range v.(*schema.Set).List() {
+			list[i] = j.(string)
+		}
+		return &list
+	}
+
+	return nil
+}

--- a/exoscale/resource_exoscale_database_kafka.go
+++ b/exoscale/resource_exoscale_database_kafka.go
@@ -169,18 +169,10 @@ func resourceDatabaseCreateKafka(
 		databaseService.SchemaRegistryEnabled = &enabled
 	}
 
-	if s, ok := d.GetOk(resDatabaseAttrKafka(resDatabaseAttrKafkaIPFilter)); ok {
-		databaseService.IpFilter = func() (v *[]string) {
-			if l := s.(*schema.Set).Len(); l > 0 {
-				list := make([]string, l)
-				for i, v := range s.(*schema.Set).List() {
-					list[i] = v.(string)
-				}
-				v = &list
-			}
-			return
-		}()
-	}
+	dg := newResourceDataGetter(d)
+	dgos := dg.Under("kafka").Under("0")
+
+	databaseService.IpFilter = dgos.GetSet(resDatabaseAttrKafkaIPFilter)
 
 	if v, ok := d.GetOk(resDatabaseAttrKafka(resDatabaseAttrKafkaRESTSettings)); ok {
 		settings, err := validateDatabaseServiceSettings(v.(string), settingsSchema.JSON200.Settings.KafkaRest)
@@ -319,13 +311,10 @@ func resourceDatabaseUpdateKafka(
 		}
 
 		if d.HasChange(resDatabaseAttrKafka(resDatabaseAttrKafkaIPFilter)) {
-			databaseService.IpFilter = func() *[]string {
-				list := make([]string, 0)
-				for _, v := range d.Get(resDatabaseAttrKafka(resDatabaseAttrKafkaIPFilter)).(*schema.Set).List() {
-					list = append(list, v.(string))
-				}
-				return &list
-			}()
+			dg := newResourceDataGetter(d)
+			dgos := dg.Under("redis").Under("0")
+
+			databaseService.IpFilter = dgos.GetSet(resDatabaseAttrKafkaIPFilter)
 			updated = true
 		}
 

--- a/exoscale/resource_exoscale_database_kafka.go
+++ b/exoscale/resource_exoscale_database_kafka.go
@@ -312,7 +312,7 @@ func resourceDatabaseUpdateKafka(
 
 		if d.HasChange(resDatabaseAttrKafka(resDatabaseAttrKafkaIPFilter)) {
 			dg := newResourceDataGetter(d)
-			dgos := dg.Under("redis").Under("0")
+			dgos := dg.Under("kafka").Under("0")
 
 			databaseService.IpFilter = dgos.GetSet(resDatabaseAttrKafkaIPFilter)
 			updated = true

--- a/exoscale/resource_exoscale_database_mysql.go
+++ b/exoscale/resource_exoscale_database_mysql.go
@@ -128,18 +128,10 @@ func resourceDatabaseCreateMysql(
 		}
 	}
 
-	if s, ok := d.GetOk(resDatabaseAttrMysql(resDatabaseAttrMysqlIPFilter)); ok {
-		databaseService.IpFilter = func() (v *[]string) {
-			if l := s.(*schema.Set).Len(); l > 0 {
-				list := make([]string, l)
-				for i, v := range s.(*schema.Set).List() {
-					list[i] = v.(string)
-				}
-				v = &list
-			}
-			return
-		}()
-	}
+	dg := newResourceDataGetter(d)
+	dgos := dg.Under("mysql").Under("0")
+
+	databaseService.IpFilter = dgos.GetSet(resDatabaseAttrMysqlIPFilter)
 
 	if v, ok := d.GetOk(resDatabaseAttrMysql(resDatabaseAttrMysqlSettings)); ok {
 		settings, err := validateDatabaseServiceSettings(v.(string), settingsSchema.JSON200.Settings.Mysql)
@@ -233,13 +225,10 @@ func resourceDatabaseUpdateMysql(
 		}
 
 		if d.HasChange(resDatabaseAttrMysql(resDatabaseAttrMysqlIPFilter)) {
-			databaseService.IpFilter = func() *[]string {
-				list := make([]string, 0)
-				for _, v := range d.Get(resDatabaseAttrMysql(resDatabaseAttrMysqlIPFilter)).(*schema.Set).List() {
-					list = append(list, v.(string))
-				}
-				return &list
-			}()
+			dg := newResourceDataGetter(d)
+			dgos := dg.Under("mysql").Under("0")
+
+			databaseService.IpFilter = dgos.GetSet(resDatabaseAttrMysqlIPFilter)
 			updated = true
 		}
 

--- a/exoscale/resource_exoscale_database_pg.go
+++ b/exoscale/resource_exoscale_database_pg.go
@@ -140,18 +140,10 @@ func resourceDatabaseCreatePg(
 		}
 	}
 
-	if s, ok := d.GetOk(resDatabaseAttrPg(resDatabaseAttrPgIPFilter)); ok {
-		databaseService.IpFilter = func() (v *[]string) {
-			if l := s.(*schema.Set).Len(); l > 0 {
-				list := make([]string, l)
-				for i, v := range s.(*schema.Set).List() {
-					list[i] = v.(string)
-				}
-				v = &list
-			}
-			return
-		}()
-	}
+	dg := newResourceDataGetter(d)
+	dgos := dg.Under("pg").Under("0")
+
+	databaseService.IpFilter = dgos.GetSet(resDatabaseAttrPgIPFilter)
 
 	if v, ok := d.GetOk(resDatabaseAttrPg(resDatabaseAttrPgSettings)); ok {
 		settings, err := validateDatabaseServiceSettings(v.(string), settingsSchema.JSON200.Settings.Pg)
@@ -261,13 +253,10 @@ func resourceDatabaseUpdatePg(
 		}
 
 		if d.HasChange(resDatabaseAttrPg(resDatabaseAttrPgIPFilter)) {
-			databaseService.IpFilter = func() *[]string {
-				list := make([]string, 0)
-				for _, v := range d.Get(resDatabaseAttrPg(resDatabaseAttrPgIPFilter)).(*schema.Set).List() {
-					list = append(list, v.(string))
-				}
-				return &list
-			}()
+			dg := newResourceDataGetter(d)
+			dgos := dg.Under("pg").Under("0")
+
+			databaseService.IpFilter = dgos.GetSet(resDatabaseAttrPgIPFilter)
 			updated = true
 		}
 


### PR DESCRIPTION
This PR fixes the `ip-filter` sorting issue of resource `exoscale_database` for opensearch.

Field `ip-filter` for `opensearch` is now of type `Set`, which is inline with other databases.

Minor refactor to leverage a helper.