### PR TITLE
Allow security group rule to target public security group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.48.0 (To be released)
+
+FEATURES:
+
+- Resource `security_group_rule`: add the `public_security_group` attribute (#263)
+
 ## 0.47.0 (April 24, 2023)
 
 FEATURES:

--- a/docs/resources/security_group_rule.md
+++ b/docs/resources/security_group_rule.md
@@ -39,18 +39,19 @@ directory for complete configuration examples.
 
 ### Optional
 
-- `cidr` (String) ❗ An (`INGRESS`) source / (`EGRESS`) destination IP subnet (in [CIDR notation](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing#CIDR_notation)) to match (conflicts with `user_security_group`/`user_security_group_id`).
+- `cidr` (String) ❗ An (`INGRESS`) source / (`EGRESS`) destination IP subnet (in [CIDR notation](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing#CIDR_notation)) to match (conflicts with `public_security_group`/`user_security_group`/`user_security_group_id`).
 - `description` (String) ❗ A free-form text describing the security group rule.
 - `end_port` (Number) ❗ A `TCP`/`UDP` port range to match.
 - `icmp_code` (Number) ❗ An ICMP/ICMPv6 [type/code](https://en.wikipedia.org/wiki/Internet_Control_Message_Protocol#Control_messages) to match.
 - `icmp_type` (Number) ❗ An ICMP/ICMPv6 [type/code](https://en.wikipedia.org/wiki/Internet_Control_Message_Protocol#Control_messages) to match.
 - `protocol` (String) ❗ The network protocol to match (`TCP`, `UDP`, `ICMP`, `ICMPv6`, `AH`, `ESP`, `GRE`, `IPIP` or `ALL`)
+- `public_security_group` (String) ❗ An (`INGRESS`) source / (`EGRESS`) destination public security group name to match (conflicts with `cidr`/`user_security_group`/`user_security_group_id`).
 - `security_group` (String, Deprecated) ❗ The parent security group name. Please use the `security_group_id` argument along the [exoscale_security_group](../data-sources/security_group.md) data source instead.
 - `security_group_id` (String) ❗ The parent [exoscale_security_group](./security_group.md) ID.
 - `start_port` (Number) ❗ A `TCP`/`UDP` port range to match.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
-- `user_security_group` (String, Deprecated) ❗ An (`INGRESS`) source / (`EGRESS`) destination security group name to match (conflicts with `cidr`/`user_security_group_id`). Please use the `user_security_group_id` argument along the [exoscale_security_group](../data-sources/security_group.md) data source instead.
-- `user_security_group_id` (String) ❗ An (`INGRESS`) source / (`EGRESS`) destination security group ID to match (conflicts with `cidr`/`user_security_group)`).
+- `user_security_group` (String, Deprecated) ❗ An (`INGRESS`) source / (`EGRESS`) destination security group name to match (conflicts with `cidr`/`public_security_group`/`user_security_group_id`). Please use the `user_security_group_id` argument along the [exoscale_security_group](../data-sources/security_group.md) data source instead.
+- `user_security_group_id` (String) ❗ An (`INGRESS`) source / (`EGRESS`) destination security group ID to match (conflicts with `cidr`/`public_security_group`/`user_security_group)`).
 
 ### Read-Only
 

--- a/exoscale/resource_exoscale_security_group_rule.go
+++ b/exoscale/resource_exoscale_security_group_rule.go
@@ -125,7 +125,7 @@ func resourceSecurityGroupRule() *schema.Resource {
 				Optional: true,
 				Computed: true,
 				ForceNew: true,
-				Description: "An (`INGRESS`) source / (`EGRESS`) destination public security group name to match (conflicts with `cidr`/`user_security_group`/`user_security_group_id`). Please use the `user_security_group_id` argument along the [exoscale_security_group](../data-sources/security_group.md) data source instead.",
+				Description: "An (`INGRESS`) source / (`EGRESS`) destination public security group name to match (conflicts with `cidr`/`user_security_group`/`user_security_group_id`).",
 			},
 			resSecurityGroupRuleAttrSecurityGroupID: {
 				Type:          schema.TypeString,

--- a/exoscale/resource_exoscale_security_group_rule.go
+++ b/exoscale/resource_exoscale_security_group_rule.go
@@ -121,10 +121,10 @@ func resourceSecurityGroupRule() *schema.Resource {
 				Description:      "The network protocol to match (`TCP`, `UDP`, `ICMP`, `ICMPv6`, `AH`, `ESP`, `GRE`, `IPIP` or `ALL`)",
 			},
 			resSecurityGroupRuleAttrPublicSecurityGroup: {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
 				Description: "An (`INGRESS`) source / (`EGRESS`) destination public security group name to match (conflicts with `cidr`/`user_security_group`/`user_security_group_id`).",
 			},
 			resSecurityGroupRuleAttrSecurityGroupID: {
@@ -278,16 +278,17 @@ func resourceSecurityGroupRuleCreate(ctx context.Context, d *schema.ResourceData
 		)
 	}
 
-	if byNetwork {
+	switch {
+	case byNetwork:
 		_, cidr, err := net.ParseCIDR(network.(string))
 		if err != nil {
 			return diag.FromErr(err)
 		}
 		securityGroupRule.Network = cidr
-	} else if byPublicSecurityGroupName {
+	case byPublicSecurityGroupName:
 		securityGroupName := publicSecurityGroupName.(string)
 		securityGroupRule.SecurityGroupName = &securityGroupName
-	} else {
+	default:
 		userSecurityGroup, err := client.FindSecurityGroup(
 			ctx,
 			zone, func() string {

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/exoscale/terraform-provider-exoscale
 
 require (
-	github.com/exoscale/egoscale v0.94.0
+	github.com/exoscale/egoscale v0.100.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/go-retryablehttp v0.7.1

--- a/go.sum
+++ b/go.sum
@@ -61,6 +61,8 @@ github.com/envoyproxy/go-control-plane v0.10.2-0.20220325020618-49ff273808a1/go.
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/exoscale/egoscale v0.94.0 h1:ZkOnt+J9k3DB/1NFOIoq2Bp6b259fMrahnrYwauFyjk=
 github.com/exoscale/egoscale v0.94.0/go.mod h1:BAb9p4rmyU+Wl400CJZO5270H2sXtdsZjLcm5xMKkz4=
+github.com/exoscale/egoscale v0.100.0 h1:QQGL4nwpN07iCIE3TbGHx67ItLZtN4j9GcsigVg0ZZk=
+github.com/exoscale/egoscale v0.100.0/go.mod h1:BAb9p4rmyU+Wl400CJZO5270H2sXtdsZjLcm5xMKkz4=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=

--- a/vendor/github.com/exoscale/egoscale/.golangci.yml
+++ b/vendor/github.com/exoscale/egoscale/.golangci.yml
@@ -9,7 +9,6 @@ linters-settings:
 
 linters:
   enable:
-    - deadcode
     - errcheck
     - exportloopref
     - gocritic
@@ -21,9 +20,7 @@ linters:
     - nakedret
     - revive
     - staticcheck
-    - structcheck
     - unused
-    - varcheck
   disable-all: true
 
 issues:

--- a/vendor/github.com/exoscale/egoscale/CHANGELOG.md
+++ b/vendor/github.com/exoscale/egoscale/CHANGELOG.md
@@ -1,11 +1,50 @@
 Changelog
 =========
 
+0.100.0
+-------
+
+- feature: v2: allow supply security group rules referencing public security groups.
+
+0.99.0
+------
+
+- feature: v2: add RevealInstancePassword
+
+0.98.1
+------
+
+- feature: v2: add FindSecurityGroups with parameter support
+
+0.98.0
+------
+
+- v2: refresh openapi generated code
+- feature: v2: add an option to the ListInstances call that allows users to filter by IP address
+
+0.97.0
+------
+
+- v2: database migration stop methods for databases supporting it: Redis, PostgreSQL, MySQL
+
+0.96.0
+------
+
+- v2: refresh openapi generated code
+- feature: v2: rename SKS nodepool addon
+
+
+0.95.0
+------
+
+- feature: v2: add `Client.FindTemplate()` method
+- fix: v2: error for `Client.GetTemplateByName()`
+
 0.94.0
 ------
 
 - feature: v2: add `Client.GetTemplateByName()` method
-- feature: v2: implement sort.Interface for []*Template by CreatedAt or by Nane
+- feature: v2: implement sort.Interface for []*Template by CreatedAt or by Name
 
 0.93.0
 ------

--- a/vendor/github.com/exoscale/egoscale/doc.go
+++ b/vendor/github.com/exoscale/egoscale/doc.go
@@ -177,4 +177,5 @@ An Elastic IP is a way to attach an IP address to many Virtual Machines. The API
 See: https://community.exoscale.com/documentation/compute/eip/
 
 */
+//nolint:goimports
 package egoscale

--- a/vendor/github.com/exoscale/egoscale/isos.go
+++ b/vendor/github.com/exoscale/egoscale/isos.go
@@ -28,9 +28,7 @@ func (iso ISO) ListRequest() (ListCommand, error) {
 		*req.IsReady = true
 	}
 
-	for i := range iso.Tags {
-		req.Tags = append(req.Tags, iso.Tags[i])
-	}
+	req.Tags = append(req.Tags, iso.Tags...)
 
 	return req, nil
 }

--- a/vendor/github.com/exoscale/egoscale/templates.go
+++ b/vendor/github.com/exoscale/egoscale/templates.go
@@ -60,9 +60,7 @@ func (template Template) ListRequest() (ListCommand, error) {
 		*req.ShowRemoved = true
 	}
 
-	for i := range template.Tags {
-		req.Tags = append(req.Tags, template.Tags[i])
-	}
+	req.Tags = append(req.Tags, template.Tags...)
 
 	return req, nil
 }

--- a/vendor/github.com/exoscale/egoscale/v2/client.go
+++ b/vendor/github.com/exoscale/egoscale/v2/client.go
@@ -13,10 +13,11 @@ import (
 	"runtime"
 	"time"
 
+	"github.com/hashicorp/go-retryablehttp"
+
 	"github.com/exoscale/egoscale/v2/api"
 	"github.com/exoscale/egoscale/v2/oapi"
 	"github.com/exoscale/egoscale/version"
-	"github.com/hashicorp/go-retryablehttp"
 )
 
 const (
@@ -240,15 +241,14 @@ func setEndpointFromContext(ctx context.Context, req *http.Request) error {
 // fetchFromIDs returns a list of API resources fetched from the specified list of IDs.
 // It is meant to be used with API resources implementing the getter interface, e.g.:
 //
-//     func (i Instance) get(ctx context.Context, client *Client, zone, id string) (interface{}, error) {
-//         return client.GetInstance(ctx, zone, id)
-//     }
+//	func (i Instance) get(ctx context.Context, client *Client, zone, id string) (interface{}, error) {
+//	    return client.GetInstance(ctx, zone, id)
+//	}
 //
-//     func (i *InstancePool) Instances(ctx context.Context) ([]*Instance, error) {
-//         res, err := i.c.fetchFromIDs(ctx, i.zone, i.InstanceIDs, new(Instance))
-//         return res.([]*Instance), err
-//     }
-//
+//	func (i *InstancePool) Instances(ctx context.Context) ([]*Instance, error) {
+//	    res, err := i.c.fetchFromIDs(ctx, i.zone, i.InstanceIDs, new(Instance))
+//	    return res.([]*Instance), err
+//	}
 func (c *Client) fetchFromIDs(ctx context.Context, zone string, ids []string, rt interface{}) (interface{}, error) {
 	if rt == nil {
 		return nil, errors.New("resource type must not be <nil>")

--- a/vendor/github.com/exoscale/egoscale/v2/client_mock.go
+++ b/vendor/github.com/exoscale/egoscale/v2/client_mock.go
@@ -1157,3 +1157,30 @@ func (m *oapiClientMock) UpdateReverseDnsElasticIpWithResponse(
 	args := m.Called(ctx, id, body, reqEditors)
 	return args.Get(0).(*oapi.UpdateReverseDnsElasticIpResponse), args.Error(1)
 }
+
+func (m *oapiClientMock) StopDbaasRedisMigrationWithResponse(
+	ctx context.Context,
+	name oapi.DbaasServiceName,
+	reqEditors ...oapi.RequestEditorFn,
+) (*oapi.StopDbaasRedisMigrationResponse, error) {
+	args := m.Called(ctx, name, reqEditors)
+	return args.Get(0).(*oapi.StopDbaasRedisMigrationResponse), args.Error(1)
+}
+
+func (m *oapiClientMock) StopDbaasPgMigrationWithResponse(
+	ctx context.Context,
+	name oapi.DbaasServiceName,
+	reqEditors ...oapi.RequestEditorFn,
+) (*oapi.StopDbaasPgMigrationResponse, error) {
+	args := m.Called(ctx, name, reqEditors)
+	return args.Get(0).(*oapi.StopDbaasPgMigrationResponse), args.Error(1)
+}
+
+func (m *oapiClientMock) StopDbaasMysqlMigrationWithResponse(
+	ctx context.Context,
+	name oapi.DbaasServiceName,
+	reqEditors ...oapi.RequestEditorFn,
+) (*oapi.StopDbaasMysqlMigrationResponse, error) {
+	args := m.Called(ctx, name, reqEditors)
+	return args.Get(0).(*oapi.StopDbaasMysqlMigrationResponse), args.Error(1)
+}

--- a/vendor/github.com/exoscale/egoscale/v2/database_mysql.go
+++ b/vendor/github.com/exoscale/egoscale/v2/database_mysql.go
@@ -1,0 +1,26 @@
+package v2
+
+import (
+	"context"
+
+	apiv2 "github.com/exoscale/egoscale/v2/api"
+	"github.com/exoscale/egoscale/v2/oapi"
+)
+
+// StopMysqlDatabaseMigration stops running Database migration.
+func (c *Client) StopMysqlDatabaseMigration(ctx context.Context, zone string, name string) error {
+	resp, err := c.StopDbaasMysqlMigrationWithResponse(apiv2.WithZone(ctx, zone), oapi.DbaasServiceName(name))
+	if err != nil {
+		return err
+	}
+
+	_, err = oapi.NewPoller().
+		WithTimeout(c.timeout).
+		WithInterval(c.pollInterval).
+		Poll(ctx, oapi.OperationPoller(c, zone, *resp.JSON200.Id))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/vendor/github.com/exoscale/egoscale/v2/database_pg.go
+++ b/vendor/github.com/exoscale/egoscale/v2/database_pg.go
@@ -1,0 +1,26 @@
+package v2
+
+import (
+	"context"
+
+	apiv2 "github.com/exoscale/egoscale/v2/api"
+	"github.com/exoscale/egoscale/v2/oapi"
+)
+
+// StopPgDatabaseMigration stops running Database migration.
+func (c *Client) StopPgDatabaseMigration(ctx context.Context, zone string, name string) error {
+	resp, err := c.StopDbaasPgMigrationWithResponse(apiv2.WithZone(ctx, zone), oapi.DbaasServiceName(name))
+	if err != nil {
+		return err
+	}
+
+	_, err = oapi.NewPoller().
+		WithTimeout(c.timeout).
+		WithInterval(c.pollInterval).
+		Poll(ctx, oapi.OperationPoller(c, zone, *resp.JSON200.Id))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/vendor/github.com/exoscale/egoscale/v2/database_redis.go
+++ b/vendor/github.com/exoscale/egoscale/v2/database_redis.go
@@ -1,0 +1,26 @@
+package v2
+
+import (
+	"context"
+
+	apiv2 "github.com/exoscale/egoscale/v2/api"
+	"github.com/exoscale/egoscale/v2/oapi"
+)
+
+// StopRedisDatabaseMigration stops running Database migration.
+func (c *Client) StopRedisDatabaseMigration(ctx context.Context, zone string, name string) error {
+	resp, err := c.StopDbaasRedisMigrationWithResponse(apiv2.WithZone(ctx, zone), oapi.DbaasServiceName(name))
+	if err != nil {
+		return err
+	}
+
+	_, err = oapi.NewPoller().
+		WithTimeout(c.timeout).
+		WithInterval(c.pollInterval).
+		Poll(ctx, oapi.OperationPoller(c, zone, *resp.JSON200.Id))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/vendor/github.com/exoscale/egoscale/v2/deploy_target.go
+++ b/vendor/github.com/exoscale/egoscale/v2/deploy_target.go
@@ -19,7 +19,7 @@ type DeployTarget struct {
 func deployTargetFromAPI(d *oapi.DeployTarget, zone string) *DeployTarget {
 	return &DeployTarget{
 		Description: d.Description,
-		ID:          d.Id,
+		ID:          &d.Id,
 		Name:        d.Name,
 		Type:        (*string)(d.Type),
 		Zone:        &zone,

--- a/vendor/github.com/exoscale/egoscale/v2/instance.go
+++ b/vendor/github.com/exoscale/egoscale/v2/instance.go
@@ -76,6 +76,15 @@ func ListInstancesByManagerType(v string) ListInstancesOpt {
 	}
 }
 
+// ListInstancesByIpAddress sets a Compute instances listing filter based on an IP Address.
+func ListInstancesByIpAddress(v string) ListInstancesOpt { //nolint:revive
+	return func(p *oapi.ListInstancesParams) {
+		if v != "" {
+			p.IpAddress = &v
+		}
+	}
+}
+
 // ResetInstanceOpt represents a ResetInstance operation option.
 type ResetInstanceOpt func(*oapi.ResetInstanceJSONRequestBody)
 
@@ -124,7 +133,7 @@ func instanceFromAPI(i *oapi.Instance, zone string) *Instance {
 		CreatedAt: i.CreatedAt,
 		DeployTargetID: func() (v *string) {
 			if i.DeployTarget != nil {
-				v = i.DeployTarget.Id
+				v = &i.DeployTarget.Id
 			}
 			return
 		}(),
@@ -275,7 +284,9 @@ func (c *Client) AttachInstanceToPrivateNetwork(
 		opt(&body)
 	}
 
-	body.Instance = oapi.Instance{Id: instance.ID}
+	a := oapi.AttachInstanceToPrivateNetworkJSONBody{}
+	a.Instance.Id = instance.ID
+	body.Instance = a.Instance
 
 	resp, err := c.AttachInstanceToPrivateNetworkWithResponse(apiv2.WithZone(ctx, zone), *privateNetwork.ID, body)
 	if err != nil {
@@ -348,7 +359,7 @@ func (c *Client) CreateInstance(ctx context.Context, zone string, instance *Inst
 			}(),
 			DeployTarget: func() (v *oapi.DeployTarget) {
 				if instance.DeployTargetID != nil {
-					v = &oapi.DeployTarget{Id: instance.DeployTargetID}
+					v = &oapi.DeployTarget{Id: *instance.DeployTargetID}
 				}
 				return
 			}(),
@@ -795,6 +806,19 @@ func (c *Client) StopInstance(ctx context.Context, zone string, instance *Instan
 	}
 
 	return nil
+}
+
+// RevealInstancePassword retrieves a recently started instance's root password if possible.
+func (c *Client) RevealInstancePassword(ctx context.Context, zone string, instance *Instance) (string, error) {
+	resp, err := c.RevealInstancePasswordWithResponse(apiv2.WithZone(ctx, zone), *instance.ID)
+	if err != nil {
+		return "", err
+	}
+	// If the password is unavailable, return an empty string
+	if resp.JSON200.Password == nil {
+		return "", nil
+	}
+	return *resp.JSON200.Password, nil
 }
 
 // UpdateInstance updates a Compute instance.

--- a/vendor/github.com/exoscale/egoscale/v2/instance_pool.go
+++ b/vendor/github.com/exoscale/egoscale/v2/instance_pool.go
@@ -52,7 +52,7 @@ func instancePoolFromAPI(i *oapi.InstancePool, zone string) *InstancePool {
 		}(),
 		DeployTargetID: func() (v *string) {
 			if i.DeployTarget != nil {
-				v = i.DeployTarget.Id
+				v = &i.DeployTarget.Id
 			}
 			return
 		}(),
@@ -158,7 +158,7 @@ func (c *Client) CreateInstancePool(
 			}(),
 			DeployTarget: func() (v *oapi.DeployTarget) {
 				if instancePool.DeployTargetID != nil {
-					v = &oapi.DeployTarget{Id: instancePool.DeployTargetID}
+					v = &oapi.DeployTarget{Id: *instancePool.DeployTargetID}
 				}
 				return
 			}(),
@@ -385,7 +385,7 @@ func (c *Client) UpdateInstancePool(ctx context.Context, zone string, instancePo
 			}(),
 			DeployTarget: func() (v *oapi.DeployTarget) {
 				if instancePool.DeployTargetID != nil {
-					v = &oapi.DeployTarget{Id: instancePool.DeployTargetID}
+					v = &oapi.DeployTarget{Id: *instancePool.DeployTargetID}
 				}
 				return
 			}(),

--- a/vendor/github.com/exoscale/egoscale/v2/oapi/oapi.gen.go
+++ b/vendor/github.com/exoscale/egoscale/v2/oapi/oapi.gen.go
@@ -305,6 +305,29 @@ const (
 	EnumSortOrderDesc EnumSortOrder = "desc"
 )
 
+// Defines values for IamPolicyDefaultServiceStrategy.
+const (
+	IamPolicyDefaultServiceStrategyAllow IamPolicyDefaultServiceStrategy = "allow"
+
+	IamPolicyDefaultServiceStrategyDeny IamPolicyDefaultServiceStrategy = "deny"
+)
+
+// Defines values for IamServicePolicyType.
+const (
+	IamServicePolicyTypeAllow IamServicePolicyType = "allow"
+
+	IamServicePolicyTypeDeny IamServicePolicyType = "deny"
+
+	IamServicePolicyTypeRules IamServicePolicyType = "rules"
+)
+
+// Defines values for IamServicePolicyRuleAction.
+const (
+	IamServicePolicyRuleActionAllow IamServicePolicyRuleAction = "allow"
+
+	IamServicePolicyRuleActionDeny IamServicePolicyRuleAction = "deny"
+)
+
 // Defines values for InstanceState.
 const (
 	InstanceStateDestroyed InstanceState = "destroyed"
@@ -570,7 +593,7 @@ const (
 
 // Defines values for SksNodepoolAddons.
 const (
-	SksNodepoolAddonsLinbit SksNodepoolAddons = "linbit"
+	SksNodepoolAddonsStorageLvm SksNodepoolAddons = "storage-lvm"
 )
 
 // Defines values for SksNodepoolState.
@@ -631,6 +654,8 @@ const (
 // Defines values for ZoneName.
 const (
 	ZoneNameAtVie1 ZoneName = "at-vie-1"
+
+	ZoneNameAtVie2 ZoneName = "at-vie-2"
 
 	ZoneNameBgSof1 ZoneName = "bg-sof-1"
 
@@ -1051,6 +1076,7 @@ type DbaasServiceKafka struct {
 	ConnectionInfo *struct {
 		AccessCert  *string   `json:"access-cert,omitempty"`
 		AccessKey   *string   `json:"access-key,omitempty"`
+		ConnectUri  *string   `json:"connect-uri,omitempty"`
 		Nodes       *[]string `json:"nodes,omitempty"`
 		RegistryUri *string   `json:"registry-uri,omitempty"`
 		RestUri     *string   `json:"rest-uri,omitempty"`
@@ -1712,7 +1738,7 @@ type DeployTarget struct {
 	Description *string `json:"description,omitempty"`
 
 	// Deploy Target ID
-	Id *string `json:"id,omitempty"`
+	Id string `json:"id"`
 
 	// Deploy Target name
 	Name *string `json:"name,omitempty"`
@@ -1796,13 +1822,13 @@ type ElasticIpAddressfamily string
 
 // Elastic IP address healthcheck
 type ElasticIpHealthcheck struct {
-	// Interval between the checks (default: 10)
+	// Interval between the checks in seconds (default: 10)
 	Interval *int64 `json:"interval,omitempty"`
 
-	// Healthcheck mode
+	// Health check mode
 	Mode ElasticIpHealthcheckMode `json:"mode"`
 
-	// Healthcheck port
+	// Health check port
 	Port int64 `json:"port"`
 
 	// Number of attempts before considering the target unhealthy (default: 3)
@@ -1811,20 +1837,20 @@ type ElasticIpHealthcheck struct {
 	// Number of attempts before considering the target healthy (default: 2)
 	StrikesOk *int64 `json:"strikes-ok,omitempty"`
 
-	// Healthcheck timeout value (default: 2)
+	// Health check timeout value in seconds (default: 2)
 	Timeout *int64 `json:"timeout,omitempty"`
 
 	// Skip TLS verification
 	TlsSkipVerify *bool `json:"tls-skip-verify,omitempty"`
 
-	// SNI domain for HTTPS healthchecks
+	// An optional domain or subdomain to check TLS against
 	TlsSni *string `json:"tls-sni,omitempty"`
 
-	// Healthcheck URI
+	// An endpoint to use for the health check, for example '/status'
 	Uri *string `json:"uri,omitempty"`
 }
 
-// Healthcheck mode
+// Health check mode
 type ElasticIpHealthcheckMode string
 
 // EnumComponentRoute defines model for enum-component-route.
@@ -1863,14 +1889,126 @@ type EnumServiceState string
 // EnumSortOrder defines model for enum-sort-order.
 type EnumSortOrder string
 
-// A notable event which happened on the infrastructure
+// A notable Mutation Event which happened on the infrastructure
 type Event struct {
-	// Event payload. This is a free-form map
-	Payload *map[string]interface{} `json:"payload,omitempty"`
+	// Body parameters (free form map)
+	BodyParams *map[string]interface{} `json:"body-params,omitempty"`
+
+	// Operation processing time
+	ElapsedMs *int64 `json:"elapsed-ms,omitempty"`
+
+	// Query string parameters (free form map)
+	GetParams *map[string]interface{} `json:"get-params,omitempty"`
+
+	// Operation handler name
+	Handler *string `json:"handler,omitempty"`
+
+	// Operation message
+	Message *string `json:"message,omitempty"`
+
+	// URI path parameters (free form map)
+	PathParams *map[string]interface{} `json:"path-params,omitempty"`
+
+	// Client IP address
+	RemoteAddr *string `json:"remote-addr,omitempty"`
+
+	// Operation unique identifier
+	RequestId *string `json:"request-id,omitempty"`
+
+	// Operation HTTP status
+	Status *int64 `json:"status,omitempty"`
 
 	// Time at which the event happened, millisecond resolution
 	Timestamp *time.Time `json:"timestamp,omitempty"`
+
+	// Operation request URI
+	Uri *string `json:"uri,omitempty"`
+
+	// Operation targeted zone
+	Zone *string `json:"zone,omitempty"`
 }
+
+// IAM API Key
+type IamApiKey struct {
+	// IAM API Key
+	Key *string `json:"key,omitempty"`
+
+	// IAM API Key name
+	Name *string `json:"name,omitempty"`
+
+	// IAM API Key Role ID
+	RoleId *string `json:"role-id,omitempty"`
+}
+
+// IAM API Key
+type IamApiKeyCreated struct {
+	// IAM API Key
+	Key *string `json:"key,omitempty"`
+
+	// IAM API Key name
+	Name *string `json:"name,omitempty"`
+
+	// IAM API Key Role ID
+	RoleId *string `json:"role-id,omitempty"`
+
+	// IAM API Key Secret
+	Secret *string `json:"secret,omitempty"`
+}
+
+// Policy
+type IamPolicy struct {
+	// IAM default service strategy
+	DefaultServiceStrategy IamPolicyDefaultServiceStrategy `json:"default-service-strategy"`
+
+	// IAM services
+	Services IamPolicy_Services `json:"services"`
+}
+
+// IAM default service strategy
+type IamPolicyDefaultServiceStrategy string
+
+// IAM services
+type IamPolicy_Services struct {
+	AdditionalProperties map[string]IamServicePolicy `json:"-"`
+}
+
+// IAM Role
+type IamRole struct {
+	// IAM Role description
+	Description *string `json:"description,omitempty"`
+
+	// IAM Role mutability
+	Editable *bool `json:"editable,omitempty"`
+
+	// IAM Role ID
+	Id     *string `json:"id,omitempty"`
+	Labels *Labels `json:"labels,omitempty"`
+
+	// IAM Role name
+	Name *string `json:"name,omitempty"`
+
+	// Policy
+	Policy *IamPolicy `json:"policy,omitempty"`
+}
+
+// IamServicePolicy defines model for iam-service-policy.
+type IamServicePolicy struct {
+	Rules *[]IamServicePolicyRule `json:"rules,omitempty"`
+	Type  *IamServicePolicyType   `json:"type,omitempty"`
+}
+
+// IamServicePolicyType defines model for IamServicePolicy.Type.
+type IamServicePolicyType string
+
+// IamServicePolicyRule defines model for iam-service-policy-rule.
+type IamServicePolicyRule struct {
+	Action     *IamServicePolicyRuleAction `json:"action,omitempty"`
+	Expression *string                     `json:"expression,omitempty"`
+	Resources  *[]string                   `json:"resources,omitempty"`
+}
+
+// IamServicePolicyRuleAction defines model for IamServicePolicyRule.Action.
+type IamServicePolicyRuleAction string
 
 // Instance
 type Instance struct {
@@ -1920,6 +2058,9 @@ type Instance struct {
 
 	// SSH key
 	SshKey *SshKey `json:"ssh-key,omitempty"`
+
+	// Instance SSH Keys
+	SshKeys *[]SshKey `json:"ssh-keys,omitempty"`
 
 	// Instance state
 	State *InstanceState `json:"state,omitempty"`
@@ -1994,6 +2135,9 @@ type InstancePool struct {
 
 	// SSH key
 	SshKey *SshKey `json:"ssh-key,omitempty"`
+
+	// Instances SSH keys
+	SshKeys *[]SshKey `json:"ssh-keys,omitempty"`
 
 	// Instance Pool state
 	State *InstancePoolState `json:"state,omitempty"`
@@ -2289,7 +2433,8 @@ type SecurityGroupResource struct {
 }
 
 // Whether this points to a public security group. This is only valid when in the context of
-//                    a rule addition which uses a public security group as a source or destination.
+//
+//	a rule addition which uses a public security group as a source or destination.
 type SecurityGroupResourceVisibility string
 
 // Security Group rule
@@ -2653,6 +2798,15 @@ type CreateAntiAffinityGroupJSONBody struct {
 
 	// Anti-affinity Group name
 	Name string `json:"name"`
+}
+
+// CreateApiKeyJSONBody defines parameters for CreateApiKey.
+type CreateApiKeyJSONBody struct {
+	// IAM API Key Name
+	Name string `json:"name"`
+
+	// IAM API Key Role ID
+	RoleId string `json:"role-id"`
 }
 
 // CreateDbaasIntegrationJSONBody defines parameters for CreateDbaasIntegration.
@@ -3504,7 +3658,7 @@ type UpdateDnsDomainRecordJSONBody struct {
 
 // CreateElasticIpJSONBody defines parameters for CreateElasticIp.
 type CreateElasticIpJSONBody struct {
-	// Elastic IP address family (default: inet4)
+	// Elastic IP address family (default: :inet4)
 	Addressfamily *CreateElasticIpJSONBodyAddressfamily `json:"addressfamily,omitempty"`
 
 	// Elastic IP description
@@ -3521,7 +3675,7 @@ type CreateElasticIpJSONBodyAddressfamily string
 // UpdateElasticIpJSONBody defines parameters for UpdateElasticIp.
 type UpdateElasticIpJSONBody struct {
 	// Elastic IP description
-	Description *string `json:"description"`
+	Description *string `json:"description,omitempty"`
 
 	// Elastic IP address healthcheck
 	Healthcheck *ElasticIpHealthcheck `json:"healthcheck,omitempty"`
@@ -3549,10 +3703,40 @@ type ListEventsParams struct {
 	To   *time.Time `json:"to,omitempty"`
 }
 
+// UpdateIamOrganizationPolicyJSONBody defines parameters for UpdateIamOrganizationPolicy.
+type UpdateIamOrganizationPolicyJSONBody IamPolicy
+
+// CreateIamRoleJSONBody defines parameters for CreateIamRole.
+type CreateIamRoleJSONBody struct {
+	// IAM Role description
+	Description *string `json:"description,omitempty"`
+
+	// Make IAM Role editable (default: true)
+	Editable *bool   `json:"editable,omitempty"`
+	Labels   *Labels `json:"labels,omitempty"`
+
+	// IAM Role name
+	Name string `json:"name"`
+
+	// Policy
+	Policy *IamPolicy `json:"policy,omitempty"`
+}
+
+// UpdateIamRoleJSONBody defines parameters for UpdateIamRole.
+type UpdateIamRoleJSONBody struct {
+	// IAM Role description
+	Description *string `json:"description,omitempty"`
+	Labels      *Labels `json:"labels,omitempty"`
+}
+
+// UpdateIamRolePolicyJSONBody defines parameters for UpdateIamRolePolicy.
+type UpdateIamRolePolicyJSONBody IamPolicy
+
 // ListInstancesParams defines parameters for ListInstances.
 type ListInstancesParams struct {
 	ManagerId   *string                         `json:"manager-id,omitempty"`
 	ManagerType *ListInstancesParamsManagerType `json:"manager-type,omitempty"`
+	IpAddress   *string                         `json:"ip-address,omitempty"`
 }
 
 // ListInstancesParamsManagerType defines parameters for ListInstances.
@@ -3588,6 +3772,9 @@ type CreateInstanceJSONBody struct {
 
 	// SSH key
 	SshKey *SshKey `json:"ssh-key,omitempty"`
+
+	// Instance SSH Keys
+	SshKeys *[]SshKey `json:"ssh-keys,omitempty"`
 
 	// Instance template
 	Template Template `json:"template"`
@@ -3641,6 +3828,9 @@ type CreateInstancePoolJSONBody struct {
 
 	// SSH key
 	SshKey *SshKey `json:"ssh-key,omitempty"`
+
+	// Instances SSH Keys
+	SshKeys *[]SshKey `json:"ssh-keys,omitempty"`
 
 	// Instance template
 	Template Template `json:"template"`
@@ -3893,8 +4083,11 @@ type ResetPrivateNetworkFieldParamsField string
 
 // AttachInstanceToPrivateNetworkJSONBody defines parameters for AttachInstanceToPrivateNetwork.
 type AttachInstanceToPrivateNetworkJSONBody struct {
-	// Instance
-	Instance Instance `json:"instance"`
+	// Compute instance
+	Instance struct {
+		// Instance ID
+		Id *string `json:"id,omitempty"`
+	} `json:"instance"`
 
 	// Static IP address lease for the corresponding network interface
 	Ip *string `json:"ip,omitempty"`
@@ -4257,7 +4450,7 @@ type CopyTemplateJSONBody struct {
 // UpdateTemplateJSONBody defines parameters for UpdateTemplate.
 type UpdateTemplateJSONBody struct {
 	// Template Description
-	Description *string `json:"description"`
+	Description *string `json:"description,omitempty"`
 
 	// Template name
 	Name *string `json:"name,omitempty"`
@@ -4268,6 +4461,9 @@ type CreateAccessKeyJSONRequestBody CreateAccessKeyJSONBody
 
 // CreateAntiAffinityGroupJSONRequestBody defines body for CreateAntiAffinityGroup for application/json ContentType.
 type CreateAntiAffinityGroupJSONRequestBody CreateAntiAffinityGroupJSONBody
+
+// CreateApiKeyJSONRequestBody defines body for CreateApiKey for application/json ContentType.
+type CreateApiKeyJSONRequestBody CreateApiKeyJSONBody
 
 // CreateDbaasIntegrationJSONRequestBody defines body for CreateDbaasIntegration for application/json ContentType.
 type CreateDbaasIntegrationJSONRequestBody CreateDbaasIntegrationJSONBody
@@ -4355,6 +4551,18 @@ type AttachInstanceToElasticIpJSONRequestBody AttachInstanceToElasticIpJSONBody
 
 // DetachInstanceFromElasticIpJSONRequestBody defines body for DetachInstanceFromElasticIp for application/json ContentType.
 type DetachInstanceFromElasticIpJSONRequestBody DetachInstanceFromElasticIpJSONBody
+
+// UpdateIamOrganizationPolicyJSONRequestBody defines body for UpdateIamOrganizationPolicy for application/json ContentType.
+type UpdateIamOrganizationPolicyJSONRequestBody UpdateIamOrganizationPolicyJSONBody
+
+// CreateIamRoleJSONRequestBody defines body for CreateIamRole for application/json ContentType.
+type CreateIamRoleJSONRequestBody CreateIamRoleJSONBody
+
+// UpdateIamRoleJSONRequestBody defines body for UpdateIamRole for application/json ContentType.
+type UpdateIamRoleJSONRequestBody UpdateIamRoleJSONBody
+
+// UpdateIamRolePolicyJSONRequestBody defines body for UpdateIamRolePolicy for application/json ContentType.
+type UpdateIamRolePolicyJSONRequestBody UpdateIamRolePolicyJSONBody
 
 // CreateInstanceJSONRequestBody defines body for CreateInstance for application/json ContentType.
 type CreateInstanceJSONRequestBody CreateInstanceJSONBody
@@ -4478,6 +4686,59 @@ type CopyTemplateJSONRequestBody CopyTemplateJSONBody
 
 // UpdateTemplateJSONRequestBody defines body for UpdateTemplate for application/json ContentType.
 type UpdateTemplateJSONRequestBody UpdateTemplateJSONBody
+
+// Getter for additional properties for IamPolicy_Services. Returns the specified
+// element and whether it was found
+func (a IamPolicy_Services) Get(fieldName string) (value IamServicePolicy, found bool) {
+	if a.AdditionalProperties != nil {
+		value, found = a.AdditionalProperties[fieldName]
+	}
+	return
+}
+
+// Setter for additional properties for IamPolicy_Services
+func (a *IamPolicy_Services) Set(fieldName string, value IamServicePolicy) {
+	if a.AdditionalProperties == nil {
+		a.AdditionalProperties = make(map[string]IamServicePolicy)
+	}
+	a.AdditionalProperties[fieldName] = value
+}
+
+// Override default JSON handling for IamPolicy_Services to handle AdditionalProperties
+func (a *IamPolicy_Services) UnmarshalJSON(b []byte) error {
+	object := make(map[string]json.RawMessage)
+	err := json.Unmarshal(b, &object)
+	if err != nil {
+		return err
+	}
+
+	if len(object) != 0 {
+		a.AdditionalProperties = make(map[string]IamServicePolicy)
+		for fieldName, fieldBuf := range object {
+			var fieldVal IamServicePolicy
+			err := json.Unmarshal(fieldBuf, &fieldVal)
+			if err != nil {
+				return fmt.Errorf("error unmarshaling field %s: %w", fieldName, err)
+			}
+			a.AdditionalProperties[fieldName] = fieldVal
+		}
+	}
+	return nil
+}
+
+// Override default JSON handling for IamPolicy_Services to handle AdditionalProperties
+func (a IamPolicy_Services) MarshalJSON() ([]byte, error) {
+	var err error
+	object := make(map[string]json.RawMessage)
+
+	for fieldName, field := range a.AdditionalProperties {
+		object[fieldName], err = json.Marshal(field)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling '%s': %w", fieldName, err)
+		}
+	}
+	return json.Marshal(object)
+}
 
 // Getter for additional properties for Labels. Returns the specified
 // element and whether it was found
@@ -4798,6 +5059,20 @@ type ClientInterface interface {
 	// GetAntiAffinityGroup request
 	GetAntiAffinityGroup(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// ListApiKeys request
+	ListApiKeys(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// CreateApiKey request with any body
+	CreateApiKeyWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	CreateApiKey(ctx context.Context, body CreateApiKeyJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// DeleteApiKey request
+	DeleteApiKey(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetApiKey request
+	GetApiKey(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// GetDbaasCaCertificate request
 	GetDbaasCaCertificate(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -4838,6 +5113,9 @@ type ClientInterface interface {
 
 	// GetDbaasKafkaAclConfig request
 	GetDbaasKafkaAclConfig(ctx context.Context, name DbaasServiceName, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// StartDbaasKafkaMaintenance request
+	StartDbaasKafkaMaintenance(ctx context.Context, name DbaasServiceName, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// CreateDbaasKafkaSchemaRegistryAclConfig request with any body
 	CreateDbaasKafkaSchemaRegistryAclConfigWithBody(ctx context.Context, name DbaasServiceName, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -4884,6 +5162,9 @@ type ClientInterface interface {
 
 	UpdateDbaasServiceMysql(ctx context.Context, name DbaasServiceName, body UpdateDbaasServiceMysqlJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// StartDbaasMysqlMaintenance request
+	StartDbaasMysqlMaintenance(ctx context.Context, name DbaasServiceName, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// StopDbaasMysqlMigration request
 	StopDbaasMysqlMigration(ctx context.Context, name DbaasServiceName, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -4900,6 +5181,9 @@ type ClientInterface interface {
 
 	UpdateDbaasServiceOpensearch(ctx context.Context, name DbaasServiceName, body UpdateDbaasServiceOpensearchJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// StartDbaasOpensearchMaintenance request
+	StartDbaasOpensearchMaintenance(ctx context.Context, name DbaasServiceName, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// GetDbaasServicePg request
 	GetDbaasServicePg(ctx context.Context, name DbaasServiceName, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -4912,6 +5196,9 @@ type ClientInterface interface {
 	UpdateDbaasServicePgWithBody(ctx context.Context, name DbaasServiceName, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	UpdateDbaasServicePg(ctx context.Context, name DbaasServiceName, body UpdateDbaasServicePgJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// StartDbaasPgMaintenance request
+	StartDbaasPgMaintenance(ctx context.Context, name DbaasServiceName, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// StopDbaasPgMigration request
 	StopDbaasPgMigration(ctx context.Context, name DbaasServiceName, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -4946,6 +5233,9 @@ type ClientInterface interface {
 	UpdateDbaasServiceRedisWithBody(ctx context.Context, name DbaasServiceName, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	UpdateDbaasServiceRedis(ctx context.Context, name DbaasServiceName, body UpdateDbaasServiceRedisJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// StartDbaasRedisMaintenance request
+	StartDbaasRedisMaintenance(ctx context.Context, name DbaasServiceName, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// StopDbaasRedisMigration request
 	StopDbaasRedisMigration(ctx context.Context, name DbaasServiceName, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -5071,6 +5361,38 @@ type ClientInterface interface {
 
 	// ListEvents request
 	ListEvents(ctx context.Context, params *ListEventsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetIamOrganizationPolicy request
+	GetIamOrganizationPolicy(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UpdateIamOrganizationPolicy request with any body
+	UpdateIamOrganizationPolicyWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UpdateIamOrganizationPolicy(ctx context.Context, body UpdateIamOrganizationPolicyJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ListIamRoles request
+	ListIamRoles(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// CreateIamRole request with any body
+	CreateIamRoleWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	CreateIamRole(ctx context.Context, body CreateIamRoleJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// DeleteIamRole request
+	DeleteIamRole(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetIamRole request
+	GetIamRole(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UpdateIamRole request with any body
+	UpdateIamRoleWithBody(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UpdateIamRole(ctx context.Context, id string, body UpdateIamRoleJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UpdateIamRolePolicy request with any body
+	UpdateIamRolePolicyWithBody(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UpdateIamRolePolicy(ctx context.Context, id string, body UpdateIamRolePolicyJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ListInstances request
 	ListInstances(ctx context.Context, params *ListInstancesParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -5614,6 +5936,66 @@ func (c *Client) GetAntiAffinityGroup(ctx context.Context, id string, reqEditors
 	return c.Client.Do(req)
 }
 
+func (c *Client) ListApiKeys(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListApiKeysRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CreateApiKeyWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateApiKeyRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CreateApiKey(ctx context.Context, body CreateApiKeyJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateApiKeyRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) DeleteApiKey(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeleteApiKeyRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetApiKey(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetApiKeyRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
 func (c *Client) GetDbaasCaCertificate(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewGetDbaasCaCertificateRequest(c.Server)
 	if err != nil {
@@ -5784,6 +6166,18 @@ func (c *Client) UpdateDbaasServiceKafka(ctx context.Context, name DbaasServiceN
 
 func (c *Client) GetDbaasKafkaAclConfig(ctx context.Context, name DbaasServiceName, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewGetDbaasKafkaAclConfigRequest(c.Server, name)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) StartDbaasKafkaMaintenance(ctx context.Context, name DbaasServiceName, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewStartDbaasKafkaMaintenanceRequest(c.Server, name)
 	if err != nil {
 		return nil, err
 	}
@@ -5998,6 +6392,18 @@ func (c *Client) UpdateDbaasServiceMysql(ctx context.Context, name DbaasServiceN
 	return c.Client.Do(req)
 }
 
+func (c *Client) StartDbaasMysqlMaintenance(ctx context.Context, name DbaasServiceName, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewStartDbaasMysqlMaintenanceRequest(c.Server, name)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
 func (c *Client) StopDbaasMysqlMigration(ctx context.Context, name DbaasServiceName, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewStopDbaasMysqlMigrationRequest(c.Server, name)
 	if err != nil {
@@ -6070,6 +6476,18 @@ func (c *Client) UpdateDbaasServiceOpensearch(ctx context.Context, name DbaasSer
 	return c.Client.Do(req)
 }
 
+func (c *Client) StartDbaasOpensearchMaintenance(ctx context.Context, name DbaasServiceName, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewStartDbaasOpensearchMaintenanceRequest(c.Server, name)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
 func (c *Client) GetDbaasServicePg(ctx context.Context, name DbaasServiceName, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewGetDbaasServicePgRequest(c.Server, name)
 	if err != nil {
@@ -6120,6 +6538,18 @@ func (c *Client) UpdateDbaasServicePgWithBody(ctx context.Context, name DbaasSer
 
 func (c *Client) UpdateDbaasServicePg(ctx context.Context, name DbaasServiceName, body UpdateDbaasServicePgJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewUpdateDbaasServicePgRequest(c.Server, name, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) StartDbaasPgMaintenance(ctx context.Context, name DbaasServiceName, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewStartDbaasPgMaintenanceRequest(c.Server, name)
 	if err != nil {
 		return nil, err
 	}
@@ -6276,6 +6706,18 @@ func (c *Client) UpdateDbaasServiceRedisWithBody(ctx context.Context, name Dbaas
 
 func (c *Client) UpdateDbaasServiceRedis(ctx context.Context, name DbaasServiceName, body UpdateDbaasServiceRedisJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewUpdateDbaasServiceRedisRequest(c.Server, name, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) StartDbaasRedisMaintenance(ctx context.Context, name DbaasServiceName, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewStartDbaasRedisMaintenanceRequest(c.Server, name)
 	if err != nil {
 		return nil, err
 	}
@@ -6816,6 +7258,150 @@ func (c *Client) DetachInstanceFromElasticIp(ctx context.Context, id string, bod
 
 func (c *Client) ListEvents(ctx context.Context, params *ListEventsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewListEventsRequest(c.Server, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetIamOrganizationPolicy(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetIamOrganizationPolicyRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateIamOrganizationPolicyWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateIamOrganizationPolicyRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateIamOrganizationPolicy(ctx context.Context, body UpdateIamOrganizationPolicyJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateIamOrganizationPolicyRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ListIamRoles(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListIamRolesRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CreateIamRoleWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateIamRoleRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CreateIamRole(ctx context.Context, body CreateIamRoleJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateIamRoleRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) DeleteIamRole(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeleteIamRoleRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetIamRole(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetIamRoleRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateIamRoleWithBody(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateIamRoleRequestWithBody(c.Server, id, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateIamRole(ctx context.Context, id string, body UpdateIamRoleJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateIamRoleRequest(c.Server, id, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateIamRolePolicyWithBody(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateIamRolePolicyRequestWithBody(c.Server, id, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateIamRolePolicy(ctx context.Context, id string, body UpdateIamRolePolicyJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateIamRolePolicyRequest(c.Server, id, body)
 	if err != nil {
 		return nil, err
 	}
@@ -8902,6 +9488,141 @@ func NewGetAntiAffinityGroupRequest(server string, id string) (*http.Request, er
 	return req, nil
 }
 
+// NewListApiKeysRequest generates requests for ListApiKeys
+func NewListApiKeysRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api-key")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewCreateApiKeyRequest calls the generic CreateApiKey builder with application/json body
+func NewCreateApiKeyRequest(server string, body CreateApiKeyJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewCreateApiKeyRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewCreateApiKeyRequestWithBody generates requests for CreateApiKey with any type of body
+func NewCreateApiKeyRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api-key")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewDeleteApiKeyRequest generates requests for DeleteApiKey
+func NewDeleteApiKeyRequest(server string, id string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api-key/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("DELETE", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetApiKeyRequest generates requests for GetApiKey
+func NewGetApiKeyRequest(server string, id string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api-key/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewGetDbaasCaCertificateRequest generates requests for GetDbaasCaCertificate
 func NewGetDbaasCaCertificateRequest(server string) (*http.Request, error) {
 	var err error
@@ -9314,6 +10035,40 @@ func NewGetDbaasKafkaAclConfigRequest(server string, name DbaasServiceName) (*ht
 	}
 
 	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewStartDbaasKafkaMaintenanceRequest generates requests for StartDbaasKafkaMaintenance
+func NewStartDbaasKafkaMaintenanceRequest(server string, name DbaasServiceName) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "name", runtime.ParamLocationPath, name)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/dbaas-kafka/%s/maintenance/start", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PUT", queryURL.String(), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -9801,6 +10556,40 @@ func NewUpdateDbaasServiceMysqlRequestWithBody(server string, name DbaasServiceN
 	return req, nil
 }
 
+// NewStartDbaasMysqlMaintenanceRequest generates requests for StartDbaasMysqlMaintenance
+func NewStartDbaasMysqlMaintenanceRequest(server string, name DbaasServiceName) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "name", runtime.ParamLocationPath, name)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/dbaas-mysql/%s/maintenance/start", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PUT", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewStopDbaasMysqlMigrationRequest generates requests for StopDbaasMysqlMigration
 func NewStopDbaasMysqlMigrationRequest(server string, name DbaasServiceName) (*http.Request, error) {
 	var err error
@@ -9963,6 +10752,40 @@ func NewUpdateDbaasServiceOpensearchRequestWithBody(server string, name DbaasSer
 	return req, nil
 }
 
+// NewStartDbaasOpensearchMaintenanceRequest generates requests for StartDbaasOpensearchMaintenance
+func NewStartDbaasOpensearchMaintenanceRequest(server string, name DbaasServiceName) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "name", runtime.ParamLocationPath, name)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/dbaas-opensearch/%s/maintenance/start", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PUT", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewGetDbaasServicePgRequest generates requests for GetDbaasServicePg
 func NewGetDbaasServicePgRequest(server string, name DbaasServiceName) (*http.Request, error) {
 	var err error
@@ -10087,6 +10910,40 @@ func NewUpdateDbaasServicePgRequestWithBody(server string, name DbaasServiceName
 	}
 
 	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewStartDbaasPgMaintenanceRequest generates requests for StartDbaasPgMaintenance
+func NewStartDbaasPgMaintenanceRequest(server string, name DbaasServiceName) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "name", runtime.ParamLocationPath, name)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/dbaas-postgres/%s/maintenance/start", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PUT", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
 
 	return req, nil
 }
@@ -10445,6 +11302,40 @@ func NewUpdateDbaasServiceRedisRequestWithBody(server string, name DbaasServiceN
 	}
 
 	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewStartDbaasRedisMaintenanceRequest generates requests for StartDbaasRedisMaintenance
+func NewStartDbaasRedisMaintenanceRequest(server string, name DbaasServiceName) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "name", runtime.ParamLocationPath, name)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/dbaas-redis/%s/maintenance/start", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PUT", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
 
 	return req, nil
 }
@@ -11749,6 +12640,302 @@ func NewListEventsRequest(server string, params *ListEventsParams) (*http.Reques
 	return req, nil
 }
 
+// NewGetIamOrganizationPolicyRequest generates requests for GetIamOrganizationPolicy
+func NewGetIamOrganizationPolicyRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/iam-organization-policy")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewUpdateIamOrganizationPolicyRequest calls the generic UpdateIamOrganizationPolicy builder with application/json body
+func NewUpdateIamOrganizationPolicyRequest(server string, body UpdateIamOrganizationPolicyJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUpdateIamOrganizationPolicyRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewUpdateIamOrganizationPolicyRequestWithBody generates requests for UpdateIamOrganizationPolicy with any type of body
+func NewUpdateIamOrganizationPolicyRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/iam-organization-policy")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PUT", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewListIamRolesRequest generates requests for ListIamRoles
+func NewListIamRolesRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/iam-role")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewCreateIamRoleRequest calls the generic CreateIamRole builder with application/json body
+func NewCreateIamRoleRequest(server string, body CreateIamRoleJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewCreateIamRoleRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewCreateIamRoleRequestWithBody generates requests for CreateIamRole with any type of body
+func NewCreateIamRoleRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/iam-role")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewDeleteIamRoleRequest generates requests for DeleteIamRole
+func NewDeleteIamRoleRequest(server string, id string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/iam-role/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("DELETE", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetIamRoleRequest generates requests for GetIamRole
+func NewGetIamRoleRequest(server string, id string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/iam-role/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewUpdateIamRoleRequest calls the generic UpdateIamRole builder with application/json body
+func NewUpdateIamRoleRequest(server string, id string, body UpdateIamRoleJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUpdateIamRoleRequestWithBody(server, id, "application/json", bodyReader)
+}
+
+// NewUpdateIamRoleRequestWithBody generates requests for UpdateIamRole with any type of body
+func NewUpdateIamRoleRequestWithBody(server string, id string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/iam-role/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PUT", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewUpdateIamRolePolicyRequest calls the generic UpdateIamRolePolicy builder with application/json body
+func NewUpdateIamRolePolicyRequest(server string, id string, body UpdateIamRolePolicyJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUpdateIamRolePolicyRequestWithBody(server, id, "application/json", bodyReader)
+}
+
+// NewUpdateIamRolePolicyRequestWithBody generates requests for UpdateIamRolePolicy with any type of body
+func NewUpdateIamRolePolicyRequestWithBody(server string, id string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/iam-role/%s:policy", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PUT", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
 // NewListInstancesRequest generates requests for ListInstances
 func NewListInstancesRequest(server string, params *ListInstancesParams) (*http.Request, error) {
 	var err error
@@ -11789,6 +12976,22 @@ func NewListInstancesRequest(server string, params *ListInstancesParams) (*http.
 	if params.ManagerType != nil {
 
 		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "manager-type", runtime.ParamLocationQuery, *params.ManagerType); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	if params.IpAddress != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "ip-address", runtime.ParamLocationQuery, *params.IpAddress); err != nil {
 			return nil, err
 		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
 			return nil, err
@@ -16040,6 +17243,20 @@ type ClientWithResponsesInterface interface {
 	// GetAntiAffinityGroup request
 	GetAntiAffinityGroupWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*GetAntiAffinityGroupResponse, error)
 
+	// ListApiKeys request
+	ListApiKeysWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListApiKeysResponse, error)
+
+	// CreateApiKey request with any body
+	CreateApiKeyWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateApiKeyResponse, error)
+
+	CreateApiKeyWithResponse(ctx context.Context, body CreateApiKeyJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateApiKeyResponse, error)
+
+	// DeleteApiKey request
+	DeleteApiKeyWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*DeleteApiKeyResponse, error)
+
+	// GetApiKey request
+	GetApiKeyWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*GetApiKeyResponse, error)
+
 	// GetDbaasCaCertificate request
 	GetDbaasCaCertificateWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetDbaasCaCertificateResponse, error)
 
@@ -16080,6 +17297,9 @@ type ClientWithResponsesInterface interface {
 
 	// GetDbaasKafkaAclConfig request
 	GetDbaasKafkaAclConfigWithResponse(ctx context.Context, name DbaasServiceName, reqEditors ...RequestEditorFn) (*GetDbaasKafkaAclConfigResponse, error)
+
+	// StartDbaasKafkaMaintenance request
+	StartDbaasKafkaMaintenanceWithResponse(ctx context.Context, name DbaasServiceName, reqEditors ...RequestEditorFn) (*StartDbaasKafkaMaintenanceResponse, error)
 
 	// CreateDbaasKafkaSchemaRegistryAclConfig request with any body
 	CreateDbaasKafkaSchemaRegistryAclConfigWithBodyWithResponse(ctx context.Context, name DbaasServiceName, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateDbaasKafkaSchemaRegistryAclConfigResponse, error)
@@ -16126,6 +17346,9 @@ type ClientWithResponsesInterface interface {
 
 	UpdateDbaasServiceMysqlWithResponse(ctx context.Context, name DbaasServiceName, body UpdateDbaasServiceMysqlJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateDbaasServiceMysqlResponse, error)
 
+	// StartDbaasMysqlMaintenance request
+	StartDbaasMysqlMaintenanceWithResponse(ctx context.Context, name DbaasServiceName, reqEditors ...RequestEditorFn) (*StartDbaasMysqlMaintenanceResponse, error)
+
 	// StopDbaasMysqlMigration request
 	StopDbaasMysqlMigrationWithResponse(ctx context.Context, name DbaasServiceName, reqEditors ...RequestEditorFn) (*StopDbaasMysqlMigrationResponse, error)
 
@@ -16142,6 +17365,9 @@ type ClientWithResponsesInterface interface {
 
 	UpdateDbaasServiceOpensearchWithResponse(ctx context.Context, name DbaasServiceName, body UpdateDbaasServiceOpensearchJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateDbaasServiceOpensearchResponse, error)
 
+	// StartDbaasOpensearchMaintenance request
+	StartDbaasOpensearchMaintenanceWithResponse(ctx context.Context, name DbaasServiceName, reqEditors ...RequestEditorFn) (*StartDbaasOpensearchMaintenanceResponse, error)
+
 	// GetDbaasServicePg request
 	GetDbaasServicePgWithResponse(ctx context.Context, name DbaasServiceName, reqEditors ...RequestEditorFn) (*GetDbaasServicePgResponse, error)
 
@@ -16154,6 +17380,9 @@ type ClientWithResponsesInterface interface {
 	UpdateDbaasServicePgWithBodyWithResponse(ctx context.Context, name DbaasServiceName, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateDbaasServicePgResponse, error)
 
 	UpdateDbaasServicePgWithResponse(ctx context.Context, name DbaasServiceName, body UpdateDbaasServicePgJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateDbaasServicePgResponse, error)
+
+	// StartDbaasPgMaintenance request
+	StartDbaasPgMaintenanceWithResponse(ctx context.Context, name DbaasServiceName, reqEditors ...RequestEditorFn) (*StartDbaasPgMaintenanceResponse, error)
 
 	// StopDbaasPgMigration request
 	StopDbaasPgMigrationWithResponse(ctx context.Context, name DbaasServiceName, reqEditors ...RequestEditorFn) (*StopDbaasPgMigrationResponse, error)
@@ -16188,6 +17417,9 @@ type ClientWithResponsesInterface interface {
 	UpdateDbaasServiceRedisWithBodyWithResponse(ctx context.Context, name DbaasServiceName, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateDbaasServiceRedisResponse, error)
 
 	UpdateDbaasServiceRedisWithResponse(ctx context.Context, name DbaasServiceName, body UpdateDbaasServiceRedisJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateDbaasServiceRedisResponse, error)
+
+	// StartDbaasRedisMaintenance request
+	StartDbaasRedisMaintenanceWithResponse(ctx context.Context, name DbaasServiceName, reqEditors ...RequestEditorFn) (*StartDbaasRedisMaintenanceResponse, error)
 
 	// StopDbaasRedisMigration request
 	StopDbaasRedisMigrationWithResponse(ctx context.Context, name DbaasServiceName, reqEditors ...RequestEditorFn) (*StopDbaasRedisMigrationResponse, error)
@@ -16313,6 +17545,38 @@ type ClientWithResponsesInterface interface {
 
 	// ListEvents request
 	ListEventsWithResponse(ctx context.Context, params *ListEventsParams, reqEditors ...RequestEditorFn) (*ListEventsResponse, error)
+
+	// GetIamOrganizationPolicy request
+	GetIamOrganizationPolicyWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetIamOrganizationPolicyResponse, error)
+
+	// UpdateIamOrganizationPolicy request with any body
+	UpdateIamOrganizationPolicyWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateIamOrganizationPolicyResponse, error)
+
+	UpdateIamOrganizationPolicyWithResponse(ctx context.Context, body UpdateIamOrganizationPolicyJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateIamOrganizationPolicyResponse, error)
+
+	// ListIamRoles request
+	ListIamRolesWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListIamRolesResponse, error)
+
+	// CreateIamRole request with any body
+	CreateIamRoleWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateIamRoleResponse, error)
+
+	CreateIamRoleWithResponse(ctx context.Context, body CreateIamRoleJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateIamRoleResponse, error)
+
+	// DeleteIamRole request
+	DeleteIamRoleWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*DeleteIamRoleResponse, error)
+
+	// GetIamRole request
+	GetIamRoleWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*GetIamRoleResponse, error)
+
+	// UpdateIamRole request with any body
+	UpdateIamRoleWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateIamRoleResponse, error)
+
+	UpdateIamRoleWithResponse(ctx context.Context, id string, body UpdateIamRoleJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateIamRoleResponse, error)
+
+	// UpdateIamRolePolicy request with any body
+	UpdateIamRolePolicyWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateIamRolePolicyResponse, error)
+
+	UpdateIamRolePolicyWithResponse(ctx context.Context, id string, body UpdateIamRolePolicyJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateIamRolePolicyResponse, error)
 
 	// ListInstances request
 	ListInstancesWithResponse(ctx context.Context, params *ListInstancesParams, reqEditors ...RequestEditorFn) (*ListInstancesResponse, error)
@@ -16940,6 +18204,96 @@ func (r GetAntiAffinityGroupResponse) StatusCode() int {
 	return 0
 }
 
+type ListApiKeysResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		ApiKeys *[]IamApiKey `json:"api-keys,omitempty"`
+	}
+}
+
+// Status returns HTTPResponse.Status
+func (r ListApiKeysResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListApiKeysResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type CreateApiKeyResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *IamApiKeyCreated
+}
+
+// Status returns HTTPResponse.Status
+func (r CreateApiKeyResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CreateApiKeyResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type DeleteApiKeyResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *Operation
+}
+
+// Status returns HTTPResponse.Status
+func (r DeleteApiKeyResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DeleteApiKeyResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetApiKeyResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *IamApiKey
+}
+
+// Status returns HTTPResponse.Status
+func (r GetApiKeyResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetApiKeyResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type GetDbaasCaCertificateResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -17194,6 +18548,28 @@ func (r GetDbaasKafkaAclConfigResponse) StatusCode() int {
 	return 0
 }
 
+type StartDbaasKafkaMaintenanceResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *Operation
+}
+
+// Status returns HTTPResponse.Status
+func (r StartDbaasKafkaMaintenanceResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r StartDbaasKafkaMaintenanceResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type CreateDbaasKafkaSchemaRegistryAclConfigResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -17436,6 +18812,28 @@ func (r UpdateDbaasServiceMysqlResponse) StatusCode() int {
 	return 0
 }
 
+type StartDbaasMysqlMaintenanceResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *Operation
+}
+
+// Status returns HTTPResponse.Status
+func (r StartDbaasMysqlMaintenanceResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r StartDbaasMysqlMaintenanceResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type StopDbaasMysqlMigrationResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -17524,6 +18922,28 @@ func (r UpdateDbaasServiceOpensearchResponse) StatusCode() int {
 	return 0
 }
 
+type StartDbaasOpensearchMaintenanceResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *Operation
+}
+
+// Status returns HTTPResponse.Status
+func (r StartDbaasOpensearchMaintenanceResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r StartDbaasOpensearchMaintenanceResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type GetDbaasServicePgResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -17584,6 +19004,28 @@ func (r UpdateDbaasServicePgResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r UpdateDbaasServicePgResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type StartDbaasPgMaintenanceResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *Operation
+}
+
+// Status returns HTTPResponse.Status
+func (r StartDbaasPgMaintenanceResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r StartDbaasPgMaintenanceResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -17760,6 +19202,28 @@ func (r UpdateDbaasServiceRedisResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r UpdateDbaasServiceRedisResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type StartDbaasRedisMaintenanceResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *Operation
+}
+
+// Status returns HTTPResponse.Status
+func (r StartDbaasRedisMaintenanceResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r StartDbaasRedisMaintenanceResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -18439,7 +19903,9 @@ func (r GetDnsDomainResponse) StatusCode() int {
 type GetDnsDomainZoneFileResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *string
+	JSON200      *struct {
+		ZoneFile *string `json:"zone-file,omitempty"`
+	}
 }
 
 // Status returns HTTPResponse.Status
@@ -18652,6 +20118,184 @@ func (r ListEventsResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r ListEventsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetIamOrganizationPolicyResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *[]IamPolicy
+}
+
+// Status returns HTTPResponse.Status
+func (r GetIamOrganizationPolicyResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetIamOrganizationPolicyResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UpdateIamOrganizationPolicyResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *Operation
+}
+
+// Status returns HTTPResponse.Status
+func (r UpdateIamOrganizationPolicyResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UpdateIamOrganizationPolicyResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type ListIamRolesResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		IamRoles *[]IamRole `json:"iam-roles,omitempty"`
+	}
+}
+
+// Status returns HTTPResponse.Status
+func (r ListIamRolesResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListIamRolesResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type CreateIamRoleResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *Operation
+}
+
+// Status returns HTTPResponse.Status
+func (r CreateIamRoleResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CreateIamRoleResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type DeleteIamRoleResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *Operation
+}
+
+// Status returns HTTPResponse.Status
+func (r DeleteIamRoleResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DeleteIamRoleResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetIamRoleResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *IamRole
+}
+
+// Status returns HTTPResponse.Status
+func (r GetIamRoleResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetIamRoleResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UpdateIamRoleResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *Operation
+}
+
+// Status returns HTTPResponse.Status
+func (r UpdateIamRoleResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UpdateIamRoleResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UpdateIamRolePolicyResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *Operation
+}
+
+// Status returns HTTPResponse.Status
+func (r UpdateIamRolePolicyResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UpdateIamRolePolicyResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -21108,6 +22752,50 @@ func (c *ClientWithResponses) GetAntiAffinityGroupWithResponse(ctx context.Conte
 	return ParseGetAntiAffinityGroupResponse(rsp)
 }
 
+// ListApiKeysWithResponse request returning *ListApiKeysResponse
+func (c *ClientWithResponses) ListApiKeysWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListApiKeysResponse, error) {
+	rsp, err := c.ListApiKeys(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListApiKeysResponse(rsp)
+}
+
+// CreateApiKeyWithBodyWithResponse request with arbitrary body returning *CreateApiKeyResponse
+func (c *ClientWithResponses) CreateApiKeyWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateApiKeyResponse, error) {
+	rsp, err := c.CreateApiKeyWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateApiKeyResponse(rsp)
+}
+
+func (c *ClientWithResponses) CreateApiKeyWithResponse(ctx context.Context, body CreateApiKeyJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateApiKeyResponse, error) {
+	rsp, err := c.CreateApiKey(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateApiKeyResponse(rsp)
+}
+
+// DeleteApiKeyWithResponse request returning *DeleteApiKeyResponse
+func (c *ClientWithResponses) DeleteApiKeyWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*DeleteApiKeyResponse, error) {
+	rsp, err := c.DeleteApiKey(ctx, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDeleteApiKeyResponse(rsp)
+}
+
+// GetApiKeyWithResponse request returning *GetApiKeyResponse
+func (c *ClientWithResponses) GetApiKeyWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*GetApiKeyResponse, error) {
+	rsp, err := c.GetApiKey(ctx, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetApiKeyResponse(rsp)
+}
+
 // GetDbaasCaCertificateWithResponse request returning *GetDbaasCaCertificateResponse
 func (c *ClientWithResponses) GetDbaasCaCertificateWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetDbaasCaCertificateResponse, error) {
 	rsp, err := c.GetDbaasCaCertificate(ctx, reqEditors...)
@@ -21237,6 +22925,15 @@ func (c *ClientWithResponses) GetDbaasKafkaAclConfigWithResponse(ctx context.Con
 		return nil, err
 	}
 	return ParseGetDbaasKafkaAclConfigResponse(rsp)
+}
+
+// StartDbaasKafkaMaintenanceWithResponse request returning *StartDbaasKafkaMaintenanceResponse
+func (c *ClientWithResponses) StartDbaasKafkaMaintenanceWithResponse(ctx context.Context, name DbaasServiceName, reqEditors ...RequestEditorFn) (*StartDbaasKafkaMaintenanceResponse, error) {
+	rsp, err := c.StartDbaasKafkaMaintenance(ctx, name, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseStartDbaasKafkaMaintenanceResponse(rsp)
 }
 
 // CreateDbaasKafkaSchemaRegistryAclConfigWithBodyWithResponse request with arbitrary body returning *CreateDbaasKafkaSchemaRegistryAclConfigResponse
@@ -21386,6 +23083,15 @@ func (c *ClientWithResponses) UpdateDbaasServiceMysqlWithResponse(ctx context.Co
 	return ParseUpdateDbaasServiceMysqlResponse(rsp)
 }
 
+// StartDbaasMysqlMaintenanceWithResponse request returning *StartDbaasMysqlMaintenanceResponse
+func (c *ClientWithResponses) StartDbaasMysqlMaintenanceWithResponse(ctx context.Context, name DbaasServiceName, reqEditors ...RequestEditorFn) (*StartDbaasMysqlMaintenanceResponse, error) {
+	rsp, err := c.StartDbaasMysqlMaintenance(ctx, name, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseStartDbaasMysqlMaintenanceResponse(rsp)
+}
+
 // StopDbaasMysqlMigrationWithResponse request returning *StopDbaasMysqlMigrationResponse
 func (c *ClientWithResponses) StopDbaasMysqlMigrationWithResponse(ctx context.Context, name DbaasServiceName, reqEditors ...RequestEditorFn) (*StopDbaasMysqlMigrationResponse, error) {
 	rsp, err := c.StopDbaasMysqlMigration(ctx, name, reqEditors...)
@@ -21438,6 +23144,15 @@ func (c *ClientWithResponses) UpdateDbaasServiceOpensearchWithResponse(ctx conte
 	return ParseUpdateDbaasServiceOpensearchResponse(rsp)
 }
 
+// StartDbaasOpensearchMaintenanceWithResponse request returning *StartDbaasOpensearchMaintenanceResponse
+func (c *ClientWithResponses) StartDbaasOpensearchMaintenanceWithResponse(ctx context.Context, name DbaasServiceName, reqEditors ...RequestEditorFn) (*StartDbaasOpensearchMaintenanceResponse, error) {
+	rsp, err := c.StartDbaasOpensearchMaintenance(ctx, name, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseStartDbaasOpensearchMaintenanceResponse(rsp)
+}
+
 // GetDbaasServicePgWithResponse request returning *GetDbaasServicePgResponse
 func (c *ClientWithResponses) GetDbaasServicePgWithResponse(ctx context.Context, name DbaasServiceName, reqEditors ...RequestEditorFn) (*GetDbaasServicePgResponse, error) {
 	rsp, err := c.GetDbaasServicePg(ctx, name, reqEditors...)
@@ -21479,6 +23194,15 @@ func (c *ClientWithResponses) UpdateDbaasServicePgWithResponse(ctx context.Conte
 		return nil, err
 	}
 	return ParseUpdateDbaasServicePgResponse(rsp)
+}
+
+// StartDbaasPgMaintenanceWithResponse request returning *StartDbaasPgMaintenanceResponse
+func (c *ClientWithResponses) StartDbaasPgMaintenanceWithResponse(ctx context.Context, name DbaasServiceName, reqEditors ...RequestEditorFn) (*StartDbaasPgMaintenanceResponse, error) {
+	rsp, err := c.StartDbaasPgMaintenance(ctx, name, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseStartDbaasPgMaintenanceResponse(rsp)
 }
 
 // StopDbaasPgMigrationWithResponse request returning *StopDbaasPgMigrationResponse
@@ -21591,6 +23315,15 @@ func (c *ClientWithResponses) UpdateDbaasServiceRedisWithResponse(ctx context.Co
 		return nil, err
 	}
 	return ParseUpdateDbaasServiceRedisResponse(rsp)
+}
+
+// StartDbaasRedisMaintenanceWithResponse request returning *StartDbaasRedisMaintenanceResponse
+func (c *ClientWithResponses) StartDbaasRedisMaintenanceWithResponse(ctx context.Context, name DbaasServiceName, reqEditors ...RequestEditorFn) (*StartDbaasRedisMaintenanceResponse, error) {
+	rsp, err := c.StartDbaasRedisMaintenance(ctx, name, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseStartDbaasRedisMaintenanceResponse(rsp)
 }
 
 // StopDbaasRedisMigrationWithResponse request returning *StopDbaasRedisMigrationResponse
@@ -21986,6 +23719,110 @@ func (c *ClientWithResponses) ListEventsWithResponse(ctx context.Context, params
 		return nil, err
 	}
 	return ParseListEventsResponse(rsp)
+}
+
+// GetIamOrganizationPolicyWithResponse request returning *GetIamOrganizationPolicyResponse
+func (c *ClientWithResponses) GetIamOrganizationPolicyWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetIamOrganizationPolicyResponse, error) {
+	rsp, err := c.GetIamOrganizationPolicy(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetIamOrganizationPolicyResponse(rsp)
+}
+
+// UpdateIamOrganizationPolicyWithBodyWithResponse request with arbitrary body returning *UpdateIamOrganizationPolicyResponse
+func (c *ClientWithResponses) UpdateIamOrganizationPolicyWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateIamOrganizationPolicyResponse, error) {
+	rsp, err := c.UpdateIamOrganizationPolicyWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateIamOrganizationPolicyResponse(rsp)
+}
+
+func (c *ClientWithResponses) UpdateIamOrganizationPolicyWithResponse(ctx context.Context, body UpdateIamOrganizationPolicyJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateIamOrganizationPolicyResponse, error) {
+	rsp, err := c.UpdateIamOrganizationPolicy(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateIamOrganizationPolicyResponse(rsp)
+}
+
+// ListIamRolesWithResponse request returning *ListIamRolesResponse
+func (c *ClientWithResponses) ListIamRolesWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListIamRolesResponse, error) {
+	rsp, err := c.ListIamRoles(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListIamRolesResponse(rsp)
+}
+
+// CreateIamRoleWithBodyWithResponse request with arbitrary body returning *CreateIamRoleResponse
+func (c *ClientWithResponses) CreateIamRoleWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateIamRoleResponse, error) {
+	rsp, err := c.CreateIamRoleWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateIamRoleResponse(rsp)
+}
+
+func (c *ClientWithResponses) CreateIamRoleWithResponse(ctx context.Context, body CreateIamRoleJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateIamRoleResponse, error) {
+	rsp, err := c.CreateIamRole(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateIamRoleResponse(rsp)
+}
+
+// DeleteIamRoleWithResponse request returning *DeleteIamRoleResponse
+func (c *ClientWithResponses) DeleteIamRoleWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*DeleteIamRoleResponse, error) {
+	rsp, err := c.DeleteIamRole(ctx, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDeleteIamRoleResponse(rsp)
+}
+
+// GetIamRoleWithResponse request returning *GetIamRoleResponse
+func (c *ClientWithResponses) GetIamRoleWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*GetIamRoleResponse, error) {
+	rsp, err := c.GetIamRole(ctx, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetIamRoleResponse(rsp)
+}
+
+// UpdateIamRoleWithBodyWithResponse request with arbitrary body returning *UpdateIamRoleResponse
+func (c *ClientWithResponses) UpdateIamRoleWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateIamRoleResponse, error) {
+	rsp, err := c.UpdateIamRoleWithBody(ctx, id, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateIamRoleResponse(rsp)
+}
+
+func (c *ClientWithResponses) UpdateIamRoleWithResponse(ctx context.Context, id string, body UpdateIamRoleJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateIamRoleResponse, error) {
+	rsp, err := c.UpdateIamRole(ctx, id, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateIamRoleResponse(rsp)
+}
+
+// UpdateIamRolePolicyWithBodyWithResponse request with arbitrary body returning *UpdateIamRolePolicyResponse
+func (c *ClientWithResponses) UpdateIamRolePolicyWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateIamRolePolicyResponse, error) {
+	rsp, err := c.UpdateIamRolePolicyWithBody(ctx, id, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateIamRolePolicyResponse(rsp)
+}
+
+func (c *ClientWithResponses) UpdateIamRolePolicyWithResponse(ctx context.Context, id string, body UpdateIamRolePolicyJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateIamRolePolicyResponse, error) {
+	rsp, err := c.UpdateIamRolePolicy(ctx, id, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateIamRolePolicyResponse(rsp)
 }
 
 // ListInstancesWithResponse request returning *ListInstancesResponse
@@ -23529,6 +25366,112 @@ func ParseGetAntiAffinityGroupResponse(rsp *http.Response) (*GetAntiAffinityGrou
 	return response, nil
 }
 
+// ParseListApiKeysResponse parses an HTTP response from a ListApiKeysWithResponse call
+func ParseListApiKeysResponse(rsp *http.Response) (*ListApiKeysResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListApiKeysResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			ApiKeys *[]IamApiKey `json:"api-keys,omitempty"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseCreateApiKeyResponse parses an HTTP response from a CreateApiKeyWithResponse call
+func ParseCreateApiKeyResponse(rsp *http.Response) (*CreateApiKeyResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CreateApiKeyResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest IamApiKeyCreated
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseDeleteApiKeyResponse parses an HTTP response from a DeleteApiKeyWithResponse call
+func ParseDeleteApiKeyResponse(rsp *http.Response) (*DeleteApiKeyResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DeleteApiKeyResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest Operation
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetApiKeyResponse parses an HTTP response from a GetApiKeyWithResponse call
+func ParseGetApiKeyResponse(rsp *http.Response) (*GetApiKeyResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetApiKeyResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest IamApiKey
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
 // ParseGetDbaasCaCertificateResponse parses an HTTP response from a GetDbaasCaCertificateWithResponse call
 func ParseGetDbaasCaCertificateResponse(rsp *http.Response) (*GetDbaasCaCertificateResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
@@ -23827,6 +25770,32 @@ func ParseGetDbaasKafkaAclConfigResponse(rsp *http.Response) (*GetDbaasKafkaAclC
 	return response, nil
 }
 
+// ParseStartDbaasKafkaMaintenanceResponse parses an HTTP response from a StartDbaasKafkaMaintenanceWithResponse call
+func ParseStartDbaasKafkaMaintenanceResponse(rsp *http.Response) (*StartDbaasKafkaMaintenanceResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &StartDbaasKafkaMaintenanceResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest Operation
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
 // ParseCreateDbaasKafkaSchemaRegistryAclConfigResponse parses an HTTP response from a CreateDbaasKafkaSchemaRegistryAclConfigWithResponse call
 func ParseCreateDbaasKafkaSchemaRegistryAclConfigResponse(rsp *http.Response) (*CreateDbaasKafkaSchemaRegistryAclConfigResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
@@ -24113,6 +26082,32 @@ func ParseUpdateDbaasServiceMysqlResponse(rsp *http.Response) (*UpdateDbaasServi
 	return response, nil
 }
 
+// ParseStartDbaasMysqlMaintenanceResponse parses an HTTP response from a StartDbaasMysqlMaintenanceWithResponse call
+func ParseStartDbaasMysqlMaintenanceResponse(rsp *http.Response) (*StartDbaasMysqlMaintenanceResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &StartDbaasMysqlMaintenanceResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest Operation
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
 // ParseStopDbaasMysqlMigrationResponse parses an HTTP response from a StopDbaasMysqlMigrationWithResponse call
 func ParseStopDbaasMysqlMigrationResponse(rsp *http.Response) (*StopDbaasMysqlMigrationResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
@@ -24217,6 +26212,32 @@ func ParseUpdateDbaasServiceOpensearchResponse(rsp *http.Response) (*UpdateDbaas
 	return response, nil
 }
 
+// ParseStartDbaasOpensearchMaintenanceResponse parses an HTTP response from a StartDbaasOpensearchMaintenanceWithResponse call
+func ParseStartDbaasOpensearchMaintenanceResponse(rsp *http.Response) (*StartDbaasOpensearchMaintenanceResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &StartDbaasOpensearchMaintenanceResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest Operation
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
 // ParseGetDbaasServicePgResponse parses an HTTP response from a GetDbaasServicePgWithResponse call
 func ParseGetDbaasServicePgResponse(rsp *http.Response) (*GetDbaasServicePgResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
@@ -24278,6 +26299,32 @@ func ParseUpdateDbaasServicePgResponse(rsp *http.Response) (*UpdateDbaasServiceP
 	}
 
 	response := &UpdateDbaasServicePgResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest Operation
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseStartDbaasPgMaintenanceResponse parses an HTTP response from a StartDbaasPgMaintenanceWithResponse call
+func ParseStartDbaasPgMaintenanceResponse(rsp *http.Response) (*StartDbaasPgMaintenanceResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &StartDbaasPgMaintenanceResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -24486,6 +26533,32 @@ func ParseUpdateDbaasServiceRedisResponse(rsp *http.Response) (*UpdateDbaasServi
 	}
 
 	response := &UpdateDbaasServiceRedisResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest Operation
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseStartDbaasRedisMaintenanceResponse parses an HTTP response from a StartDbaasRedisMaintenanceWithResponse call
+func ParseStartDbaasRedisMaintenanceResponse(rsp *http.Response) (*StartDbaasRedisMaintenanceResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &StartDbaasRedisMaintenanceResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -25288,7 +27361,9 @@ func ParseGetDnsDomainZoneFileResponse(rsp *http.Response) (*GetDnsDomainZoneFil
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest string
+		var dest struct {
+			ZoneFile *string `json:"zone-file,omitempty"`
+		}
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -25525,6 +27600,216 @@ func ParseListEventsResponse(rsp *http.Response) (*ListEventsResponse, error) {
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest []Event
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetIamOrganizationPolicyResponse parses an HTTP response from a GetIamOrganizationPolicyWithResponse call
+func ParseGetIamOrganizationPolicyResponse(rsp *http.Response) (*GetIamOrganizationPolicyResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetIamOrganizationPolicyResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest []IamPolicy
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUpdateIamOrganizationPolicyResponse parses an HTTP response from a UpdateIamOrganizationPolicyWithResponse call
+func ParseUpdateIamOrganizationPolicyResponse(rsp *http.Response) (*UpdateIamOrganizationPolicyResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UpdateIamOrganizationPolicyResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest Operation
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListIamRolesResponse parses an HTTP response from a ListIamRolesWithResponse call
+func ParseListIamRolesResponse(rsp *http.Response) (*ListIamRolesResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListIamRolesResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			IamRoles *[]IamRole `json:"iam-roles,omitempty"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseCreateIamRoleResponse parses an HTTP response from a CreateIamRoleWithResponse call
+func ParseCreateIamRoleResponse(rsp *http.Response) (*CreateIamRoleResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CreateIamRoleResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest Operation
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseDeleteIamRoleResponse parses an HTTP response from a DeleteIamRoleWithResponse call
+func ParseDeleteIamRoleResponse(rsp *http.Response) (*DeleteIamRoleResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DeleteIamRoleResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest Operation
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetIamRoleResponse parses an HTTP response from a GetIamRoleWithResponse call
+func ParseGetIamRoleResponse(rsp *http.Response) (*GetIamRoleResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetIamRoleResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest IamRole
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUpdateIamRoleResponse parses an HTTP response from a UpdateIamRoleWithResponse call
+func ParseUpdateIamRoleResponse(rsp *http.Response) (*UpdateIamRoleResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UpdateIamRoleResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest Operation
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUpdateIamRolePolicyResponse parses an HTTP response from a UpdateIamRolePolicyWithResponse call
+func ParseUpdateIamRolePolicyResponse(rsp *http.Response) (*UpdateIamRolePolicyResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UpdateIamRolePolicyResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest Operation
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/vendor/github.com/exoscale/egoscale/v2/security_group.go
+++ b/vendor/github.com/exoscale/egoscale/v2/security_group.go
@@ -167,6 +167,25 @@ func (c *Client) ListSecurityGroups(ctx context.Context, zone string) ([]*Securi
 	return list, nil
 }
 
+// FindSecurityGroups returns the list of existing Security Groups.
+// The `params` allows specifying standard filters.
+func (c *Client) FindSecurityGroups(ctx context.Context, zone string, params *oapi.ListSecurityGroupsParams) ([]*SecurityGroup, error) {
+	list := make([]*SecurityGroup, 0)
+
+	resp, err := c.ListSecurityGroupsWithResponse(apiv2.WithZone(ctx, zone), params)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.JSON200.SecurityGroups != nil {
+		for i := range *resp.JSON200.SecurityGroups {
+			list = append(list, securityGroupFromAPI(&(*resp.JSON200.SecurityGroups)[i]))
+		}
+	}
+
+	return list, nil
+}
+
 // RemoveExternalSourceFromSecurityGroup removes an external source from
 // a Security Group. This operation is idempotent.
 func (c *Client) RemoveExternalSourceFromSecurityGroup(

--- a/vendor/github.com/exoscale/egoscale/v2/security_group_rule.go
+++ b/vendor/github.com/exoscale/egoscale/v2/security_group_rule.go
@@ -12,16 +12,18 @@ import (
 
 // SecurityGroupRule represents a Security Group rule.
 type SecurityGroupRule struct {
-	Description     *string
-	EndPort         *uint16
-	FlowDirection   *string `req-for:"create"`
-	ICMPCode        *int64
-	ICMPType        *int64
-	ID              *string `req-for:"delete"`
-	Network         *net.IPNet
-	Protocol        *string `req-for:"create"`
-	SecurityGroupID *string
-	StartPort       *uint16
+	Description       *string
+	EndPort           *uint16
+	FlowDirection     *string `req-for:"create"`
+	ICMPCode          *int64
+	ICMPType          *int64
+	ID                *string `req-for:"delete"`
+	Network           *net.IPNet
+	Protocol          *string `req-for:"create"`
+	SecurityGroupID   *string
+	SecurityGroupName *string
+	Visibility        *string
+	StartPort         *uint16
 }
 
 func securityGroupRuleFromAPI(r *oapi.SecurityGroupRule) *SecurityGroupRule {
@@ -56,8 +58,17 @@ func securityGroupRuleFromAPI(r *oapi.SecurityGroupRule) *SecurityGroupRule {
 		}(),
 		Protocol: (*string)(r.Protocol),
 		SecurityGroupID: func() (v *string) {
-			if r.SecurityGroup != nil {
+			if r.SecurityGroup != nil &&
+				(r.SecurityGroup.Visibility == nil ||
+					*r.SecurityGroup.Visibility != "public") {
 				v = r.SecurityGroup.Id
+			}
+			return
+		}(),
+		SecurityGroupName: func() (v *string) {
+			if r.SecurityGroup != nil && r.SecurityGroup.Visibility != nil &&
+				*r.SecurityGroup.Visibility == "public" && r.SecurityGroup.Name != nil {
+				v = r.SecurityGroup.Name
 			}
 			return
 		}(),
@@ -65,6 +76,12 @@ func securityGroupRuleFromAPI(r *oapi.SecurityGroupRule) *SecurityGroupRule {
 			if r.StartPort != nil {
 				port := uint16(*r.StartPort)
 				v = &port
+			}
+			return
+		}(),
+		Visibility: func() (v *string) {
+			if r.SecurityGroup != nil && r.SecurityGroup.Visibility != nil {
+				v = (*string)(r.SecurityGroup.Visibility)
 			}
 			return
 		}(),
@@ -143,6 +160,10 @@ func (c *Client) CreateSecurityGroupRule(
 			SecurityGroup: func() (v *oapi.SecurityGroupResource) {
 				if rule.SecurityGroupID != nil {
 					v = &oapi.SecurityGroupResource{Id: rule.SecurityGroupID}
+				}
+				if rule.SecurityGroupName != nil {
+					visibility := oapi.SecurityGroupResourceVisibilityPublic
+					v = &oapi.SecurityGroupResource{Name: rule.SecurityGroupName, Visibility: &visibility}
 				}
 				return
 			}(),

--- a/vendor/github.com/exoscale/egoscale/v2/sks_nodepool.go
+++ b/vendor/github.com/exoscale/egoscale/v2/sks_nodepool.go
@@ -71,7 +71,7 @@ func sksNodepoolFromAPI(n *oapi.SksNodepool) *SKSNodepool {
 		CreatedAt: n.CreatedAt,
 		DeployTargetID: func() (v *string) {
 			if n.DeployTarget != nil {
-				v = n.DeployTarget.Id
+				v = &n.DeployTarget.Id
 			}
 			return
 		}(),
@@ -168,7 +168,7 @@ func (c *Client) CreateSKSNodepool(
 			}(),
 			DeployTarget: func() (v *oapi.DeployTarget) {
 				if nodepool.DeployTargetID != nil {
-					v = &oapi.DeployTarget{Id: nodepool.DeployTargetID}
+					v = &oapi.DeployTarget{Id: *nodepool.DeployTargetID}
 				}
 				return
 			}(),
@@ -374,7 +374,7 @@ func (c *Client) UpdateSKSNodepool(
 			}(),
 			DeployTarget: func() (v *oapi.DeployTarget) {
 				if nodepool.DeployTargetID != nil {
-					v = &oapi.DeployTarget{Id: nodepool.DeployTargetID}
+					v = &oapi.DeployTarget{Id: *nodepool.DeployTargetID}
 				}
 				return
 			}(),

--- a/vendor/github.com/exoscale/egoscale/version/version.go
+++ b/vendor/github.com/exoscale/egoscale/version/version.go
@@ -2,4 +2,4 @@
 package version
 
 // Version represents the current egoscale version.
-const Version = "0.94.0"
+const Version = "0.100.0"

--- a/vendor/github.com/exoscale/egoscale/virtual_machines.go
+++ b/vendor/github.com/exoscale/egoscale/virtual_machines.go
@@ -138,9 +138,7 @@ func (vm VirtualMachine) ListRequest() (ListCommand, error) {
 		req.IPAddress = nic.IPAddress
 	}
 
-	for i := range vm.Tags {
-		req.Tags = append(req.Tags, vm.Tags[i])
-	}
+	req.Tags = append(req.Tags, vm.Tags...)
 
 	return req, nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -29,7 +29,7 @@ github.com/davecgh/go-spew/spew
 ## explicit; go 1.16
 github.com/deepmap/oapi-codegen/pkg/runtime
 github.com/deepmap/oapi-codegen/pkg/types
-# github.com/exoscale/egoscale v0.94.0
+# github.com/exoscale/egoscale v0.100.0
 ## explicit; go 1.17
 github.com/exoscale/egoscale
 github.com/exoscale/egoscale/v2


### PR DESCRIPTION
Implement the requested feature from #260.
The implementation is similar to what can be found in the portal, adding a new possible target for security group rules: `public_security_group`.

Example:

```
resource "exoscale_security_group" "my_security_group" {
  name = "test"
}

resource "exoscale_security_group_rule" "lb1" {
  security_group_id     = exoscale_security_group.my_security_group.id
  type                  = "INGRESS"
  protocol              = "TCP"
  public_security_group = "public-nlb-healthcheck-sources"
  start_port            = 32080
  end_port              = 32080
}
```

```
❯ terraform apply

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following
symbols:
  + create

Terraform will perform the following actions:

  # exoscale_security_group.my_security_group will be created
  + resource "exoscale_security_group" "my_security_group" {
      + id   = (known after apply)
      + name = "test"
    }

  # exoscale_security_group_rule.lb1 will be created
  + resource "exoscale_security_group_rule" "lb1" {
      + end_port              = 32080
      + id                    = (known after apply)
      + protocol              = "TCP"
      + public_security_group = "public-nlb-healthcheck-sources"
      + security_group        = (known after apply)
      + security_group_id     = (known after apply)
      + start_port            = 32080
      + type                  = "INGRESS"
      + user_security_group   = (known after apply)
    }

Plan: 2 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

exoscale_security_group.my_security_group: Creating...
exoscale_security_group.my_security_group: Creation complete after 3s [id=760830ad-17a6-47f3-860e-fe6c6ee60ebd]
exoscale_security_group_rule.lb1: Creating...
exoscale_security_group_rule.lb1: Creation complete after 4s [id=ad4475ba-9cb0-41a0-803f-14f37ceb25f6]

Apply complete! Resources: 2 added, 0 changed, 0 destroyed.

❯ terraform apply
exoscale_security_group.my_security_group: Refreshing state... [id=760830ad-17a6-47f3-860e-fe6c6ee60ebd]
exoscale_security_group_rule.lb1: Refreshing state... [id=ad4475ba-9cb0-41a0-803f-14f37ceb25f6]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

❯ terraform destroy
exoscale_security_group.my_security_group: Refreshing state... [id=760830ad-17a6-47f3-860e-fe6c6ee60ebd]
exoscale_security_group_rule.lb1: Refreshing state... [id=ad4475ba-9cb0-41a0-803f-14f37ceb25f6]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following
symbols:
  - destroy

Terraform will perform the following actions:

  # exoscale_security_group.my_security_group will be destroyed
  - resource "exoscale_security_group" "my_security_group" {
      - id   = "760830ad-17a6-47f3-860e-fe6c6ee60ebd" -> null
      - name = "test" -> null
    }

  # exoscale_security_group_rule.lb1 will be destroyed
  - resource "exoscale_security_group_rule" "lb1" {
      - end_port              = 32080 -> null
      - id                    = "ad4475ba-9cb0-41a0-803f-14f37ceb25f6" -> null
      - protocol              = "TCP" -> null
      - public_security_group = "public-nlb-healthcheck-sources" -> null
      - security_group        = "test" -> null
      - security_group_id     = "760830ad-17a6-47f3-860e-fe6c6ee60ebd" -> null
      - start_port            = 32080 -> null
      - type                  = "INGRESS" -> null
    }

Plan: 0 to add, 0 to change, 2 to destroy.

Do you really want to destroy all resources?
  Terraform will destroy all your managed infrastructure, as shown above.
  There is no undo. Only 'yes' will be accepted to confirm.

  Enter a value: yes

exoscale_security_group_rule.lb1: Destroying... [id=ad4475ba-9cb0-41a0-803f-14f37ceb25f6]
exoscale_security_group_rule.lb1: Destruction complete after 4s
exoscale_security_group.my_security_group: Destroying... [id=760830ad-17a6-47f3-860e-fe6c6ee60ebd]
exoscale_security_group.my_security_group: Destruction complete after 3s

Destroy complete! Resources: 2 destroyed.

```

Local testing:

```
❯ TF_ACC=true go test -timeout 600s -run ^TestAccResourceSecurityGroupRule$ github.com/exoscale/terraform-provider-exoscale/exoscale
ok      github.com/exoscale/terraform-provider-exoscale/exoscale        38.742s
```