### PR TITLE
Disable sks cluster update tests until upstream bug is fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ BUG FIXES:
 
 - Add missing `vie2` zone in validator used by framework resources (#300)
 - Update kafka version used in tests (#301)
+- Temporarily disable SKS cluster update test (#302)
 
 ## 0.52.0 (September 8, 2023)
 

--- a/exoscale/resource_exoscale_sks_cluster_test.go
+++ b/exoscale/resource_exoscale_sks_cluster_test.go
@@ -18,10 +18,10 @@ import (
 )
 
 var (
-	testAccResourceSKSClusterLabelValue             = acctest.RandomWithPrefix(testPrefix)
-	testAccResourceSKSClusterLabelValueUpdated      = testAccResourceSKSClusterLabelValue + "-updated"
-	testAccResourceSKSClusterName                   = acctest.RandomWithPrefix(testPrefix)
-	testAccResourceSKSClusterNameUpdated            = testAccResourceSKSClusterName + "-updated"
+	testAccResourceSKSClusterLabelValue = acctest.RandomWithPrefix(testPrefix)
+	//testAccResourceSKSClusterLabelValueUpdated      = testAccResourceSKSClusterLabelValue + "-updated"
+	testAccResourceSKSClusterName = acctest.RandomWithPrefix(testPrefix)
+	//testAccResourceSKSClusterNameUpdated            = testAccResourceSKSClusterName + "-updated"
 	testAccResourceSKSClusterOIDCClientID           = acctest.RandString(10)
 	testAccResourceSKSClusterOIDCGroupsClaim        = acctest.RandString(10)
 	testAccResourceSKSClusterOIDCGroupsPrefix       = acctest.RandString(10)
@@ -30,7 +30,7 @@ var (
 	testAccResourceSKSClusterOIDCUsernameClaim      = acctest.RandString(10)
 	testAccResourceSKSClusterOIDCUsernamePrefix     = acctest.RandString(10)
 	testAccResourceSKSClusterDescription            = acctest.RandString(10)
-	testAccResourceSKSClusterDescriptionUpdated     = testAccResourceSKSClusterDescription + "-updated"
+	//testAccResourceSKSClusterDescriptionUpdated     = testAccResourceSKSClusterDescription + "-updated"
 
 	testAccResourceSKSClusterConfigCreate = fmt.Sprintf(`
 locals {
@@ -89,45 +89,45 @@ resource "exoscale_sks_nodepool" "test" {
 		testAccResourceSKSClusterOIDCUsernamePrefix,
 	)
 
-	testAccResourceSKSClusterConfigUpdate = fmt.Sprintf(`
-locals {
-  zone = "%s"
-}
-
-resource "exoscale_sks_cluster" "test" {
-  zone = local.zone
-  name = "%s"
-  description = "%s"
-  exoscale_ccm = true
-  metrics_server = false
-  auto_upgrade = true
-  labels = {
-    test = "%s"
-  }
-
-  timeouts {
-    create = "10m"
-  }
-}
-
-resource "exoscale_sks_nodepool" "test" {
-  zone = local.zone
-  cluster_id = exoscale_sks_cluster.test.id
-  name = "test"
-  instance_type = "standard.small"
-  disk_size = 20
-  size = 1
-
-  timeouts {
-    create = "10m"
-  }
-}
-`,
-		testZoneName,
-		testAccResourceSKSClusterNameUpdated,
-		testAccResourceSKSClusterDescriptionUpdated,
-		testAccResourceSKSClusterLabelValueUpdated,
-	)
+	// testAccResourceSKSClusterConfigUpdate = fmt.Sprintf(`
+	// locals {
+	// zone = "%s"
+	// }
+	//
+	// resource "exoscale_sks_cluster" "test" {
+	// zone = local.zone
+	// name = "%s"
+	// description = "%s"
+	// exoscale_ccm = true
+	// metrics_server = false
+	// auto_upgrade = true
+	// labels = {
+	// test = "%s"
+	// }
+	//
+	// timeouts {
+	// create = "10m"
+	// }
+	// }
+	//
+	// resource "exoscale_sks_nodepool" "test" {
+	// zone = local.zone
+	// cluster_id = exoscale_sks_cluster.test.id
+	// name = "test"
+	// instance_type = "standard.small"
+	// disk_size = 20
+	// size = 1
+	//
+	// timeouts {
+	// create = "10m"
+	// }
+	// }
+	// `,
+	// testZoneName,
+	// testAccResourceSKSClusterNameUpdated,
+	// testAccResourceSKSClusterDescriptionUpdated,
+	// testAccResourceSKSClusterLabelValueUpdated,
+	// )
 
 	testAccResourceSKSClusterConfig2Format = `
 locals {
@@ -223,54 +223,54 @@ func TestAccResourceSKSCluster(t *testing.T) {
 					})),
 				),
 			},
-			// NOTE: Temporarily disabled Update test until upstream fix lands:
-			// https://app.shortcut.com/exoscale/story/77029/tf-provider-sks-acc-test-times-out-after-a-cluster-update
-			//{
-			//// Update
-			//Config: testAccResourceSKSClusterConfigUpdate,
-			//Check: resource.ComposeTestCheckFunc(
-			//testAccCheckResourceSKSClusterExists(r, &sksCluster),
-			//func(s *terraform.State) error {
-			//a := assert.New(t)
+			//  NOTE: Temporarily disabled Update test until upstream fix lands:
+			//  https://app.shortcut.com/exoscale/story/77029/tf-provider-sks-acc-test-times-out-after-a-cluster-update
+			// {
+			// // Update
+			// Config: testAccResourceSKSClusterConfigUpdate,
+			// Check: resource.ComposeTestCheckFunc(
+			// testAccCheckResourceSKSClusterExists(r, &sksCluster),
+			// func(s *terraform.State) error {
+			// a := assert.New(t)
 			//
-			//a.True(defaultBool(sksCluster.AutoUpgrade, false))
-			//a.Equal(testAccResourceSKSClusterDescriptionUpdated, *sksCluster.Description)
-			//a.Equal(testAccResourceSKSClusterLabelValueUpdated, (*sksCluster.Labels)["test"])
-			//a.Equal(testAccResourceSKSClusterNameUpdated, *sksCluster.Name)
+			// a.True(defaultBool(sksCluster.AutoUpgrade, false))
+			// a.Equal(testAccResourceSKSClusterDescriptionUpdated, *sksCluster.Description)
+			// a.Equal(testAccResourceSKSClusterLabelValueUpdated, (*sksCluster.Labels)["test"])
+			// a.Equal(testAccResourceSKSClusterNameUpdated, *sksCluster.Name)
 			//
-			//// Wait for the cluster to be in the Running state
-			//for i := 0; i < 60; i++ {
-			//c, err := client.GetSKSCluster(clientctx, testZoneName, *sksCluster.ID)
-			//if err != nil {
-			//return fmt.Errorf("failed to fetch sks cluster: %s", err)
-			//}
-			//if *c.State == "running" {
-			//return nil
-			//}
-			//t.Logf("waiting for cluster to be Running, current state: %s", *c.State)
-			//time.Sleep(10 * time.Second)
-			//}
+			// // Wait for the cluster to be in the Running state
+			// for i := 0; i < 60; i++ {
+			// c, err := client.GetSKSCluster(clientctx, testZoneName, *sksCluster.ID)
+			// if err != nil {
+			// return fmt.Errorf("failed to fetch sks cluster: %s", err)
+			// }
+			// if *c.State == "running" {
+			// return nil
+			// }
+			// t.Logf("waiting for cluster to be Running, current state: %s", *c.State)
+			// time.Sleep(10 * time.Second)
+			// }
 			//
-			//return fmt.Errorf("timeout waiting for the cluster to be Running: current state")
-			//},
-			//checkResourceState(r, checkResourceStateValidateAttributes(testAttrs{
-			//resSKSClusterAttrAggregationLayerCA: validation.ToDiagFunc(validation.StringMatch(testPemCertificateFormatRegex, "Aggregation CA must be a PEM certificate")),
-			//resSKSClusterAttrAutoUpgrade:        validateString("true"),
-			//resSKSClusterAttrCNI:                validateString(defaultSKSClusterCNI),
-			//resSKSClusterAttrControlPlaneCA:     validation.ToDiagFunc(validation.StringMatch(testPemCertificateFormatRegex, "Control-plane CA must be a PEM certificate")),
-			//resSKSClusterAttrCreatedAt:          validation.ToDiagFunc(validation.NoZeroValues),
-			//resSKSClusterAttrDescription:        validateString(testAccResourceSKSClusterDescriptionUpdated),
-			//resSKSClusterAttrEndpoint:           validation.ToDiagFunc(validation.IsURLWithHTTPS),
-			//resSKSClusterAttrExoscaleCCM:        validateString("true"),
-			//resSKSClusterAttrKubeletCA:          validation.ToDiagFunc(validation.StringMatch(testPemCertificateFormatRegex, "Kubelet CA must be a PEM certificate")),
-			//resSKSClusterAttrMetricsServer:      validateString("false"),
-			//resSKSClusterAttrLabels + ".test":   validateString(testAccResourceSKSClusterLabelValueUpdated),
-			//resSKSClusterAttrName:               validateString(testAccResourceSKSClusterNameUpdated),
-			//resSKSClusterAttrServiceLevel:       validateString(defaultSKSClusterServiceLevel),
-			//resSKSClusterAttrState:              validation.ToDiagFunc(validation.NoZeroValues),
-			//})),
-			//),
-			//},
+			// return fmt.Errorf("timeout waiting for the cluster to be Running: current state")
+			// },
+			// checkResourceState(r, checkResourceStateValidateAttributes(testAttrs{
+			// resSKSClusterAttrAggregationLayerCA: validation.ToDiagFunc(validation.StringMatch(testPemCertificateFormatRegex, "Aggregation CA must be a PEM certificate")),
+			// resSKSClusterAttrAutoUpgrade:        validateString("true"),
+			// resSKSClusterAttrCNI:                validateString(defaultSKSClusterCNI),
+			// resSKSClusterAttrControlPlaneCA:     validation.ToDiagFunc(validation.StringMatch(testPemCertificateFormatRegex, "Control-plane CA must be a PEM certificate")),
+			// resSKSClusterAttrCreatedAt:          validation.ToDiagFunc(validation.NoZeroValues),
+			// resSKSClusterAttrDescription:        validateString(testAccResourceSKSClusterDescriptionUpdated),
+			// resSKSClusterAttrEndpoint:           validation.ToDiagFunc(validation.IsURLWithHTTPS),
+			// resSKSClusterAttrExoscaleCCM:        validateString("true"),
+			// resSKSClusterAttrKubeletCA:          validation.ToDiagFunc(validation.StringMatch(testPemCertificateFormatRegex, "Kubelet CA must be a PEM certificate")),
+			// resSKSClusterAttrMetricsServer:      validateString("false"),
+			// resSKSClusterAttrLabels + ".test":   validateString(testAccResourceSKSClusterLabelValueUpdated),
+			// resSKSClusterAttrName:               validateString(testAccResourceSKSClusterNameUpdated),
+			// resSKSClusterAttrServiceLevel:       validateString(defaultSKSClusterServiceLevel),
+			// resSKSClusterAttrState:              validation.ToDiagFunc(validation.NoZeroValues),
+			// })),
+			// ),
+			// },
 			{
 				// Import
 				ResourceName: r,

--- a/exoscale/resource_exoscale_sks_cluster_test.go
+++ b/exoscale/resource_exoscale_sks_cluster_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -224,52 +223,54 @@ func TestAccResourceSKSCluster(t *testing.T) {
 					})),
 				),
 			},
-			{
-				// Update
-				Config: testAccResourceSKSClusterConfigUpdate,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckResourceSKSClusterExists(r, &sksCluster),
-					func(s *terraform.State) error {
-						a := assert.New(t)
-
-						a.True(defaultBool(sksCluster.AutoUpgrade, false))
-						a.Equal(testAccResourceSKSClusterDescriptionUpdated, *sksCluster.Description)
-						a.Equal(testAccResourceSKSClusterLabelValueUpdated, (*sksCluster.Labels)["test"])
-						a.Equal(testAccResourceSKSClusterNameUpdated, *sksCluster.Name)
-
-						// Wait for the cluster to be in the Running state
-						for i := 0; i < 60; i++ {
-							c, err := client.GetSKSCluster(clientctx, testZoneName, *sksCluster.ID)
-							if err != nil {
-								return fmt.Errorf("failed to fetch sks cluster: %s", err)
-							}
-							if *c.State == "running" {
-								return nil
-							}
-							t.Logf("waiting for cluster to be Running, current state: %s", *c.State)
-							time.Sleep(10 * time.Second)
-						}
-
-						return fmt.Errorf("timeout waiting for the cluster to be Running: current state")
-					},
-					checkResourceState(r, checkResourceStateValidateAttributes(testAttrs{
-						resSKSClusterAttrAggregationLayerCA: validation.ToDiagFunc(validation.StringMatch(testPemCertificateFormatRegex, "Aggregation CA must be a PEM certificate")),
-						resSKSClusterAttrAutoUpgrade:        validateString("true"),
-						resSKSClusterAttrCNI:                validateString(defaultSKSClusterCNI),
-						resSKSClusterAttrControlPlaneCA:     validation.ToDiagFunc(validation.StringMatch(testPemCertificateFormatRegex, "Control-plane CA must be a PEM certificate")),
-						resSKSClusterAttrCreatedAt:          validation.ToDiagFunc(validation.NoZeroValues),
-						resSKSClusterAttrDescription:        validateString(testAccResourceSKSClusterDescriptionUpdated),
-						resSKSClusterAttrEndpoint:           validation.ToDiagFunc(validation.IsURLWithHTTPS),
-						resSKSClusterAttrExoscaleCCM:        validateString("true"),
-						resSKSClusterAttrKubeletCA:          validation.ToDiagFunc(validation.StringMatch(testPemCertificateFormatRegex, "Kubelet CA must be a PEM certificate")),
-						resSKSClusterAttrMetricsServer:      validateString("false"),
-						resSKSClusterAttrLabels + ".test":   validateString(testAccResourceSKSClusterLabelValueUpdated),
-						resSKSClusterAttrName:               validateString(testAccResourceSKSClusterNameUpdated),
-						resSKSClusterAttrServiceLevel:       validateString(defaultSKSClusterServiceLevel),
-						resSKSClusterAttrState:              validation.ToDiagFunc(validation.NoZeroValues),
-					})),
-				),
-			},
+			// NOTE: Temporarily disabled Update test until upstream fix lands:
+			// https://app.shortcut.com/exoscale/story/77029/tf-provider-sks-acc-test-times-out-after-a-cluster-update
+			//{
+			//// Update
+			//Config: testAccResourceSKSClusterConfigUpdate,
+			//Check: resource.ComposeTestCheckFunc(
+			//testAccCheckResourceSKSClusterExists(r, &sksCluster),
+			//func(s *terraform.State) error {
+			//a := assert.New(t)
+			//
+			//a.True(defaultBool(sksCluster.AutoUpgrade, false))
+			//a.Equal(testAccResourceSKSClusterDescriptionUpdated, *sksCluster.Description)
+			//a.Equal(testAccResourceSKSClusterLabelValueUpdated, (*sksCluster.Labels)["test"])
+			//a.Equal(testAccResourceSKSClusterNameUpdated, *sksCluster.Name)
+			//
+			//// Wait for the cluster to be in the Running state
+			//for i := 0; i < 60; i++ {
+			//c, err := client.GetSKSCluster(clientctx, testZoneName, *sksCluster.ID)
+			//if err != nil {
+			//return fmt.Errorf("failed to fetch sks cluster: %s", err)
+			//}
+			//if *c.State == "running" {
+			//return nil
+			//}
+			//t.Logf("waiting for cluster to be Running, current state: %s", *c.State)
+			//time.Sleep(10 * time.Second)
+			//}
+			//
+			//return fmt.Errorf("timeout waiting for the cluster to be Running: current state")
+			//},
+			//checkResourceState(r, checkResourceStateValidateAttributes(testAttrs{
+			//resSKSClusterAttrAggregationLayerCA: validation.ToDiagFunc(validation.StringMatch(testPemCertificateFormatRegex, "Aggregation CA must be a PEM certificate")),
+			//resSKSClusterAttrAutoUpgrade:        validateString("true"),
+			//resSKSClusterAttrCNI:                validateString(defaultSKSClusterCNI),
+			//resSKSClusterAttrControlPlaneCA:     validation.ToDiagFunc(validation.StringMatch(testPemCertificateFormatRegex, "Control-plane CA must be a PEM certificate")),
+			//resSKSClusterAttrCreatedAt:          validation.ToDiagFunc(validation.NoZeroValues),
+			//resSKSClusterAttrDescription:        validateString(testAccResourceSKSClusterDescriptionUpdated),
+			//resSKSClusterAttrEndpoint:           validation.ToDiagFunc(validation.IsURLWithHTTPS),
+			//resSKSClusterAttrExoscaleCCM:        validateString("true"),
+			//resSKSClusterAttrKubeletCA:          validation.ToDiagFunc(validation.StringMatch(testPemCertificateFormatRegex, "Kubelet CA must be a PEM certificate")),
+			//resSKSClusterAttrMetricsServer:      validateString("false"),
+			//resSKSClusterAttrLabels + ".test":   validateString(testAccResourceSKSClusterLabelValueUpdated),
+			//resSKSClusterAttrName:               validateString(testAccResourceSKSClusterNameUpdated),
+			//resSKSClusterAttrServiceLevel:       validateString(defaultSKSClusterServiceLevel),
+			//resSKSClusterAttrState:              validation.ToDiagFunc(validation.NoZeroValues),
+			//})),
+			//),
+			//},
 			{
 				// Import
 				ResourceName: r,
@@ -299,13 +300,13 @@ func TestAccResourceSKSCluster(t *testing.T) {
 							resSKSClusterAttrCNI:                validateString(defaultSKSClusterCNI),
 							resSKSClusterAttrControlPlaneCA:     validation.ToDiagFunc(validation.StringMatch(testPemCertificateFormatRegex, "Control-plane CA must be a PEM certificate")),
 							resSKSClusterAttrCreatedAt:          validation.ToDiagFunc(validation.NoZeroValues),
-							resSKSClusterAttrDescription:        validateString(testAccResourceSKSClusterDescriptionUpdated),
+							resSKSClusterAttrDescription:        validateString(testAccResourceSKSClusterDescription),
 							resSKSClusterAttrEndpoint:           validation.ToDiagFunc(validation.IsURLWithHTTPS),
 							resSKSClusterAttrExoscaleCCM:        validateString("true"),
 							resSKSClusterAttrKubeletCA:          validation.ToDiagFunc(validation.StringMatch(testPemCertificateFormatRegex, "Kubelet CA must be a PEM certificate")),
 							resSKSClusterAttrMetricsServer:      validateString("false"),
-							resSKSClusterAttrLabels + ".test":   validateString(testAccResourceSKSClusterLabelValueUpdated),
-							resSKSClusterAttrName:               validateString(testAccResourceSKSClusterNameUpdated),
+							resSKSClusterAttrLabels + ".test":   validateString(testAccResourceSKSClusterLabelValue),
+							resSKSClusterAttrName:               validateString(testAccResourceSKSClusterName),
 							resSKSClusterAttrServiceLevel:       validateString(defaultSKSClusterServiceLevel),
 							resSKSClusterAttrState:              validation.ToDiagFunc(validation.NoZeroValues),
 							resSKSClusterAttrVersion:            validation.ToDiagFunc(validation.NoZeroValues),

--- a/exoscale/resource_exoscale_sks_cluster_test.go
+++ b/exoscale/resource_exoscale_sks_cluster_test.go
@@ -19,9 +19,9 @@ import (
 
 var (
 	testAccResourceSKSClusterLabelValue = acctest.RandomWithPrefix(testPrefix)
-	//testAccResourceSKSClusterLabelValueUpdated      = testAccResourceSKSClusterLabelValue + "-updated"
+	// testAccResourceSKSClusterLabelValueUpdated      = testAccResourceSKSClusterLabelValue + "-updated"
 	testAccResourceSKSClusterName = acctest.RandomWithPrefix(testPrefix)
-	//testAccResourceSKSClusterNameUpdated            = testAccResourceSKSClusterName + "-updated"
+	// testAccResourceSKSClusterNameUpdated            = testAccResourceSKSClusterName + "-updated"
 	testAccResourceSKSClusterOIDCClientID           = acctest.RandString(10)
 	testAccResourceSKSClusterOIDCGroupsClaim        = acctest.RandString(10)
 	testAccResourceSKSClusterOIDCGroupsPrefix       = acctest.RandString(10)
@@ -30,7 +30,7 @@ var (
 	testAccResourceSKSClusterOIDCUsernameClaim      = acctest.RandString(10)
 	testAccResourceSKSClusterOIDCUsernamePrefix     = acctest.RandString(10)
 	testAccResourceSKSClusterDescription            = acctest.RandString(10)
-	//testAccResourceSKSClusterDescriptionUpdated     = testAccResourceSKSClusterDescription + "-updated"
+	// testAccResourceSKSClusterDescriptionUpdated     = testAccResourceSKSClusterDescription + "-updated"
 
 	testAccResourceSKSClusterConfigCreate = fmt.Sprintf(`
 locals {


### PR DESCRIPTION
# Description

Temporarily disable SKS cluster update test to fix following issue:
```
=== RUN   TestAccResourceSKSCluster
    resource_exoscale_sks_cluster_test.go:182: Step 2/3 error: Error running apply: exit status 1
        
        Error: context deadline exceeded
        
          with exoscale_sks_cluster.test,
          on terraform_plugin_test.tf line 6, in resource "exoscale_sks_cluster" "test":
           6: resource "exoscale_sks_cluster" "test" {
```

Upstream bug: https://app.shortcut.com/exoscale/story/77408/sks-update-job-never-completes

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Acceptance tests OK
* [x] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing

```
$ TF_ACC=1 go test ./... -run 'TestAccResourceSKSCluster$'
?       github.com/exoscale/terraform-provider-exoscale [no test files]                    
?       github.com/exoscale/terraform-provider-exoscale/pkg/config      [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/general     [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/provider    [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/provider/config     [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/resources/zones     [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/testutils   [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/utils       [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/validators  [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/version     [no test files]
?       github.com/exoscale/terraform-provider-exoscale/version [no test files]              
3ok     github.com/exoscale/terraform-provider-exoscale/exoscale        265.691s                                                                                                             
ok      github.com/exoscale/terraform-provider-exoscale/pkg/filter      (cached) [no tests to run]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/list        (cached) [no tests to run]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/anti_affinity_group       (cached) [no tests to run]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/database  (cached) [no tests to run]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/instance  (cached) [no tests to run]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/instance_pool     (cached) [no tests to run]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/nlb_service       (cached) [no tests to run]
```
