### PR TITLE
sks_cluster: document possibility to use no CNI at all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## UNRELEASED
+
+IMPROVEMENTS:
+
+- sks_cluster: document possibility to use no CNI at all #313 
+
 ## 0.53.1 (October 26, 2023)
 
 IMPROVEMENTS:

--- a/docs/data-sources/sks_cluster.md
+++ b/docs/data-sources/sks_cluster.md
@@ -24,7 +24,7 @@ description: |-
 - `addons` (Set of String, Deprecated)
 - `aggregation_ca` (String) The CA certificate (in PEM format) for TLS communications between the control plane and the aggregation layer (e.g. `metrics-server`).
 - `auto_upgrade` (Boolean) Enable automatic upgrading of the control plane version.
-- `cni` (String) The CNI plugin that is to be used. Defaults to "calico".
+- `cni` (String) The CNI plugin that is to be used. Available options are "calico" or "cilium". Defaults to "calico". Setting empty string will result in a cluster with no CNI.
 - `control_plane_ca` (String) The CA certificate (in PEM format) for TLS communications between control plane components.
 - `created_at` (String) The cluster creation date.
 - `description` (String) A free-form text describing the cluster.

--- a/docs/resources/sks_cluster.md
+++ b/docs/resources/sks_cluster.md
@@ -39,7 +39,7 @@ directory for complete configuration examples.
 
 - `addons` (Set of String, Deprecated)
 - `auto_upgrade` (Boolean) Enable automatic upgrading of the control plane version.
-- `cni` (String) The CNI plugin that is to be used. Defaults to "calico".
+- `cni` (String) The CNI plugin that is to be used. Available options are "calico" or "cilium". Defaults to "calico". Setting empty string will result in a cluster with no CNI.
 - `description` (String) A free-form text describing the cluster.
 - `exoscale_ccm` (Boolean) Deploy the Exoscale [Cloud Controller Manager](https://github.com/exoscale/exoscale-cloud-controller-manager/) in the control plane (boolean; default: `true`; may only be set at creation time).
 - `labels` (Map of String) A map of key/value labels.

--- a/exoscale/resource_exoscale_sks_cluster.go
+++ b/exoscale/resource_exoscale_sks_cluster.go
@@ -81,7 +81,7 @@ func resourceSKSCluster() *schema.Resource {
 			Type:        schema.TypeString,
 			Optional:    true,
 			Default:     defaultSKSClusterCNI,
-			Description: fmt.Sprintf("The CNI plugin that is to be used. Defaults to %q.", defaultSKSClusterCNI),
+			Description: fmt.Sprintf(`The CNI plugin that is to be used. Available options are "calico" or "cilium". Defaults to %q. Setting empty string will result in a cluster with no CNI.`, defaultSKSClusterCNI),
 		},
 		resSKSClusterAttrControlPlaneCA: {
 			Type:        schema.TypeString,


### PR DESCRIPTION
# Description
It wasn't obvious that a SKS cluster can be created without a CNI. We document this possibility more clearly.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [ ] Acceptance tests OK
* [ ] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing

<!--
Describe the tests you did
-->
