### PR TITLE
sks_nodepool: add storage-lvm addon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ BREAKING CHANGES:
 IMPROVEMENTS:
 
 - resource `sks_nodepool`: wait for nodepool and instancepool in running state in tests
+- resource `sks_nodepool`: add **storage_lvm** addon
 
 BUG FIX:
 

--- a/docs/data-sources/sks_nodepool.md
+++ b/docs/data-sources/sks_nodepool.md
@@ -36,6 +36,7 @@ description: |-
 - `security_group_ids` (Set of String) A list of [exoscale_security_group](./security_group.md) (IDs) to be attached to the managed instances.
 - `size` (Number)
 - `state` (String) The current pool state.
+- `storage_lvm` (Boolean) Create nodes with non-standard partitioning for persistent storage (requires min 100G of disk space) (may only be set at creation time).
 - `taints` (Map of String) A map of key/value Kubernetes [taints](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) (`<value>:<effect>`).
 - `template_id` (String) The managed instances template ID.
 - `version` (String) The managed instances version.

--- a/docs/data-sources/sks_nodepool_list.md
+++ b/docs/data-sources/sks_nodepool_list.md
@@ -30,6 +30,7 @@ description: |-
 - `name` (String) Match against this string. If you supply a string that begins and ends with a "/" it will be matched as a regex.
 - `size` (Number) Match against this int
 - `state` (String) Match against this string. If you supply a string that begins and ends with a "/" it will be matched as a regex.
+- `storage_lvm` (Boolean) Match against this bool
 - `taints` (Map of String) Match against key/values. Keys are matched exactly, while values may be matched as a regex if you supply a string that begins and ends with "/"
 - `template_id` (String) Match against this string. If you supply a string that begins and ends with a "/" it will be matched as a regex.
 - `version` (String) Match against this string. If you supply a string that begins and ends with a "/" it will be matched as a regex.
@@ -60,6 +61,7 @@ Read-Only:
 - `security_group_ids` (Set of String)
 - `size` (Number)
 - `state` (String)
+- `storage_lvm` (Boolean)
 - `taints` (Map of String)
 - `template_id` (String)
 - `version` (String)

--- a/docs/resources/sks_nodepool.md
+++ b/docs/resources/sks_nodepool.md
@@ -51,6 +51,7 @@ directory for complete configuration examples.
 - `labels` (Map of String) A map of key/value labels.
 - `private_network_ids` (Set of String) A list of [exoscale_private_network](./private_network.md) (IDs) to be attached to the managed instances.
 - `security_group_ids` (Set of String) A list of [exoscale_security_group](./security_group.md) (IDs) to be attached to the managed instances.
+- `storage_lvm` (Boolean) Create nodes with non-standard partitioning for persistent storage (requires min 100G of disk space) (may only be set at creation time).
 - `taints` (Map of String) A map of key/value Kubernetes [taints](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) (`<value>:<effect>`).
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 

--- a/exoscale/resource_exoscale_sks_nodepool_test.go
+++ b/exoscale/resource_exoscale_sks_nodepool_test.go
@@ -21,8 +21,8 @@ var (
 	testAccResourceSKSNodepoolAntiAffinityGroupName       = acctest.RandomWithPrefix(testPrefix)
 	testAccResourceSKSNodepoolDescription                 = acctest.RandomWithPrefix(testPrefix)
 	testAccResourceSKSNodepoolDescriptionUpdated          = testAccResourceSKSNodepoolDescription + "-updated"
-	testAccResourceSKSNodepoolDiskSize                    = defaultSKSNodepoolDiskSize
-	testAccResourceSKSNodepoolDiskSizeUpdated             = defaultSKSNodepoolDiskSize * 2
+	testAccResourceSKSNodepoolDiskSize                    = defaultSKSNodepoolDiskSize * 2
+	testAccResourceSKSNodepoolDiskSizeUpdated             = defaultSKSNodepoolDiskSize*2 + 10
 	testAccResourceSKSNodepoolInstancePrefix              = "test"
 	testAccResourceSKSNodepoolInstanceType                = "standard.small"
 	testAccResourceSKSNodepoolInstanceTypeUpdated         = "standard.medium"
@@ -33,6 +33,7 @@ var (
 	testAccResourceSKSNodepoolPrivateNetworkName          = acctest.RandomWithPrefix(testPrefix)
 	testAccResourceSKSNodepoolSize                  int64 = 2
 	testAccResourceSKSNodepoolSizeUpdated           int64 = 1
+	testAccResourceSKSNodepoolStorageLVM            bool  = true
 	testAccResourceSKSNodepoolTaintEffect                 = "NoSchedule"
 	testAccResourceSKSNodepoolTaintValue                  = "test"
 	testAccResourceSKSNodepoolTaintValueUpdated           = "test-updated"
@@ -62,6 +63,7 @@ resource "exoscale_sks_nodepool" "test" {
   instance_prefix = "%s"
   labels = { test = "%s" }
   taints = { test = "%s:%s" }
+  storage_lvm = %t
 
   timeouts {
     delete = "10m"
@@ -79,6 +81,7 @@ resource "exoscale_sks_nodepool" "test" {
 		testAccResourceSKSNodepoolLabelValue,
 		testAccResourceSKSNodepoolTaintValue,
 		testAccResourceSKSNodepoolTaintEffect,
+		testAccResourceSKSNodepoolStorageLVM,
 	)
 
 	testAccResourceSKSNodepoolConfigUpdate = fmt.Sprintf(`
@@ -125,6 +128,7 @@ resource "exoscale_sks_nodepool" "test" {
   private_network_ids = [exoscale_network.test.id]
   labels = { test = "%s" }
   taints = { test = "%s:%s" }
+  storage_lvm = %t
 
   timeouts {
     delete = "10m"
@@ -144,6 +148,7 @@ resource "exoscale_sks_nodepool" "test" {
 		testAccResourceSKSNodepoolLabelValueUpdated,
 		testAccResourceSKSNodepoolTaintValueUpdated,
 		testAccResourceSKSNodepoolTaintEffect,
+		testAccResourceSKSNodepoolStorageLVM,
 	)
 )
 
@@ -175,6 +180,7 @@ func TestAccResourceSKSNodepool(t *testing.T) {
 						a.Equal(testAccResourceSKSNodepoolInstancePrefix, *sksNodepool.InstancePrefix)
 						a.Equal(testInstanceTypeIDSmall, *sksNodepool.InstanceTypeID)
 						a.Equal(testAccResourceSKSNodepoolSize, *sksNodepool.Size)
+						a.Equal(1, len(*sksNodepool.AddOns))
 						a.Equal(&egoscale.SKSNodepoolTaint{
 							Effect: testAccResourceSKSNodepoolTaintEffect,
 							Value:  testAccResourceSKSNodepoolTaintValue,


### PR DESCRIPTION
```
TF_ACC=1 /usr/bin/go test                       \
        -race                   \
        -timeout=90m            \
        -tags=testacc           \
        -v -run ^TestAccResourceSKSNodepool$   \
        github.com/exoscale/terraform-provider-exoscale/exoscale github.com/exoscale/terraform-provider-exoscale/pkg/filter github.com/exoscale/terraform-provider-exoscale/pkg/resources/anti_affinity_group github.com/exoscale/terraform-provider-exoscale/pkg/resources/instance github.com/exoscale/terraform-provider-exoscale/pkg/resources/instance_pool
=== RUN   TestAccResourceSKSNodepool
--- PASS: TestAccResourceSKSNodepool (167.63s)
```