### PR TITLE
security group: fix panic if security group has no ID in security group rule

### DIFF
--- a/exoscale/resource_exoscale_security_group_rules.go
+++ b/exoscale/resource_exoscale_security_group_rules.go
@@ -782,7 +782,16 @@ func ruleToID(
 		if securityGroupRule.Network != nil {
 			name = securityGroupRule.Network.String()
 		} else {
-			userSecurityGroup, err := client.GetSecurityGroup(ctx, zone, *securityGroupRule.SecurityGroupID)
+			var nameOrID string
+			if securityGroupRule.SecurityGroupID != nil {
+				nameOrID = *securityGroupRule.SecurityGroupID
+			} else if securityGroupRule.SecurityGroupName != nil {
+				nameOrID = *securityGroupRule.SecurityGroupName
+			} else {
+				return "", fmt.Errorf("cannot retrieve Security Group with neither ID nor name")
+			}
+
+			userSecurityGroup, err := client.GetSecurityGroup(ctx, zone, nameOrID)
 			if err != nil {
 				return "", fmt.Errorf("unable to retrieve Security Group: %w", err)
 			}

--- a/exoscale/resource_exoscale_security_group_rules.go
+++ b/exoscale/resource_exoscale_security_group_rules.go
@@ -783,11 +783,13 @@ func ruleToID(
 			name = securityGroupRule.Network.String()
 		} else {
 			var nameOrID string
-			if securityGroupRule.SecurityGroupID != nil {
+
+			switch {
+			case securityGroupRule.SecurityGroupID != nil:
 				nameOrID = *securityGroupRule.SecurityGroupID
-			} else if securityGroupRule.SecurityGroupName != nil {
+			case securityGroupRule.SecurityGroupName != nil:
 				nameOrID = *securityGroupRule.SecurityGroupName
-			} else {
+			default:
 				return "", fmt.Errorf("cannot retrieve Security Group with neither ID nor name")
 			}
 


### PR DESCRIPTION
The GET call to https://api-ch-gva-2.exoscale.com/v2/security-group/{uuid} returns a list of SG rules attached to the SG. However it is possible that the ID field is nil which can cause a panic.(see shortcut ticket)