### PR TITLE
Update kafka version used in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 BUG FIXES:
 
-- add missing `vie2` zone in validator used by framework resources (#300)
+- Add missing `vie2` zone in validator used by framework resources (#300)
+- Update kafka version used in tests (#301)
 
 ## 0.52.0 (September 8, 2023)
 

--- a/pkg/resources/database/resource_kafka_test.go
+++ b/pkg/resources/database/resource_kafka_test.go
@@ -59,7 +59,7 @@ func testResourceKafka(t *testing.T) {
 		Plan:                  "business-4",
 		Zone:                  testutils.TestZoneName,
 		TerminationProtection: false,
-		Version:               "3.3",
+		Version:               "3.5",
 	}
 
 	dataCreate := dataBase


### PR DESCRIPTION
# Description

Fixes following error:
```
     resource_kafka_test.go:96: Step 1/3 error: Error running apply: exit status 1
        
        Error: Client Error
        
          with exoscale_database.test,
          on terraform_plugin_test.tf line 1, in resource "exoscale_database" "test":
           1: resource "exoscale_database" test {
        
        Unable to create database service kafka, got error: Post
        "https://api-bg-sof-1.exoscale.com/v2/dbaas-kafka/test-terraform-exoscale-4694444206999400901":
        invalid request: Service 'kafka' version '3.3' has reached end of
        availability and cannot be created
```

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Acceptance tests OK
* [x] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing

```
$ TF_ACC=1 go test ./... -run TestDatabase/ResourceKafka
?       github.com/exoscale/terraform-provider-exoscale [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/config      [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/general     [no test files]
ok      github.com/exoscale/terraform-provider-exoscale/exoscale        0.009s [no tests to run]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/filter      0.004s [no tests to run]
?       github.com/exoscale/terraform-provider-exoscale/pkg/provider    [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/provider/config     [no test files]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/list        0.009s [no tests to run]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/anti_affinity_group       0.006s [no tests to run]
?       github.com/exoscale/terraform-provider-exoscale/pkg/resources/zones     [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/testutils   [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/utils       [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/validators  [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/version     [no test files]
?       github.com/exoscale/terraform-provider-exoscale/version [no test files]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/database  15.929s
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/instance  0.006s [no tests to run]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/instance_pool     0.006s [no tests to run]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/nlb_service       0.006s [no tests to run]
```
