### PR TITLE
docs: wrap ! symbol explanation in a box 

### DIFF
--- a/docs/resources/affinity.md
+++ b/docs/resources/affinity.md
@@ -38,6 +38,6 @@ Optional:
 - `delete` (String)
 - `read` (String)
 
-* The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
+-> The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
 
 

--- a/docs/resources/anti_affinity_group.md
+++ b/docs/resources/anti_affinity_group.md
@@ -50,7 +50,7 @@ Optional:
 - `delete` (String)
 - `read` (String)
 
-* The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
+-> The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
 
 ## Import
 

--- a/docs/resources/compute.md
+++ b/docs/resources/compute.md
@@ -64,6 +64,6 @@ Optional:
 - `read` (String)
 - `update` (String)
 
-* The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
+-> The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
 
 

--- a/docs/resources/compute_instance.md
+++ b/docs/resources/compute_instance.md
@@ -94,7 +94,7 @@ Optional:
 - `read` (String)
 - `update` (String)
 
-* The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
+-> The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
 
 ## Import
 

--- a/docs/resources/database.md
+++ b/docs/resources/database.md
@@ -191,7 +191,7 @@ Optional:
 - `read` (String)
 - `update` (String)
 
-* The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
+-> The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
 
 ## Import
 

--- a/docs/resources/domain.md
+++ b/docs/resources/domain.md
@@ -52,7 +52,7 @@ Optional:
 - `delete` (String)
 - `read` (String)
 
-* The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
+-> The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
 
 ## Import
 

--- a/docs/resources/domain_record.md
+++ b/docs/resources/domain_record.md
@@ -69,7 +69,7 @@ Optional:
 - `read` (String)
 - `update` (String)
 
-* The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
+-> The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
 
 ## Import
 

--- a/docs/resources/elastic_ip.md
+++ b/docs/resources/elastic_ip.md
@@ -96,7 +96,7 @@ Optional:
 - `read` (String)
 - `update` (String)
 
-* The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
+-> The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
 
 ## Import
 

--- a/docs/resources/iam_access_key.md
+++ b/docs/resources/iam_access_key.md
@@ -61,6 +61,6 @@ Optional:
 - `delete` (String)
 - `read` (String)
 
-* The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
+-> The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
 
 

--- a/docs/resources/instance_pool.md
+++ b/docs/resources/instance_pool.md
@@ -94,7 +94,7 @@ Optional:
 - `read` (String)
 - `update` (String)
 
-* The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
+-> The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
 
 ## Import
 

--- a/docs/resources/ipaddress.md
+++ b/docs/resources/ipaddress.md
@@ -49,6 +49,6 @@ Optional:
 - `read` (String)
 - `update` (String)
 
-* The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
+-> The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
 
 

--- a/docs/resources/network.md
+++ b/docs/resources/network.md
@@ -43,6 +43,6 @@ Optional:
 - `read` (String)
 - `update` (String)
 
-* The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
+-> The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
 
 

--- a/docs/resources/nic.md
+++ b/docs/resources/nic.md
@@ -41,6 +41,6 @@ Optional:
 - `read` (String)
 - `update` (String)
 
-* The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
+-> The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
 
 

--- a/docs/resources/nlb.md
+++ b/docs/resources/nlb.md
@@ -57,7 +57,7 @@ Optional:
 - `read` (String)
 - `update` (String)
 
-* The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
+-> The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
 
 ## Import
 

--- a/docs/resources/nlb_service.md
+++ b/docs/resources/nlb_service.md
@@ -96,7 +96,7 @@ Optional:
 - `read` (String)
 - `update` (String)
 
-* The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
+-> The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
 
 ## Import
 

--- a/docs/resources/private_network.md
+++ b/docs/resources/private_network.md
@@ -68,7 +68,7 @@ Optional:
 - `read` (String)
 - `update` (String)
 
-* The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
+-> The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
 
 ## Import
 

--- a/docs/resources/secondary_ipaddress.md
+++ b/docs/resources/secondary_ipaddress.md
@@ -38,6 +38,6 @@ Optional:
 - `delete` (String)
 - `read` (String)
 
-* The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
+-> The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
 
 

