### PR TITLE
Examples: Use datasource exoscale_template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 example.tf
 terraform.tfplan
 terraform.tfstate
+.terraform.lock.hcl
 /bin/
 /build/
 /pkg/

--- a/examples/dns/main.tf
+++ b/examples/dns/main.tf
@@ -8,7 +8,7 @@ locals {
 }
 
 # Existing resources (<-> data sources)
-data "exoscale_compute_template" "my_template" {
+data "exoscale_template" "my_template" {
   zone = local.my_zone
   name = local.my_template
 }
@@ -22,7 +22,7 @@ resource "exoscale_compute_instance" "my_instance" {
   zone = local.my_zone
   name = "my-instance"
 
-  template_id = data.exoscale_compute_template.my_template.id
+  template_id = data.exoscale_template.my_template.id
   type        = "standard.medium"
   disk_size   = 10
   ipv6        = true

--- a/examples/elastic-ip/main.tf
+++ b/examples/elastic-ip/main.tf
@@ -8,7 +8,7 @@ locals {
 }
 
 # Existing resources (<-> data sources)
-data "exoscale_compute_template" "my_template" {
+data "exoscale_template" "my_template" {
   zone = local.my_zone
   name = local.my_template
 }
@@ -48,7 +48,7 @@ resource "exoscale_compute_instance" "my_instance" {
   zone = local.my_zone
   name = "my-instance"
 
-  template_id = data.exoscale_compute_template.my_template.id
+  template_id = data.exoscale_template.my_template.id
   type        = "standard.medium"
   disk_size   = 10
 
@@ -65,7 +65,7 @@ resource "exoscale_compute_instance" "my_instance" {
   provisioner "remote-exec" {
     connection {
       host        = self.public_ip_address
-      user        = data.exoscale_compute_template.my_template.username
+      user        = data.exoscale_template.my_template.default_user
       private_key = tls_private_key.my_ssh_key.private_key_openssh
     }
 
@@ -80,7 +80,7 @@ resource "exoscale_compute_instance" "my_instance" {
 output "ssh_connection" {
   value = format(
     "ssh -i id_ssh %s@%s",
-    data.exoscale_compute_template.my_template.username,
+    data.exoscale_template.my_template.default_user,
     exoscale_compute_instance.my_instance.public_ip_address,
   )
 }

--- a/examples/import-resources/main.tf
+++ b/examples/import-resources/main.tf
@@ -8,7 +8,7 @@ locals {
 }
 
 # Existing resources (<-> data sources)
-data "exoscale_compute_template" "my_template" {
+data "exoscale_template" "my_template" {
   zone = local.my_zone
   name = local.my_template
 }
@@ -43,7 +43,7 @@ resource "exoscale_compute_instance" "my_instance" {
   zone = local.my_zone
   name = "my-instance"
 
-  template_id = data.exoscale_compute_template.my_template.id
+  template_id = data.exoscale_template.my_template.id
   type        = "standard.medium"
   disk_size   = 10
 

--- a/examples/instance-pool/main.tf
+++ b/examples/instance-pool/main.tf
@@ -8,7 +8,7 @@ locals {
 }
 
 # Existing resources (<-> data sources)
-data "exoscale_compute_template" "my_template" {
+data "exoscale_template" "my_template" {
   zone = local.my_zone
   name = local.my_template
 }
@@ -25,7 +25,7 @@ resource "exoscale_instance_pool" "my_instance_pool" {
   zone = local.my_zone
   name = "my-instance-pool"
 
-  template_id   = data.exoscale_compute_template.my_template.id
+  template_id   = data.exoscale_template.my_template.id
   instance_type = "standard.medium"
   disk_size     = 10
   size          = 3
@@ -42,7 +42,7 @@ resource "exoscale_instance_pool" "my_instance_pool" {
 output "ssh_connection" {
   value = join("\n", formatlist(
     "ssh -i id_ssh %s@%s  # %s",
-    data.exoscale_compute_template.my_template.username,
+    data.exoscale_template.my_template.default_user,
     exoscale_instance_pool.my_instance_pool.instances.*.public_ip_address,
     exoscale_instance_pool.my_instance_pool.instances.*.name,
   ))

--- a/examples/ipv6/main.tf
+++ b/examples/ipv6/main.tf
@@ -8,7 +8,7 @@ locals {
 }
 
 # Existing resources (<-> data sources)
-data "exoscale_compute_template" "my_template" {
+data "exoscale_template" "my_template" {
   zone = local.my_zone
   name = local.my_template
 }
@@ -25,7 +25,7 @@ resource "exoscale_compute_instance" "my_instance" {
   zone = local.my_zone
   name = "my-instance"
 
-  template_id = data.exoscale_compute_template.my_template.id
+  template_id = data.exoscale_template.my_template.id
   type        = "standard.medium"
   disk_size   = 10
   ipv6        = true
@@ -40,7 +40,7 @@ resource "exoscale_compute_instance" "my_instance" {
   provisioner "remote-exec" {
     connection {
       host        = self.public_ip_address
-      user        = data.exoscale_compute_template.my_template.username
+      user        = data.exoscale_template.my_template.default_user
       private_key = tls_private_key.my_ssh_key.private_key_openssh
     }
 
@@ -55,7 +55,7 @@ resource "exoscale_compute_instance" "my_instance" {
 output "ssh_connection" {
   value = format(
     "ssh -i id_ssh %s@%s",
-    data.exoscale_compute_template.my_template.username,
+    data.exoscale_template.my_template.default_user,
     exoscale_compute_instance.my_instance.public_ip_address,
   )
 }

--- a/examples/managed-private-network/main.tf
+++ b/examples/managed-private-network/main.tf
@@ -8,7 +8,7 @@ locals {
 }
 
 # Existing resources (<-> data sources)
-data "exoscale_compute_template" "my_template" {
+data "exoscale_template" "my_template" {
   zone = local.my_zone
   name = local.my_template
 }
@@ -35,7 +35,7 @@ resource "exoscale_compute_instance" "my_instance_static" {
   zone = local.my_zone
   name = "my-instance-static"
 
-  template_id = data.exoscale_compute_template.my_template.id
+  template_id = data.exoscale_template.my_template.id
   type        = "standard.medium"
   disk_size   = 10
 
@@ -52,7 +52,7 @@ resource "exoscale_compute_instance" "my_instance_static" {
   provisioner "remote-exec" {
     connection {
       host        = self.public_ip_address
-      user        = data.exoscale_compute_template.my_template.username
+      user        = data.exoscale_template.my_template.default_user
       private_key = tls_private_key.my_ssh_key.private_key_openssh
     }
 
@@ -67,7 +67,7 @@ resource "exoscale_compute_instance" "my_instance_dynamic" {
   zone = local.my_zone
   name = "my-instance-dynamic"
 
-  template_id = data.exoscale_compute_template.my_template.id
+  template_id = data.exoscale_template.my_template.id
   type        = "standard.medium"
   disk_size   = 10
 
@@ -83,7 +83,7 @@ resource "exoscale_compute_instance" "my_instance_dynamic" {
   provisioner "remote-exec" {
     connection {
       host        = self.public_ip_address
-      user        = data.exoscale_compute_template.my_template.username
+      user        = data.exoscale_template.my_template.default_user
       private_key = tls_private_key.my_ssh_key.private_key_openssh
     }
 
@@ -98,7 +98,7 @@ resource "exoscale_compute_instance" "my_instance_dynamic" {
 output "ssh_connection_static" {
   value = format(
     "ssh -i id_ssh %s@%s",
-    data.exoscale_compute_template.my_template.username,
+    data.exoscale_template.my_template.default_user,
     exoscale_compute_instance.my_instance_static.public_ip_address,
   )
 }
@@ -106,7 +106,7 @@ output "ssh_connection_static" {
 output "ssh_connection_dynamic" {
   value = format(
     "ssh -i id_ssh %s@%s",
-    data.exoscale_compute_template.my_template.username,
+    data.exoscale_template.my_template.default_user,
     exoscale_compute_instance.my_instance_dynamic.public_ip_address,
   )
 }

--- a/examples/multipart-cloud-init/main.tf
+++ b/examples/multipart-cloud-init/main.tf
@@ -9,7 +9,7 @@ locals {
 }
 
 # Existing resources (<-> data sources)
-data "exoscale_compute_template" "my_template" {
+data "exoscale_template" "my_template" {
   zone = local.my_zone
   name = local.my_template
 }
@@ -64,7 +64,7 @@ resource "exoscale_compute_instance" "my_instance" {
   zone = local.my_zone
   name = local.my_instances[count.index]
 
-  template_id = data.exoscale_compute_template.my_template.id
+  template_id = data.exoscale_template.my_template.id
   type        = "standard.medium"
   disk_size   = 10
 
@@ -79,7 +79,7 @@ resource "exoscale_compute_instance" "my_instance" {
   provisioner "remote-exec" {
     connection {
       host        = self.public_ip_address
-      user        = data.exoscale_compute_template.my_template.username
+      user        = data.exoscale_template.my_template.default_user
       private_key = tls_private_key.my_ssh_key.private_key_openssh
     }
 
@@ -94,7 +94,7 @@ resource "exoscale_compute_instance" "my_instance" {
 output "ssh_connection" {
   value = join("\n", formatlist(
     "ssh -i id_ssh %s@%s  # %s",
-    data.exoscale_compute_template.my_template.username,
+    data.exoscale_template.my_template.default_user,
     exoscale_compute_instance.my_instance.*.public_ip_address,
     exoscale_compute_instance.my_instance.*.name,
   ))

--- a/examples/nlb/main.tf
+++ b/examples/nlb/main.tf
@@ -8,7 +8,7 @@ locals {
 }
 
 # Existing resources (<-> data sources)
-data "exoscale_compute_template" "my_template" {
+data "exoscale_template" "my_template" {
   zone = local.my_zone
   name = local.my_template
 }
@@ -41,7 +41,7 @@ resource "exoscale_instance_pool" "my_instance_pool" {
   zone = local.my_zone
   name = "my-instance-pool"
 
-  template_id   = data.exoscale_compute_template.my_template.id
+  template_id   = data.exoscale_template.my_template.id
   instance_type = "standard.medium"
   disk_size     = 10
   size          = 3
@@ -88,7 +88,7 @@ resource "exoscale_nlb_service" "my_nlb_service" {
 output "ssh_connection" {
   value = join("\n", formatlist(
     "ssh -i id_ssh %s@%s  # %s",
-    data.exoscale_compute_template.my_template.username,
+    data.exoscale_template.my_template.default_user,
     exoscale_instance_pool.my_instance_pool.instances.*.public_ip_address,
     exoscale_instance_pool.my_instance_pool.instances.*.name,
   ))

--- a/examples/ssh-keys/main.tf
+++ b/examples/ssh-keys/main.tf
@@ -8,7 +8,7 @@ locals {
 }
 
 # Existing resources (<-> data sources)
-data "exoscale_compute_template" "my_template" {
+data "exoscale_template" "my_template" {
   zone = local.my_zone
   name = local.my_template
 }
@@ -63,7 +63,7 @@ resource "exoscale_compute_instance" "my_instance" {
   zone = local.my_zone
   name = "my-instance"
 
-  template_id = data.exoscale_compute_template.my_template.id
+  template_id = data.exoscale_template.my_template.id
   type        = "standard.medium"
   disk_size   = 10
 
@@ -77,7 +77,7 @@ resource "exoscale_compute_instance" "my_instance" {
   provisioner "remote-exec" {
     connection {
       host        = self.public_ip_address
-      user        = data.exoscale_compute_template.my_template.username
+      user        = data.exoscale_template.my_template.default_user
       private_key = tls_private_key.my_ssh_key.private_key_openssh
     }
 
@@ -89,7 +89,7 @@ resource "exoscale_compute_instance" "my_instance" {
 output "ssh_connection" {
   value = format(
     "ssh -i id_ssh %s@%s",
-    data.exoscale_compute_template.my_template.username,
+    data.exoscale_template.my_template.default_user,
     exoscale_compute_instance.my_instance.public_ip_address,
   )
 }


### PR DESCRIPTION
Replace deprecated **datasource** `exoscale_compute_template` by `exoscale_template`