### PR TITLE
sks acc tests: remove an unnecessary check

### DIFF
--- a/exoscale/resource_exoscale_sks_cluster_test.go
+++ b/exoscale/resource_exoscale_sks_cluster_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -237,20 +236,7 @@ func TestAccResourceSKSCluster(t *testing.T) {
 						a.Equal(testAccResourceSKSClusterLabelValueUpdated, (*sksCluster.Labels)["test"])
 						a.Equal(testAccResourceSKSClusterNameUpdated, *sksCluster.Name)
 
-						// Wait for the cluster to be in the Running state
-						for i := 0; i < 60; i++ {
-							c, err := client.GetSKSCluster(clientctx, testZoneName, *sksCluster.ID)
-							if err != nil {
-								return fmt.Errorf("failed to fetch sks cluster: %s", err)
-							}
-							if *c.State == "running" {
-								return nil
-							}
-							t.Logf("waiting for cluster to be Running, current state: %s", *c.State)
-							time.Sleep(10 * time.Second)
-						}
-
-						return fmt.Errorf("timeout waiting for the cluster to be Running: current state")
+						return nil
 					},
 					checkResourceState(r, checkResourceStateValidateAttributes(testAttrs{
 						resSKSClusterAttrAggregationLayerCA: validation.ToDiagFunc(validation.StringMatch(testPemCertificateFormatRegex, "Aggregation CA must be a PEM certificate")),


### PR DESCRIPTION
# Description
We remove a check that waits for an update to an SKS cluster to happen. It's not necessary (anymore) as the provider does a similar check before.

## Checklist

* [ ] Changelog updated (under *Unreleased* block)
* [ ] Acceptance tests OK
* [ ] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing
Ran the test locally and it failed due to a known issue not related to this change:
```shell
=== RUN   TestAccResourceSKSCluster
    resource_exoscale_sks_cluster_test.go:181: Step 2/3 error: Error running apply: exit status 1

        Error: context deadline exceeded

          with exoscale_sks_cluster.test,
          on terraform_plugin_test.tf line 6, in resource "exoscale_sks_cluster" "test":
           6: resource "exoscale_sks_cluster" "test" {

--- FAIL: TestAccResourceSKSCluster (401.42s)
FAIL
exit status 1
FAIL	github.com/exoscale/terraform-provider-exoscale/exoscale	401.427s
```