--- a/docs/resources/security_group.md
+++ b/docs/resources/security_group.md
@@ -50,7 +50,7 @@ Optional:
 - `delete` (String)
 - `read` (String)
 
-* The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
+-> The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
 
 ## Import
 

--- a/docs/resources/security_group_rule.md
+++ b/docs/resources/security_group_rule.md
@@ -66,7 +66,7 @@ Optional:
 - `delete` (String)
 - `read` (String)
 
-* The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
+-> The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
 
 ## Import
 

--- a/docs/resources/security_group_rules.md
+++ b/docs/resources/security_group_rules.md
@@ -72,6 +72,6 @@ Optional:
 - `read` (String)
 - `update` (String)
 
-* The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
+-> The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
 
 

--- a/docs/resources/sks_cluster.md
+++ b/docs/resources/sks_cluster.md
@@ -87,7 +87,7 @@ Optional:
 - `read` (String)
 - `update` (String)
 
-* The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
+-> The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
 
 ## Import
 

--- a/docs/resources/sks_kubeconfig.md
+++ b/docs/resources/sks_kubeconfig.md
@@ -63,7 +63,7 @@ Optional:
 - `read` (String)
 - `update` (String)
 
-* The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
+-> The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
 
 
 

--- a/docs/resources/sks_nodepool.md
+++ b/docs/resources/sks_nodepool.md
@@ -73,7 +73,7 @@ Optional:
 - `read` (String)
 - `update` (String)
 
-* The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
+-> The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
 
 ## Import
 

--- a/docs/resources/ssh_key.md
+++ b/docs/resources/ssh_key.md
@@ -61,7 +61,7 @@ Optional:
 - `delete` (String)
 - `read` (String)
 
-* The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
+-> The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
 
 ## Import
 

--- a/docs/resources/ssh_keypair.md
+++ b/docs/resources/ssh_keypair.md
@@ -40,6 +40,6 @@ Optional:
 - `delete` (String)
 - `read` (String)
 
-* The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
+-> The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
 
 

--- a/templates/resources.md.tmpl
+++ b/templates/resources.md.tmpl
@@ -22,7 +22,7 @@ directory for complete configuration examples.
 
 {{ .SchemaMarkdown | trimspace }}
 
-* The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
+-> The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
 
 {{ if .HasImport -}}
 ## Import

--- a/templates/resources/affinity.md.tmpl
+++ b/templates/resources/affinity.md.tmpl
@@ -18,7 +18,7 @@ description: |-
 
 {{ .SchemaMarkdown | trimspace }}
 
-* The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
+-> The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
 
 {{ if .HasImport -}}
 ## Import

--- a/templates/resources/compute.md.tmpl
+++ b/templates/resources/compute.md.tmpl
@@ -23,7 +23,7 @@ directory for complete configuration examples.
 
 {{ .SchemaMarkdown | trimspace }}
 
-* The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
+-> The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
 
 {{ if .HasImport -}}
 ## Import

--- a/templates/resources/domain.md.tmpl
+++ b/templates/resources/domain.md.tmpl
@@ -26,7 +26,7 @@ directory for complete configuration examples.
 
 {{ .SchemaMarkdown | trimspace }}
 
-* The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
+-> The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
 
 ## Import
 

--- a/templates/resources/elastic_ip.md.tmpl
+++ b/templates/resources/elastic_ip.md.tmpl
@@ -47,7 +47,7 @@ directory for complete configuration examples.
 
 {{ .SchemaMarkdown | trimspace }}
 
-* The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
+-> The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
 
 ## Import
 

--- a/templates/resources/iam_access_key.md.tmpl
+++ b/templates/resources/iam_access_key.md.tmpl
@@ -33,7 +33,7 @@ directory for complete configuration examples.
 
 {{ .SchemaMarkdown | trimspace }}
 
-* The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
+-> The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
 
 {{ if .HasImport -}}
 ## Import

--- a/templates/resources/ipaddress.md.tmpl
+++ b/templates/resources/ipaddress.md.tmpl
@@ -18,7 +18,7 @@ description: |-
 
 {{ .SchemaMarkdown | trimspace }}
 
-* The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
+-> The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
 
 {{ if .HasImport -}}
 ## Import

