### PR TITLE
datasource exoscale_instance_pool_list: fix panic when IP has labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## UNRELEASED
+
+BUG FIX:
+
+- datasource `exoscale_instance_pool_list`: fix panic when instance pool with labels is found
+
 ## 0.50.0 (June 23, 2023)
 
 IMPROVEMENTS:

--- a/docs/data-sources/instance_pool_list.md
+++ b/docs/data-sources/instance_pool_list.md
@@ -22,7 +22,7 @@ data "exoscale_instance_pool_list" "my_instance_pool_list" {
 
 output "my_instance_pool_ids" {
   value = join("\n", formatlist(
-    "%s", exoscale_instance_pool_list.my_instance_pool_list.pools.*.id
+    "%s", data.exoscale_instance_pool_list.my_instance_pool_list.pools.*.id
   ))
 }
 ```

--- a/examples/data-sources/exoscale_instance_pool_list/data-source.tf
+++ b/examples/data-sources/exoscale_instance_pool_list/data-source.tf
@@ -4,6 +4,6 @@ data "exoscale_instance_pool_list" "my_instance_pool_list" {
 
 output "my_instance_pool_ids" {
   value = join("\n", formatlist(
-    "%s", exoscale_instance_pool_list.my_instance_pool_list.pools.*.id
+    "%s", data.exoscale_instance_pool_list.my_instance_pool_list.pools.*.id
   ))
 }

--- a/pkg/resources/instance_pool/datasource.go
+++ b/pkg/resources/instance_pool/datasource.go
@@ -284,7 +284,6 @@ func dsBuildData(pool *exo.InstancePool) (map[string]interface{}, error) {
 	data[AttrInstancePrefix] = utils.DefaultString(pool.InstancePrefix, "")
 	data[AttrIPv6] = utils.DefaultBool(pool.IPv6Enabled, false)
 	data[AttrKeyPair] = pool.SSHKey
-	data[AttrLabels] = pool.Labels
 	data[AttrName] = pool.Name
 	data[AttrSize] = pool.Size
 	data[AttrState] = pool.State
@@ -293,6 +292,10 @@ func dsBuildData(pool *exo.InstancePool) (map[string]interface{}, error) {
 
 	if pool.AntiAffinityGroupIDs != nil {
 		data[AttrAffinityGroupIDs] = *pool.AntiAffinityGroupIDs
+	}
+
+	if pool.Labels != nil {
+		data[AttrLabels] = *pool.Labels
 	}
 
 	if pool.ElasticIPIDs != nil {

--- a/pkg/resources/instance_pool/datasource_list_test.go
+++ b/pkg/resources/instance_pool/datasource_list_test.go
@@ -50,6 +50,7 @@ resource "exoscale_instance_pool" "test2" {
   size = 1
   disk_size = local.disk_size
   key_pair = exoscale_ssh_keypair.test.name
+  labels = { test="test"}
 }`,
 	testutils.TestZoneName,
 	dsListInstanceType,

--- a/templates/data-sources/database_uri.md.tmpl
+++ b/templates/data-sources/database_uri.md.tmpl
@@ -47,6 +47,7 @@ resource "exoscale_database" "my_database" {
 data "exoscale_database_uri" "my_database" {
   name = "my-database"
   type = "pg"
+  zone = "ch-gva-2"
 }
 
 output "my_database_uri" {


### PR DESCRIPTION
- Fix a panic when an InstancePool with labels exist in the zone.
- Update test with an InstancePool with label
- Fix the example

```
=== RUN   TestInstancePool
=== RUN   TestInstancePool/DataSource
=== RUN   TestInstancePool/DataSourceList
=== RUN   TestInstancePool/Resource
--- PASS: TestInstancePool (241.35s)
    --- PASS: TestInstancePool/DataSource (86.53s)
    --- PASS: TestInstancePool/DataSourceList (60.21s)
    --- PASS: TestInstancePool/Resource (94.61s)
PASS
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/instance_pool     241.388s

```
