### PR TITLE
Fix domain_record resource and datasource tests

### DIFF
--- a/exoscale/datasource_exoscale_domain_record_test.go
+++ b/exoscale/datasource_exoscale_domain_record_test.go
@@ -17,8 +17,8 @@ var (
 	testAccDataSourceDomainRecordName1      = "mail1"
 	testAccDataSourceDomainRecordName2      = "mail2"
 	testAccDataSourceDomainRecordType       = "MX"
-	testAccDataSourceDomainRecordContent1   = "mta1"
-	testAccDataSourceDomainRecordContent2   = "mta2"
+	testAccDataSourceDomainRecordContent1   = "mta1." + testAccDataSourceDomainRecordDomainName
+	testAccDataSourceDomainRecordContent2   = "mta2." + testAccDataSourceDomainRecordDomainName
 	testAccDataSourceDomainRecordPrio       = 10
 	testAccDataSourceDomainRecordTTL        = 10
 

--- a/exoscale/resource_exoscale_domain_record_test.go
+++ b/exoscale/resource_exoscale_domain_record_test.go
@@ -19,8 +19,8 @@ var (
 	testAccResourceDomainRecordName           = "mail1"
 	testAccResourceDomainRecordNameUpdated    = "mail2"
 	testAccResourceDomainRecordType           = "MX"
-	testAccResourceDomainRecordContent        = "mta1"
-	testAccResourceDomainRecordContentUpdated = "mta2"
+	testAccResourceDomainRecordContent        = "mta1." + testAccResourceDomainRecordDomainName
+	testAccResourceDomainRecordContentUpdated = "mta2." + testAccResourceDomainRecordDomainName
 	testAccResourceDomainRecordPrio           = 10
 	testAccResourceDomainRecordPrioUpdated    = 20
 	testAccResourceDomainRecordTTL            = 10


### PR DESCRIPTION
Recent change upstream (DNSimple) forces usage of full domain names for `MX` record content. This PR fixes our tests for `domain_record` resource and data source.