--- a/templates/resources/network.md.tmpl
+++ b/templates/resources/network.md.tmpl
@@ -18,7 +18,7 @@ description: |-
 
 {{ .SchemaMarkdown | trimspace }}
 
-* The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
+-> The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
 
 {{ if .HasImport -}}
 ## Import

--- a/templates/resources/nic.md.tmpl
+++ b/templates/resources/nic.md.tmpl
@@ -18,7 +18,7 @@ description: |-
 
 {{ .SchemaMarkdown | trimspace }}
 
-* The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
+-> The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
 
 {{ if .HasImport -}}
 ## Import

--- a/templates/resources/nlb.md.tmpl
+++ b/templates/resources/nlb.md.tmpl
@@ -27,7 +27,7 @@ directory for complete configuration examples.
 
 {{ .SchemaMarkdown | trimspace }}
 
-* The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
+-> The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
 
 ## Import
 

--- a/templates/resources/private_network.md.tmpl
+++ b/templates/resources/private_network.md.tmpl
@@ -40,7 +40,7 @@ directory for complete configuration examples.
 
 {{ .SchemaMarkdown | trimspace }}
 
-* The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
+-> The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
 
 ## Import
 

--- a/templates/resources/secondary_ipaddress.md.tmpl
+++ b/templates/resources/secondary_ipaddress.md.tmpl
@@ -18,7 +18,7 @@ description: |-
 
 {{ .SchemaMarkdown | trimspace }}
 
-* The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
+-> The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
 
 {{ if .HasImport -}}
 ## Import

--- a/templates/resources/security_group.md.tmpl
+++ b/templates/resources/security_group.md.tmpl
@@ -26,7 +26,7 @@ directory for complete configuration examples.
 
 {{ .SchemaMarkdown | trimspace }}
 
-* The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
+-> The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
 
 ## Import
 

--- a/templates/resources/security_group_rules.md.tmpl
+++ b/templates/resources/security_group_rules.md.tmpl
@@ -18,7 +18,7 @@ description: |-
 
 {{ .SchemaMarkdown | trimspace }}
 
-* The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
+-> The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
 
 {{ if .HasImport -}}
 ## Import

--- a/templates/resources/sks_cluster.md.tmpl
+++ b/templates/resources/sks_cluster.md.tmpl
@@ -23,7 +23,7 @@ directory for complete configuration examples.
 
 {{ .SchemaMarkdown | trimspace }}
 
-* The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
+-> The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
 
 {{ if .HasImport -}}
 ## Import

--- a/templates/resources/sks_kubeconfig.md.tmpl
+++ b/templates/resources/sks_kubeconfig.md.tmpl
@@ -33,7 +33,7 @@ directory for complete configuration examples.
 
 {{ .SchemaMarkdown | trimspace }}
 
-* The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
+-> The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
 
 {{ if .HasImport -}}
 ## Import

--- a/templates/resources/sks_nodepool.md.tmpl
+++ b/templates/resources/sks_nodepool.md.tmpl
@@ -32,7 +32,7 @@ directory for complete configuration examples.
 
 {{ .SchemaMarkdown | trimspace }}
 
-* The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
+-> The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
 
 ## Import
 

--- a/templates/resources/ssh_key.md.tmpl
+++ b/templates/resources/ssh_key.md.tmpl
@@ -37,7 +37,7 @@ Please refer to the [examples](https://github.com/exoscale/terraform-provider-ex
 
 {{ .SchemaMarkdown | trimspace }}
 
-* The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
+-> The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
 
 {{ if .HasImport -}}
 ## Import

--- a/templates/resources/ssh_keypair.md.tmpl
+++ b/templates/resources/ssh_keypair.md.tmpl
@@ -20,7 +20,7 @@ description: |-
 
 {{ .SchemaMarkdown | trimspace }}
 
-* The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
+-> The symbol ❗ in an attribute indicates that modifying it, will force the creation of a new resource.
 
 {{ if .HasImport -}}
 ## Import


### PR DESCRIPTION
Updated resource template to separate ! symbol note from timeout schema block (check [here](https://registry.terraform.io/providers/exoscale/exoscale/0.48.0/docs/resources/compute_instance) how it looks now).