### PR TITLE
automate release with GH Action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,10 @@ jobs:
         shell: bash
 
       - name: Import GPG key
+        # This is a third-party GitHub action and we trust it with our GPG key.
+        # To be on the safer side, we should always pin to the commit SHA.
+        # It's not a perfect mitigation, but we should always do some due diligence before upgrading.
+        # The author seems trustworthy, as the author is part of the docker and goreleaser organizations on GitHub.
         uses: crazy-max/ghaction-import-gpg@72b6676b71ab476b77e676928516f6982eef7a41
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,12 +24,6 @@ jobs:
       - run: git submodule update --init --recursive go.mk
         shell: bash
 
-      # TODO needed?
-      # - uses: ./go.mk/.github/actions/setup
-
-      # TODO needed?
-      # - uses: ./go.mk/.github/actions/pre-check
-
       - run: |
           # TODO(sauterp) remove
           # counts the number of seconds since yesterday and sets it as the patch version in the git tag
@@ -40,7 +34,7 @@ jobs:
         shell: bash
 
       - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@v5
+        uses: crazy-max/ghaction-import-gpg@72b6676b71ab476b77e676928516f6982eef7a41
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PASSPHRASE }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,8 @@ name: release
 
 on:
   push:
-    #tags:
-    #  - 'v[0-9]+\.[0-9]+\.[0-9]+'
+    tags:
+      - 'v[0-9]+\.[0-9]+\.[0-9]+'
 
 jobs:
   goreleaser:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,9 +8,6 @@ on:
 
 jobs:
   goreleaser:
-    # TODO remove before merging the branch
-    if: ${{ false }}
-
     runs-on: ubuntu-latest
 
     permissions:
@@ -32,7 +29,7 @@ jobs:
         uses: crazy-max/ghaction-import-gpg@72b6676b71ab476b77e676928516f6982eef7a41
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-          passphrase: ${{ secrets.PASSPHRASE }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
       - uses: ./go.mk/.github/actions/release
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,15 @@ jobs:
         with:
           fetch-depth: 0
 
+      - run: git submodule update --init --recursive go.mk
+        shell: bash
+
+      # TODO needed?
+      # - uses: ./go.mk/.github/actions/setup
+
+      # TODO needed?
+      # - uses: ./go.mk/.github/actions/pre-check
+
       - run: |
           # TODO(sauterp) remove
           # counts the number of seconds since yesterday and sets it as the patch version in the git tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ on:
 
 jobs:
   goreleaser:
+    # TODO remove before merging the branch
+    if: ${{ false }}
+
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,11 +3,8 @@ name: release
 
 on:
   push:
-    branches:
-      - 'sauterp/sc-75095/tf-release-in-gh-action'
-    # TODO uncomment
-    # tags:
-    #   - 'v[0-9]+\.[0-9]+\.[0-9]+'
+    tags:
+      - 'v[0-9]+\.[0-9]+\.[0-9]+'
 
 jobs:
   goreleaser:
@@ -22,15 +19,6 @@ jobs:
           fetch-depth: 0
 
       - run: git submodule update --init --recursive go.mk
-        shell: bash
-
-      - run: |
-          # TODO(sauterp) remove
-          # counts the number of seconds since yesterday and sets it as the patch version in the git tag
-          current=$(date +%s)
-          yesterday=$(date -d "yesterday 00:00:00" +%s)
-          difference=$((current - yesterday))
-          git tag v1.70.$difference
         shell: bash
 
       - name: Import GPG key

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,8 @@ name: release
 
 on:
   push:
-    tags:
-      - 'v[0-9]+\.[0-9]+\.[0-9]+'
+    #tags:
+    #  - 'v[0-9]+\.[0-9]+\.[0-9]+'
 
 jobs:
   goreleaser:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,41 @@
+---
+name: release
+
+on:
+  push:
+    branches:
+      - 'sauterp/sc-75095/tf-release-in-gh-action'
+    # TODO uncomment
+    # tags:
+    #   - 'v[0-9]+\.[0-9]+\.[0-9]+'
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - run: |
+          # TODO(sauterp) remove
+          # counts the number of seconds since yesterday and sets it as the patch version in the git tag
+          current=$(date +%s)
+          yesterday=$(date -d "yesterday 00:00:00" +%s)
+          difference=$((current - yesterday))
+          git tag v1.70.$difference
+        shell: bash
+
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v5
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.PASSPHRASE }}
+
+      - uses: ./go.mk/.github/actions/release
+        with:
+          release_github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,12 +5,11 @@ on:
   push:
     branches:
     - '**'
-    paths-ignore:
-    - '**.md'
-    - '.github/ISSUE_TEMPLATE/*'
-    - '.github/*.md'
-    - 'examples/**'
-    - '.goreleaser.yml'
+    paths:
+    - 'go.mod'
+    - 'go.sum'
+    - '**.go'
+    - '.github/workflows/tests.yml'
     tags-ignore:
     - 'v*' # Don't run CI tests on release tags
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -37,8 +37,7 @@ signs:
 
 release:
   github:
-    # TODO temporary -> exoscale
-    owner: sauterp
+    owner: exoscale
     name: terraform-provider-exoscale
 
 changelog:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -33,11 +33,12 @@ checksum:
 signs:
   - artifacts: checksum
     cmd: gpg
-    args: ["--default-key", "B2DB6B250321137D9DB7210281426F034A3D05F7", "--detach-sign", "${artifact}"]
+    args: ["--default-key", "59EFBBAD405D53EB9D247E222011692C8159DECE", "--detach-sign", "${artifact}"]
 
 release:
   github:
-    owner: exoscale
+    # TODO temporary -> exoscale
+    owner: sauterp
     name: terraform-provider-exoscale
 
 changelog:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -33,7 +33,7 @@ checksum:
 signs:
   - artifacts: checksum
     cmd: gpg
-    args: ["--default-key", "59EFBBAD405D53EB9D247E222011692C8159DECE", "--detach-sign", "${artifact}"]
+    args: ["--default-key", "7100E8BFD6199CE0374CB7F003686F8CDE378D41", "--detach-sign", "${artifact}"]
 
 release:
   github:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,13 @@ FEATURES:
 - `exoscale_database` resource: add Grafana (#276).
 
 BUG FIXES:
+
 - `resource_exoscale_nlb_service`: unset uri and tls_sni when healthcheck mode is tcp (#295)
 - `resource_exoscale_nlb_service`: force service re-creation when InstancePool ID is updated (#295)
+
+IMPROVEMENTS:
+
+- automate releases with a GitHub Action workflow
 
 ## 0.51.0 (August 9, 2023)
 


### PR DESCRIPTION
We add a GH Action workflow "release" that automates the release of the provider.

Successful output on my fork: https://github.com/sauterp/terraform-provider-exoscale/actions/runs/5939662677/job/16106533031

One acceptance test used to fail consistently last week, it must have been a problem on the API side since I ran it locally today and it succeeded:
```shell
TF_ACC=1 go test -test.v -run='^(TestAccResourceSKSCluster)$'
=== RUN   TestAccResourceSKSCluster
--- PASS: TestAccResourceSKSCluster (289.38s)
PASS
ok  	github.com/exoscale/terraform-provider-exoscale/exoscale	289.382s
```