### PR TITLE
Add vie2 zone to framework validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## UNRELEASED
+
+BUG FIXES:
+
+- add missing `vie2` zone in validator used by framework resources (#300)
+
 ## 0.52.0 (September 8, 2023)
 
 FEATURES:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -25,6 +25,7 @@ var Zones = []string{
 	"ch-gva-2",
 	"ch-dk-2",
 	"at-vie-1",
+	"at-vie-2",
 	"de-fra-1",
 	"bg-sof-1",
 	"de-muc-1",


### PR DESCRIPTION
# Description
<!--
* Prefix: the title with the component name being changed. Add a short and self describing sentence to ease the review
* Please add a few lines providing context and describing the change
* Please self comment changes whenever applicable to help with the review process
* Please keep the checklist as part of the PR. Tick what applies to this change.
-->

Adds `vie2` zone the the list of zones used by validator in framework resources.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Acceptance tests OK
* [x] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing

<!--
Describe the tests you did
-->
Before change:
```
$ terraform plan 
╷
│ Error: Invalid Attribute Value Match
│ 
│   with exoscale_database.my_database,
│   on main.tf line 10, in resource "exoscale_database" "my_database":
│   10:   zone = "at-vie-2"
│ 
│ Attribute zone value must be one of: ["\"ch-gva-2\"" "\"ch-dk-2\"" "\"at-vie-1\"" "\"de-fra-1\"" "\"bg-sof-1\"" "\"de-muc-1\""], got: "at-vie-2"
╵
```
No error after change.