### PR TITLE
SKS nodepool tests: wait for np and ip in running state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ BREAKING CHANGES:
 
 - user data are not gzipped anymore. If you want to gzip user data, you may want to use the cloudinit_config datasource.
 
+IMPROVEMENTS:
+
+- resource `sks_nodepool`: wait for nodepool and instancepool in running state in tests
+
 BUG FIX:
 
 - datasource `exoscale_instance_pool_list`: fix panic when instance pool with labels is found


### PR DESCRIPTION
Sometimes tests are failing when we try to delete a nodepool still updating (or the instancepool) 
```
=== RUN   TestAccResourceSKSNodepool
resource SKS Nodepool not running (running)    resource_exoscale_sks_nodepool_test.go:156: Step 2/3 error: Error running apply: exit status 1

        Error: job failed

          with exoscale_sks_nodepool.test,
          on terraform_plugin_test.tf line 31, in resource "exoscale_sks_nodepool" "test":
          31: resource "exoscale_sks_nodepool" "test" {

    testing_new.go:82: Error running post-test destroy, there may be dangling resources: exit status 1

        Error: Delete "https://api-bg-sof-1.exoscale.com/v2/sks-cluster/dd5f5bfc-ebea-4286-b034-c16d7176cb1c/nodepool/27dd7c41-d6c0-44e8-8321-4dc2c9cff57f": invalid request: The nodepool is already being updated.
```

Workaround with the additional checks (bug will be fixed soon in sks itself)

```

=== RUN   TestAccResourceSKSNodepool
--- PASS: TestAccResourceSKSNodepool (163.43s)
PASS
ok      github.com/exoscale/terraform-provider-exoscale/exoscale        163.468s

```