### PR TITLE
SOS (example): update provider config and add versioning

### DIFF
--- a/examples/sos/main.tf
+++ b/examples/sos/main.tf
@@ -15,12 +15,6 @@ resource "random_uuid" "my_uuid" {
 # SOS bucket
 resource "aws_s3_bucket" "my_bucket" {
   bucket = "${local.my_bucket}-${resource.random_uuid.my_uuid.result}"
-
-  lifecycle {
-    ignore_changes = [
-      object_lock_configuration,
-    ]
-  }
 }
 
 # (associated ACL)
@@ -40,6 +34,14 @@ resource "aws_s3_bucket_cors_configuration" "my_bucket_cors" {
     allowed_origins = ["https://s3-website-test.hashicorp.com"]
     expose_headers  = ["ETag"]
     max_age_seconds = 3000
+  }
+}
+
+# Enable versioning
+resource "aws_s3_bucket_versioning" "my_bucket_versioning" {
+  bucket = aws_s3_bucket.my_bucket.id
+  versioning_configuration {
+    status = "Enabled"
   }
 }
 

--- a/examples/sos/providers.tf
+++ b/examples/sos/providers.tf
@@ -19,7 +19,6 @@ provider "aws" {
 
   # Disable AWS-specific features
   skip_credentials_validation = true
-  skip_get_ec2_platforms      = true
   skip_requesting_account_id  = true
   skip_metadata_api_check     = true
   skip_region_validation      = true


### PR DESCRIPTION
- skip_get_ec2_platforms deprecated (#286)
- enable versioning in the SOS example
