### PR TITLE
External sources in security group datasource

### DIFF
--- a/docs/data-sources/security_group.md
+++ b/docs/data-sources/security_group.md
@@ -36,4 +36,8 @@ directory for complete configuration examples.
 - `id` (String) The security group ID to match (conflicts with `name`)
 - `name` (String) The name to match (conflicts with `id`)
 
+### Read-Only
+
+- `external_sources` (Set of String) The list of external network sources, in [CIDR](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing#CIDR_notatio) notation.
+
 

--- a/exoscale/datasource_exoscale_security_group.go
+++ b/exoscale/datasource_exoscale_security_group.go
@@ -10,8 +10,9 @@ import (
 )
 
 const (
-	dsSecurityGroupAttrID   = "id"
-	dsSecurityGroupAttrName = "name"
+	dsSecurityGroupAttrID              = "id"
+	dsSecurityGroupAttrName            = "name"
+	dsSecurityGroupAttrExternalSources = "external_sources"
 )
 
 func dataSourceSecurityGroup() *schema.Resource {
@@ -31,6 +32,14 @@ Corresponding resource: [exoscale_security_group](../resources/security_group.md
 				Type:          schema.TypeString,
 				Optional:      true,
 				ConflictsWith: []string{dsSecurityGroupAttrID},
+			},
+			dsSecurityGroupAttrExternalSources: {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Description: "The list of external network sources, in [CIDR](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing#CIDR_notatio) notation.",
 			},
 		},
 
@@ -78,6 +87,12 @@ func dataSourceSecurityGroupRead(ctx context.Context, d *schema.ResourceData, me
 
 	if err := d.Set(dsSecurityGroupAttrName, *securityGroup.Name); err != nil {
 		return diag.FromErr(err)
+	}
+
+	if securityGroup.ExternalSources != nil {
+		if err := d.Set(resSecurityGroupAttrExternalSources, *securityGroup.ExternalSources); err != nil {
+			return diag.FromErr(err)
+		}
 	}
 
 	tflog.Debug(ctx, "read finished successfully", map[string]interface{}{


### PR DESCRIPTION
Add support for external sources in the security group data source.

Local test:

```
❯ TF_ACC=true go test -timeout 600s -run ^TestAccDataSourceSecurityGroup$ github.com/exoscale/terraform-provider-exoscale/exoscale
ok      github.com/exoscale/terraform-provider-exoscale/exoscale        16.944s
```