### PR TITLE
fix acceptance test panic for filterable list

### DIFF
--- a/pkg/list/filterable_list_datasource_test.go
+++ b/pkg/list/filterable_list_datasource_test.go
@@ -4,7 +4,7 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
 	"github.com/exoscale/terraform-provider-exoscale/pkg/testutils"
 )


### PR DESCRIPTION
We ran the acceptance tests locally for all affected data sources.
```shell
export TF_ACC=1
go test github.com/exoscale/terraform-provider-exoscale/pkg/resources/instance -v -run "^TestInstance/DataSourceList$"
go test github.com/exoscale/terraform-provider-exoscale/pkg/resources/instance_pool -v -run "^TestInstancePool/DataSourceList$"
go test github.com/exoscale/terraform-provider-exoscale/pkg/list -v

=== RUN   TestInstance
=== RUN   TestInstance/DataSourceList
--- PASS: TestInstance (66.31s)
    --- PASS: TestInstance/DataSourceList (66.31s)
PASS
ok  	github.com/exoscale/terraform-provider-exoscale/pkg/resources/instance	66.316s
=== RUN   TestInstancePool
=== RUN   TestInstancePool/DataSourceList
--- PASS: TestInstancePool (175.69s)
    --- PASS: TestInstancePool/DataSourceList (175.69s)
PASS
ok  	github.com/exoscale/terraform-provider-exoscale/pkg/resources/instance_pool	175.698s
=== RUN   TestFilterableListDataSource
--- PASS: TestFilterableListDataSource (0.11s)
PASS
ok  	github.com/exoscale/terraform-provider-exoscale/pkg/list	0.110s
```