### PR TITLE
exoscale_nlb_service: unset uri and tls_sni when healthcheck mode is tcp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ FEATURES:
 - `exoscale_database` resource & `exoscale_database_uri` datasource: migrate to framework (#276).
 - `exoscale_database` resource: add Grafana (#276).
 
+BUG FIXES:
+- `resource_exoscale_nlb_service`: unset uri and tls_sni when healthcheck mode is tcp (#295)
+- `resource_exoscale_nlb_service`: force service re-creation when InstancePool ID is updated (#295)
+
 ## 0.51.0 (August 9, 2023)
 
 FEATURES:

--- a/docs/resources/nlb_service.md
+++ b/docs/resources/nlb_service.md
@@ -49,8 +49,8 @@ directory for complete configuration examples.
 
 ### Required
 
-- `healthcheck` (Block Set, Min: 1) The service health checking configuration (may only bet set at creation time). (see [below for nested schema](#nestedblock--healthcheck))
-- `instance_pool_id` (String) The [exoscale_instance_pool](./instance_pool.md) (ID) to forward traffic to.
+- `healthcheck` (Block Set, Min: 1) The service health checking configuration. (see [below for nested schema](#nestedblock--healthcheck))
+- `instance_pool_id` (String) ❗ The [exoscale_instance_pool](./instance_pool.md) (ID) to forward traffic to.
 - `name` (String) The NLB service name.
 - `nlb_id` (String) ❗ The parent [exoscale_nlb](./nlb.md) ID.
 - `port` (Number) The healthcheck port.

--- a/exoscale/resource_exoscale_nlb_service.go
+++ b/exoscale/resource_exoscale_nlb_service.go
@@ -57,7 +57,7 @@ func resourceNLBService() *schema.Resource {
 			Description: "A free-form text describing the NLB service.",
 		},
 		resNLBServiceAttrHealthcheck: {
-			Description: "The service health checking configuration (may only bet set at creation time).",
+			Description: "The service health checking configuration.",
 			Type:        schema.TypeSet,
 			Required:    true,
 			Elem: &schema.Resource{
@@ -107,6 +107,7 @@ func resourceNLBService() *schema.Resource {
 		resNLBServiceAttrInstancePoolID: {
 			Type:        schema.TypeString,
 			Required:    true,
+			ForceNew:    true,
 			Description: "The [exoscale_instance_pool](./instance_pool.md) (ID) to forward traffic to.",
 		},
 		resNLBServiceAttrName: {
@@ -421,6 +422,15 @@ func resourceNLBServiceUpdate(ctx context.Context, d *schema.ResourceData, meta 
 			if v, ok := healthcheck[resNLBServiceAttrHealthcheckURI]; ok {
 				s := v.(string)
 				nlbService.Healthcheck.URI = &s
+			}
+			// We need a need struct to remove URI and TLSSNI
+		} else {
+			*nlbService.Healthcheck = egoscale.NetworkLoadBalancerServiceHealthcheck{
+				Interval: &nlbServiceHealthcheckInterval,
+				Mode:     &nlbServiceHealthcheckMode,
+				Port:     &nlbServiceHealthcheckPort,
+				Retries:  &nlbServiceHealthcheckRetries,
+				Timeout:  &nlbServiceHealthcheckTimeout,
 			}
 		}
 


### PR DESCRIPTION
# Description
<!--
* Prefix: the title with the component name being changed. Add a short and self describing sentence to ease the review
* Please add a few lines providing context and describing the change
* Please self comment changes whenever applicable to help with the review process
* Please keep the checklist as part of the PR. Tick what applies to this change.
-->

- unset **uri** and **tls_sni** when healthcheck mode is **tcp** 
  Example without the fix (at each plan/apply, the uri appears in diff)
```
  # exoscale_nlb_service.my_nlb_service will be updated in-place
  ~ resource "exoscale_nlb_service" "my_nlb_service" {
        id               = "bc2fdb55-0ba8-4f12-a836-b4a9b1cba2f9"
        name             = "my-nlb-service"
        # (8 unchanged attributes hidden)

      - healthcheck {
          - interval = 15 -> null
          - mode     = "tcp" -> null
          - port     = 842 -> null
          - retries  = 3 -> null
          - timeout  = 4 -> null
          - uri      = "/" -> null
        }
      + healthcheck {
          + interval = 15
          + mode     = "tcp"
          + port     = 842
          + retries  = 3
          + timeout  = 4
        }
    }
```
- **force re-creation** of a service when **instancepool_id** is updated

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Acceptance tests OK
* [x] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing

<!--
Describe the tests you did
-->
```
 make GO_TEST_EXTRA_ARGS="-v -run ^TestAccResourceNLBService$" test-acc
TF_ACC=1 /usr/bin/go test                       \
        -race                   \
        -timeout=90m            \
        -tags=testacc           \
        -v -run ^TestAccResourceNLBService$   \
        github.com/exoscale/terraform-provider-exoscale/exoscale github.com/exoscale/terraform-provider-exoscale/pkg/filter github.com/exoscale/terraform-provider-exoscale/pkg/list github.com/exoscale/terraform-provider-exoscale/pkg/resources/anti_affinity_group github.com/exoscale/terraform-provider-exoscale/pkg/resources/database github.com/exoscale/terraform-provider-exoscale/pkg/resources/instance github.com/exoscale/terraform-provider-exoscale/pkg/resources/instance_pool
=== RUN   TestAccResourceNLBService
--- PASS: TestAccResourceNLBService (120.24s)
PASS
ok      github.com/exoscale/terraform-provider-exoscale/exoscale        (cached)
testing: warning: no tests to run
PASS
ok      github.com/exoscale/terraform-provider-exoscale/pkg/filter      (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/exoscale/terraform-provider-exoscale/pkg/list        (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/anti_affinity_group       (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/database  (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/instance  (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/instance_pool     (cached) [no tests to run]

```