### PR TITLE
Disable user_data gzip compression

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,18 @@
+name: check-documentation
+
+on:
+  push:
+    branches:
+    - '**'
+    tags-ignore:
+    - 'v*' # Don't run CI tests on release tags
+
+jobs:
+  check-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: git submodule update --init --recursive go.mk
+      - uses: ./go.mk/.github/actions/setup
+      - name: Check documentation is up to date
+        run: './scripts/check-documentation-clean.sh'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: CI
+name: run-acceptance-tests
 
 on:
   push:
@@ -6,22 +6,12 @@ on:
     - '**'
     paths-ignore:
     - '**.md'
-    - 'website/**'
     - 'examples/**'
     - '.goreleaser.yml'
     tags-ignore:
     - 'v*' # Don't run CI tests on release tags
 
 jobs:
-  check-docs:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - run: git submodule update --init --recursive go.mk
-      - uses: ./go.mk/.github/actions/setup
-      - name: Check documentation is up to date
-        run: './scripts/check-documentation-clean.sh'
-
   test:
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TO BE RELEASED
+
+BREAKING CHANGES:
+
+- user data are not gzipped anymore. If you want to gzip user data, you may want to use the cloudinit_config datasource.
+
 ## 0.50.0 (June 23, 2023)
 
 IMPROVEMENTS:

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,7 +52,6 @@ provider "exoscale" {
 - `delay` (Number, Deprecated)
 - `dns_endpoint` (String) Exoscale DNS API endpoint (by default: https://api.exoscale.com/dns)
 - `environment` (String)
-- `gzip_user_data` (Boolean) Defines if the user-data of compute instances should be gzipped (by default: true)
 - `key` (String) Exoscale API key
 - `profile` (String, Deprecated)
 - `region` (String) CloudStack ini configuration section name (by default: cloudstack)

--- a/docs/resources/compute.md
+++ b/docs/resources/compute.md
@@ -40,7 +40,7 @@ Manage Exoscale Compute Instances.
 - `template` (String) ❗ The compute instance template (name). Only *featured* templates are available, if you want to reference *custom templates* use the `template_id` attribute instead.
 - `template_id` (String) ❗ The compute instance template (ID). Usage of the `exoscale_compute_template` data source is recommended.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
-- `user_data` (String) cloud-init configuration (no need to base64-encode or gzip it as the provider will take care of it).
+- `user_data` (String) cloud-init configuration.
 
 ### Read-Only
 

--- a/docs/resources/compute_instance.md
+++ b/docs/resources/compute_instance.md
@@ -62,7 +62,7 @@ directory for complete configuration examples.
 - `ssh_key` (String) The [exoscale_ssh_key](./ssh_key.md) (name) to authorize in the instance (may only be set at creation time).
 - `state` (String) The instance state (`running` or `stopped`; default: `running`).
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
-- `user_data` (String) [cloud-init](https://cloudinit.readthedocs.io/) configuration (no need to base64-encode or gzip it as the provider will take care of it).
+- `user_data` (String) [cloud-init](https://cloudinit.readthedocs.io/) configuration.
 
 ### Read-Only
 

--- a/docs/resources/instance_pool.md
+++ b/docs/resources/instance_pool.md
@@ -63,7 +63,7 @@ directory for complete configuration examples.
 - `service_offering` (String, Deprecated) The managed instances type. Please use the `instance_type` argument instead.
 - `state` (String)
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
-- `user_data` (String) [cloud-init](http://cloudinit.readthedocs.io/) configuration to apply to the managed instances (no need to base64-encode or gzip it as the provider will take care of it).
+- `user_data` (String) [cloud-init](http://cloudinit.readthedocs.io/) configuration to apply to the managed instances.
 - `virtual_machines` (Set of String, Deprecated) The list of managed instances (IDs). Please use the `instances.*.id` attribute instead.
 
 ### Read-Only

--- a/exoscale/provider.go
+++ b/exoscale/provider.go
@@ -109,13 +109,6 @@ func Provider() *schema.Provider {
 					"Timeout in seconds for waiting on compute resources to become available (by default: %.0f)",
 					config.DefaultTimeout.Seconds()),
 			},
-			"gzip_user_data": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Description: fmt.Sprintf(
-					"Defines if the user-data of compute instances should be gzipped (by default: %t)",
-					config.DefaultGzipUserData),
-			},
 			"delay": {
 				Type:       schema.TypeInt,
 				Optional:   true,
@@ -424,16 +417,6 @@ func ProviderConfigure(_ context.Context, d *schema.ResourceData) (interface{}, 
 		}
 	}
 
-	gzipUserData, gzipUserDataOK := d.GetOk("gzip_user_data")
-	if !gzipUserDataOK {
-		var err error
-		gzipUserData, err = providerConfig.GetGZIPUserData()
-
-		if err != nil {
-			return nil, diag.FromErr(err)
-		}
-	}
-
 	baseConfig := providerConfig.BaseConfig{
 		Key:             key.(string),
 		Secret:          secret.(string),
@@ -441,7 +424,6 @@ func ProviderConfigure(_ context.Context, d *schema.ResourceData) (interface{}, 
 		ComputeEndpoint: endpoint.(string),
 		DNSEndpoint:     dnsEndpoint.(string),
 		Environment:     environment.(string),
-		GZIPUserData:    gzipUserData.(bool),
 	}
 
 	clv2, err := CreateClient(&baseConfig)

--- a/exoscale/resource_exoscale_compute.go
+++ b/exoscale/resource_exoscale_compute.go
@@ -15,11 +15,11 @@ import (
 	"github.com/exoscale/egoscale"
 	"github.com/exoscale/terraform-provider-exoscale/pkg/config"
 	"github.com/exoscale/terraform-provider-exoscale/pkg/general"
+	"github.com/exoscale/terraform-provider-exoscale/pkg/utils"
 )
 
 const (
 	computeHostnameRegexp    = `^[a-zA-Z0-9][a-zA-Z0-9\-]+$`
-	computeMaxUserDataLength = 32768
 )
 
 func resourceComputeIDString(d general.ResourceIDStringer) string {
@@ -93,7 +93,7 @@ func resourceCompute() *schema.Resource {
 		"user_data": {
 			Type:             schema.TypeString,
 			Optional:         true,
-			Description:      "cloud-init configuration (no need to base64-encode or gzip it as the provider will take care of it).",
+			Description:      "cloud-init configuration.",
 			ValidateDiagFunc: validateComputeUserData,
 		},
 		"user_data_base64": {
@@ -1153,7 +1153,7 @@ func getSecurityGroup(ctx context.Context, client *egoscale.Client, name string)
 func prepareUserData(d *schema.ResourceData, meta interface{}, key string) (string, bool, error) {
 	userData := d.Get(key).(string)
 
-	userData, userDataBase64, err := encodeUserData(userData)
+	userData, userDataBase64, err := utils.EncodeUserData(userData)
 	if err != nil {
 		return "", false, err
 	}

--- a/exoscale/resource_exoscale_compute.go
+++ b/exoscale/resource_exoscale_compute.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	computeHostnameRegexp    = `^[a-zA-Z0-9][a-zA-Z0-9\-]+$`
+	computeHostnameRegexp = `^[a-zA-Z0-9][a-zA-Z0-9\-]+$`
 )
 
 func resourceComputeIDString(d general.ResourceIDStringer) string {

--- a/exoscale/util.go
+++ b/exoscale/util.go
@@ -1,10 +1,6 @@
 package exoscale
 
 import (
-	"bytes"
-	"compress/gzip"
-	"encoding/base64"
-	"errors"
 	"fmt"
 	"strings"
 
@@ -86,42 +82,6 @@ func unique(s []string) []string {
 // Do no show case differences between state and resource
 func suppressCaseDiff(k, old, new string, d *schema.ResourceData) bool {
 	return strings.EqualFold(old, new)
-}
-
-// user-data compression and base64 encoding, used in resource_exoscale_compute[_instance[_pool]]
-// returns (user_data, user_data_already_base64, error)
-func encodeUserData(userData string) (string, bool, error) {
-	// template_cloudinit_config alows to gzip but not base64, prevent such case
-	if len(userData) > 2 && userData[0] == '\x1f' && userData[1] == '\x8b' {
-		return "", false, errors.New("user_data appears to be gzipped: it should be left raw, or also be base64 encoded")
-	}
-
-	// If user supplied data is already base64 encoded, do nothing.
-	_, err := base64.StdEncoding.DecodeString(userData)
-	if err == nil {
-		return userData, true, nil
-	}
-
-	b := new(bytes.Buffer)
-	gz := gzip.NewWriter(b)
-
-	if _, err := gz.Write([]byte(userData)); err != nil {
-		return "", false, err
-	}
-	if err := gz.Flush(); err != nil {
-		return "", false, err
-	}
-	if err := gz.Close(); err != nil {
-		return "", false, err
-	}
-
-	userDataBase64 := base64.StdEncoding.EncodeToString(b.Bytes())
-
-	if len(userDataBase64) >= computeMaxUserDataLength {
-		return "", false, fmt.Errorf("user-data maximum allowed length is %d bytes", computeMaxUserDataLength)
-	}
-
-	return userDataBase64, false, nil
 }
 
 func parseIAMAccessKeyResource(v string) (*egoscale.IAMAccessKeyResource, error) {

--- a/exoscale/validation.go
+++ b/exoscale/validation.go
@@ -5,6 +5,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/exoscale/terraform-provider-exoscale/pkg/utils"
+
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -89,7 +91,7 @@ func validateComputeUserData(v interface{}, _ cty.Path) diag.Diagnostics {
 		return diag.Errorf("expected field %q type to be string", v)
 	}
 
-	_, _, err := encodeUserData(value)
+	_, _, err := utils.EncodeUserData(value)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -15,8 +15,8 @@ const (
 	//  global endpoint.
 	DefaultZone = "ch-gva-2"
 
-	DefaultEnvironment  = "api"
-	DefaultTimeout      = 5 * time.Minute
+	DefaultEnvironment = "api"
+	DefaultTimeout     = 5 * time.Minute
 
 	ComputeMaxUserDataLength = 32768
 )

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -17,7 +17,6 @@ const (
 
 	DefaultEnvironment  = "api"
 	DefaultTimeout      = 5 * time.Minute
-	DefaultGzipUserData = true
 
 	ComputeMaxUserDataLength = 32768
 )

--- a/pkg/provider/config/config.go
+++ b/pkg/provider/config/config.go
@@ -20,7 +20,6 @@ type BaseConfig struct {
 	ComputeEndpoint string
 	DNSEndpoint     string
 	Environment     string
-	GZIPUserData    bool
 	ComputeClient   *egoscale.Client
 	DNSClient       *egoscale.Client
 }
@@ -64,13 +63,4 @@ func GetTimeout() (float64, error) {
 	}
 
 	return defaultTimeout, nil
-}
-
-func GetGZIPUserData() (bool, error) {
-	gzipUserDataRaw := GetEnvDefault("EXOSCALE_GZIP_USER_DATA", "")
-	if gzipUserDataRaw == "" {
-		return config.DefaultGzipUserData, nil
-	} else {
-		return strconv.ParseBool(gzipUserDataRaw)
-	}
 }

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -29,7 +29,6 @@ const (
 	DnsEndpointAttrName     = "dns_endpoint"
 	EnvironmentAttrName     = "environment"
 	TimeoutAttrName         = "timeout"
-	GZIPUserDataAttrName    = "gzip_user_data"
 	DelayAttrName           = "delay"
 )
 
@@ -48,7 +47,6 @@ type ExoscaleProviderModel struct {
 	DnsEndpoint     types.String  `tfsdk:"dns_endpoint"`
 	Environment     types.String  `tfsdk:"environment"`
 	Timeout         types.Float64 `tfsdk:"timeout"`
-	GzipUserData    types.Bool    `tfsdk:"gzip_user_data"`
 	Delay           types.Int64   `tfsdk:"delay"`
 }
 
@@ -100,12 +98,6 @@ func (p *ExoscaleProvider) Schema(ctx context.Context, req provider.SchemaReques
 				MarkdownDescription: fmt.Sprintf(
 					"Timeout in seconds for waiting on compute resources to become available (by default: %.0f)",
 					config.DefaultTimeout.Seconds()),
-			},
-			GZIPUserDataAttrName: schema.BoolAttribute{
-				Optional: true,
-				MarkdownDescription: fmt.Sprintf(
-					"Defines if the user-data of compute instances should be gzipped (by default: %t)",
-					config.DefaultGzipUserData),
 			},
 			DelayAttrName: schema.Int64Attribute{
 				Optional:           true,
@@ -259,18 +251,6 @@ func (p *ExoscaleProvider) Configure(ctx context.Context, req provider.Configure
 		timeout = data.Timeout.ValueFloat64()
 	}
 
-	var gzipUserData bool
-	if data.GzipUserData.IsNull() {
-		var err error
-		gzipUserData, err = providerConfig.GetGZIPUserData()
-
-		if err != nil {
-			resp.Diagnostics.AddError(err.Error(), "")
-		}
-	} else {
-		gzipUserData = data.GzipUserData.ValueBool()
-	}
-
 	exov2.UserAgent = exoscale.UserAgent
 
 	baseConfig := providerConfig.BaseConfig{
@@ -280,7 +260,6 @@ func (p *ExoscaleProvider) Configure(ctx context.Context, req provider.Configure
 		ComputeEndpoint: endpoint,
 		DNSEndpoint:     dnsEndpoint,
 		Environment:     environment,
-		GZIPUserData:    gzipUserData,
 	}
 
 	clv1 := exoscale.GetComputeClient(map[string]interface{}{

--- a/pkg/resources/instance/resource.go
+++ b/pkg/resources/instance/resource.go
@@ -154,7 +154,7 @@ func Resource() *schema.Resource {
 			DiffSuppressFunc: utils.SuppressCaseDiff,
 		},
 		AttrUserData: {
-			Description:      "[cloud-init](https://cloudinit.readthedocs.io/) configuration (no need to base64-encode or gzip it as the provider will take care of it).",
+			Description:      "[cloud-init](https://cloudinit.readthedocs.io/) configuration.",
 			Type:             schema.TypeString,
 			ValidateDiagFunc: utils.ValidateComputeUserData,
 			Optional:         true,

--- a/pkg/resources/instance_pool/resource.go
+++ b/pkg/resources/instance_pool/resource.go
@@ -137,7 +137,7 @@ func Resource() *schema.Resource {
 			Required:    true,
 		},
 		AttrUserData: {
-			Description: "[cloud-init](http://cloudinit.readthedocs.io/) configuration to apply to the managed instances (no need to base64-encode or gzip it as the provider will take care of it).",
+			Description: "[cloud-init](http://cloudinit.readthedocs.io/) configuration to apply to the managed instances.",
 			Type:        schema.TypeString,
 			Optional:    true,
 		},

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -152,20 +152,7 @@ func EncodeUserData(userData string) (string, bool, error) {
 		return userData, true, nil
 	}
 
-	b := new(bytes.Buffer)
-	gz := gzip.NewWriter(b)
-
-	if _, err := gz.Write([]byte(userData)); err != nil {
-		return "", false, err
-	}
-	if err := gz.Flush(); err != nil {
-		return "", false, err
-	}
-	if err := gz.Close(); err != nil {
-		return "", false, err
-	}
-
-	userDataBase64 := base64.StdEncoding.EncodeToString(b.Bytes())
+	userDataBase64 := base64.StdEncoding.EncodeToString([]byte(userData))
 
 	if len(userDataBase64) >= config.ComputeMaxUserDataLength {
 		return "", false, fmt.Errorf("user-data maximum allowed length is %d bytes", config.ComputeMaxUserDataLength)

--- a/templates/data-sources/database_uri.md.tmpl
+++ b/templates/data-sources/database_uri.md.tmpl
@@ -47,6 +47,7 @@ resource "exoscale_database" "my_database" {
 data "exoscale_database_uri" "my_database" {
   name = "my-database"
   type = "pg"
+  zone = "ch-gva-2"
 }
 
 output "my_database_uri" {


### PR DESCRIPTION
Disable gzip of user_data, since it could be handled by the [`cloudinit` datasource](https://registry.terraform.io/providers/hashicorp/cloudinit/latest/docs/data-sources/config)