### PR TITLE
Don't throw error if db settings JSON schema cannot be loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ IMPROVEMENTS:
 BUG FIXES:
 
 - Fixed CI Badge in README.md (#306)
+- Fixed database settings schema error when regex pattern cannot be compiled #310
+- Replaced deprecated setting in database pg test #310
 
 ## 0.53.0 (October 6, 2023)
 

--- a/pkg/resources/database/resource_pg_test.go
+++ b/pkg/resources/database/resource_pg_test.go
@@ -78,7 +78,7 @@ func testResourcePg(t *testing.T) {
 	dataUpdate.MaintenanceTime = "02:34:00"
 	dataUpdate.BackupSchedule = "23:45"
 	dataUpdate.IpFilter = nil
-	dataUpdate.PgSettings = strconv.Quote(`{"autovacuum_max_workers":5,"timezone":"Europe/Zurich"}`)
+	dataUpdate.PgSettings = strconv.Quote(`{"max_worker_processes":10,"timezone":"Europe/Zurich"}`)
 	dataUpdate.PgbouncerSettings = strconv.Quote(`{"autodb_pool_size":5,"min_pool_size":10}`)
 	dataUpdate.PglookoutSettings = strconv.Quote(`{"max_failover_replication_time_lag":30}`)
 	buf = &bytes.Buffer{}

--- a/pkg/resources/database/utils.go
+++ b/pkg/resources/database/utils.go
@@ -24,7 +24,10 @@ func validateSettings(in string, schema interface{}) (map[string]interface{}, er
 		gojsonschema.NewStringLoader(in),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("unable to validate JSON Schema: %w", err)
+		// JSON Schema is provided by API and if loading fails there is nothing a user can to to fix the issue.
+		// One example is incompatible regex engines for pattern validation that will prevent loading JSON schema.
+		// When that happens we should still allow running the command as API would validate request.
+		return userSettings, nil
 	}
 
 	if !res.Valid() {


### PR DESCRIPTION
# Description
Ignores the error when JSON schema for database settings cannot be loaded.
Due to some regex patterns in JSON schema not compiling with validator library (`github.com/xeipuuv/gojsonschema`) this could happen and block the usage of database resource. This PR makes schema validation only work if JSON schema can be compiled, otherwise data is sent as is and API server will throw errors instead.

Also replaces deprecated setting (`autovacuum_max_workers`) in database pg test.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Acceptance tests OK
* [x] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing

```
$ TF_ACC=1 go test ./... -count 1 -run '^TestDatabase' 
?       github.com/exoscale/terraform-provider-exoscale [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/config      [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/general     [no test files]
ok      github.com/exoscale/terraform-provider-exoscale/exoscale        0.008s [no tests to run]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/filter      0.004s [no tests to run]
?       github.com/exoscale/terraform-provider-exoscale/pkg/provider    [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/provider/config     [no test files]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/list        0.008s [no tests to run]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/anti_affinity_group       0.006s [no tests to run]
?       github.com/exoscale/terraform-provider-exoscale/pkg/resources/zones     [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/testutils   [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/utils       [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/validators  [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/version     [no test files]
?       github.com/exoscale/terraform-provider-exoscale/version [no test files]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/database  134.226s
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/iam       0.007s [no tests to run]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/instance  0.005s [no tests to run]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/instance_pool     0.005s [no tests to run]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/nlb_service       0.005s [no tests to run]
```
