### PR TITLE
Fix CI Badge in README.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+BUG FIXES:
+-  Fixed CI Badge in README.md (#306)
+
 ## 0.53.0 (October 6, 2023)
 
 FEATURES:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Exoscale Terraform Provider
 
 - Website: https://www.terraform.io
-- [![Actions Status](https://github.com/exoscale/terraform-provider-exoscale/workflows/CI/badge.svg?branch=master)](https://github.com/exoscale/terraform-provider-exoscale/actions?query=workflow%3ACI+branch%3Amaster)
+- [![Actions Status](https://github.com/exoscale/terraform-provider-exoscale/workflows/run-acceptance-tests/badge.svg?branch=master)](https://github.com/exoscale/terraform-provider-exoscale/actions?query=workflow%3Arun-acceptance-tests+branch%3Amaster)
 - [![Gitter chat](https://badges.gitter.im/hashicorp-terraform/Lobby.png)](https://gitter.im/hashicorp-terraform/Lobby)
 - Mailing list: [Google Groups](http://groups.google.com/group/terraform-tool)
 


### PR DESCRIPTION
# Description
Just fixes the badge url since we renamed our workflows.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Acceptance tests OK
* [x] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing

New badge:
[![Actions Status](https://github.com/exoscale/terraform-provider-exoscale/workflows/run-acceptance-tests/badge.svg?branch=master)](https://github.com/exoscale/terraform-provider-exoscale/actions?query=workflow%3Arun-acceptance-tests+branch%3Amaster)