### PR TITLE
IAM API Key examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## UNRELEASED
+
+FEATURES:
+
+- Add IAMv3 examples #316
+
 ## 0.54.0 (November 23, 2023)
 
 BREAKING CHANGES:

--- a/examples/README.md
+++ b/examples/README.md
@@ -87,6 +87,12 @@ This example demonstrates how to create
 [IAM API Key](https://community.exoscale.com/documentation/iam/iam-api-key-roles-policies/)
 that only allows private instances to be deployed.
 
+## [IAM API Key DBaaS](./iam-dbaas-instance)
+
+This example demonstrates how to create
+[IAM API Key](https://community.exoscale.com/documentation/iam/iam-api-key-roles-policies/)
+that only allows access to the specific instance of DBaaS service.
+
 ## [SOS as Terraform Backend](./sos-backend)
 
 This example demonstrates how to configure Terraform to use a

--- a/examples/README.md
+++ b/examples/README.md
@@ -75,6 +75,12 @@ This example demonstrates how to setup
 [Secure Shell (SSH) keys](https://community.exoscale.com/documentation/compute/ssh-keypairs/)
 to access your computes instances, using the `exoscale_ssh_key` resource.
 
+## [IAM API Key SOS bucket access](./iam-bucket-access)
+
+This example demonstrates how to create
+[IAM API Key](https://community.exoscale.com/documentation/iam/iam-api-key-roles-policies/)
+that has restricted access to an SOS bucket.
+
 ## [SOS as Terraform Backend](./sos-backend)
 
 This example demonstrates how to configure Terraform to use a

--- a/examples/README.md
+++ b/examples/README.md
@@ -75,11 +75,17 @@ This example demonstrates how to setup
 [Secure Shell (SSH) keys](https://community.exoscale.com/documentation/compute/ssh-keypairs/)
 to access your computes instances, using the `exoscale_ssh_key` resource.
 
-## [IAM API Key SOS bucket access](./iam-bucket-access)
+## [IAM API Key SOS](./iam-bucket-access)
 
 This example demonstrates how to create
 [IAM API Key](https://community.exoscale.com/documentation/iam/iam-api-key-roles-policies/)
 that has restricted access to an SOS bucket.
+
+## [IAM API Key Compute](./iam-priv-instance)
+
+This example demonstrates how to create
+[IAM API Key](https://community.exoscale.com/documentation/iam/iam-api-key-roles-policies/)
+that only allows private instances to be deployed.
 
 ## [SOS as Terraform Backend](./sos-backend)
 

--- a/examples/iam-bucket-access/README.md
+++ b/examples/iam-bucket-access/README.md
@@ -1,0 +1,36 @@
+# IAM API Key SOS bucket access
+
+This example demonstrates how to provision
+[IAM](https://community.exoscale.com/documentation/iam/iam-api-key-roles-policies)
+Roles and API Keys using `exoscale_iam_role` and `exoscale_iam_api_key` resources.
+
+In our configuration we will define 2 Roles:
+- Read-Write access for 2 different buckets,
+- Read-Only access for one specific bucket.
+
+For each role we define an API Key and assigne the role.
+
+Please refer to the [main.tf](./main.tf) Terraform configuration file.
+
+```console
+terraform init
+terraform apply \
+  -var exoscale_api_key=$EXOSCALE_API_KEY \
+  -var exoscale_api_secret=$EXOSCALE_API_SECRET
+
+...
+
+Outputs:
+
+sos_rw_key = "EXO238a7fc2c438815bc71e9bc3"
+sos_rw_secret = <sensitive>
+sos_ro_key = "EXO2ebe95a7ddee20c608b7faf6"
+sos_ro_secret = <sensitive>
+```
+
+Because API Secret is sensitive, it can be printed with a command `terraform output`:
+
+```console
+terraform output sos_rw_key
+"ABC..."
+```

--- a/examples/iam-bucket-access/README.md
+++ b/examples/iam-bucket-access/README.md
@@ -1,4 +1,4 @@
-# IAM API Key SOS bucket access
+# IAM API Key SOS
 
 This example demonstrates how to provision
 [IAM](https://community.exoscale.com/documentation/iam/iam-api-key-roles-policies)

--- a/examples/iam-bucket-access/main.tf
+++ b/examples/iam-bucket-access/main.tf
@@ -13,12 +13,12 @@ resource "exoscale_iam_role" "sos_rw_role" {
         type = "rules"
         rules = [
           {
-            expression = "!(parameters.bucket in ['my-test-bucket', 'my-other-bucket'])"
-            action     = "deny"
-          },
-          {
             expression = "operation in ['list-sos-buckets-usage', 'list-buckets']"
             action     = "allow"
+          },
+          {
+            expression = "!(parameters.bucket in ['predrag-test-bucket', 'predrag-other-bucket'])"
+            action     = "deny"
           },
           {
             expression = "operation in ['create-bucket', 'delete-bucket']"
@@ -50,7 +50,7 @@ resource "exoscale_iam_role" "sos_ro_role" {
             action     = "allow"
           },
           {
-            expression = "!(parameters.bucket == 'my-test-bucket')"
+            expression = "!(parameters.bucket == 'predrag-test-bucket')"
             action     = "deny"
           },
           {

--- a/examples/iam-bucket-access/main.tf
+++ b/examples/iam-bucket-access/main.tf
@@ -1,0 +1,94 @@
+# Providers
+# -> providers.tf
+
+resource "exoscale_iam_role" "sos_rw_role" {
+  name        = "sos-rw-role"
+  description = "Role for Read-Write access for 2 buckets"
+  editable    = true
+
+  policy = {
+    default_service_strategy = "deny"
+    services = {
+      sos = {
+        type = "rules"
+        rules = [
+          {
+            expression = "true",
+            action     = "allow"
+          },
+          {
+            expression = "!(parameters.bucket in ['my-test-bucket', 'my-other-bucket'])",
+            action     = "deny"
+          },
+          {
+            expression = "operation in ['list-sos-buckets-usage', 'list-buckets']"
+            action     = "allow"
+          },
+          {
+            expression = "operation in ['create-bucket', 'delete-bucket']",
+            action     = "deny"
+          },
+        ]
+      }
+    }
+  }
+}
+
+resource "exoscale_iam_role" "sos_ro_role" {
+  name        = "sos-ro-role"
+  description = "Role for Read-Only access to specific Bucket"
+  editable    = true
+
+  policy = {
+    default_service_strategy = "deny"
+    services = {
+      sos = {
+        type = "rules"
+        rules = [
+          {
+            expression = "operation in ['list-sos-buckets-usage', 'list-buckets']"
+            action     = "allow"
+          },
+          {
+            expression = "!(parameters.bucket == 'my-test-bucket')"
+            action     = "deny"
+          },
+          {
+            expression = "operation in ['list-objects', 'get-object']"
+            action     = "allow"
+          },
+          {
+            expression = "operation in ['get-bucket-acl', 'get-bucket-cors', 'get-bucket-ownership-controls']"
+            action     = "allow"
+          }
+        ]
+      }
+    }
+  }
+}
+
+resource "exoscale_iam_api_key" "sos_rw_key" {
+  name    = "my-api-key"
+  role_id = exoscale_iam_role.sos_rw_role.id
+}
+
+resource "exoscale_iam_api_key" "sos_ro_key" {
+  name    = "my-api-key"
+  role_id = exoscale_iam_role.sos_ro_role.id
+}
+
+# Outputs
+output "sos_rw_key" {
+  value = exoscale_iam_api_key.sos_rw_key.key
+}
+output "sos_rw_secret" {
+  value     = exoscale_iam_api_key.sos_rw_key.secret
+  sensitive = true
+}
+output "sos_ro_key" {
+  value = exoscale_iam_api_key.sos_ro_key.key
+}
+output "sos_ro_secret" {
+  value     = exoscale_iam_api_key.sos_ro_key.secret
+  sensitive = true
+}

--- a/examples/iam-bucket-access/main.tf
+++ b/examples/iam-bucket-access/main.tf
@@ -13,10 +13,6 @@ resource "exoscale_iam_role" "sos_rw_role" {
         type = "rules"
         rules = [
           {
-            expression = "true"
-            action     = "allow"
-          },
-          {
             expression = "!(parameters.bucket in ['my-test-bucket', 'my-other-bucket'])"
             action     = "deny"
           },
@@ -27,6 +23,10 @@ resource "exoscale_iam_role" "sos_rw_role" {
           {
             expression = "operation in ['create-bucket', 'delete-bucket']"
             action     = "deny"
+          },
+          {
+            expression = "true"
+            action     = "allow"
           },
         ]
       }

--- a/examples/iam-bucket-access/main.tf
+++ b/examples/iam-bucket-access/main.tf
@@ -17,7 +17,7 @@ resource "exoscale_iam_role" "sos_rw_role" {
             action     = "allow"
           },
           {
-            expression = "!(parameters.bucket in ['predrag-test-bucket', 'predrag-other-bucket'])"
+            expression = "!(parameters.bucket in ['my-test-bucket', 'my-other-bucket'])"
             action     = "deny"
           },
           {
@@ -50,7 +50,7 @@ resource "exoscale_iam_role" "sos_ro_role" {
             action     = "allow"
           },
           {
-            expression = "!(parameters.bucket == 'predrag-test-bucket')"
+            expression = "!(parameters.bucket == 'my-test-bucket')"
             action     = "deny"
           },
           {

--- a/examples/iam-bucket-access/main.tf
+++ b/examples/iam-bucket-access/main.tf
@@ -13,11 +13,11 @@ resource "exoscale_iam_role" "sos_rw_role" {
         type = "rules"
         rules = [
           {
-            expression = "true",
+            expression = "true"
             action     = "allow"
           },
           {
-            expression = "!(parameters.bucket in ['my-test-bucket', 'my-other-bucket'])",
+            expression = "!(parameters.bucket in ['my-test-bucket', 'my-other-bucket'])"
             action     = "deny"
           },
           {
@@ -25,7 +25,7 @@ resource "exoscale_iam_role" "sos_rw_role" {
             action     = "allow"
           },
           {
-            expression = "operation in ['create-bucket', 'delete-bucket']",
+            expression = "operation in ['create-bucket', 'delete-bucket']"
             action     = "deny"
           },
         ]
@@ -68,12 +68,12 @@ resource "exoscale_iam_role" "sos_ro_role" {
 }
 
 resource "exoscale_iam_api_key" "sos_rw_key" {
-  name    = "my-api-key"
+  name    = "sos_rw-api-key"
   role_id = exoscale_iam_role.sos_rw_role.id
 }
 
 resource "exoscale_iam_api_key" "sos_ro_key" {
-  name    = "my-api-key"
+  name    = "sos-ro-api-key"
   role_id = exoscale_iam_role.sos_ro_role.id
 }
 

--- a/examples/iam-bucket-access/providers.tf
+++ b/examples/iam-bucket-access/providers.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_providers {
+    exoscale = {
+      source = "exoscale/exoscale"
+    }
+  }
+}
+
+variable "exoscale_api_key" { type = string }
+variable "exoscale_api_secret" { type = string }
+provider "exoscale" {
+  key    = var.exoscale_api_key
+  secret = var.exoscale_api_secret
+}

--- a/examples/iam-dbaas-instance/README.md
+++ b/examples/iam-dbaas-instance/README.md
@@ -1,0 +1,69 @@
+# IAM API Key Compute
+
+This example demonstrates how to provision
+[IAM](https://community.exoscale.com/documentation/iam/iam-api-key-roles-policies)
+Roles and API Keys using `exoscale_iam_role` and `exoscale_iam_api_key` resources.
+
+In our configuration we define Role that only allows access to a single DBaaS service instance.
+
+Please refer to the [main.tf](./main.tf) Terraform configuration file.
+
+```console
+terraform init
+terraform apply \
+  -var exoscale_api_key=$EXOSCALE_API_KEY \
+  -var exoscale_api_secret=$EXOSCALE_API_SECRET
+
+...
+
+Outputs:
+
+my_api_key = "EXO238a7fc2c438815bc71e9bc3"
+my_api_secret = <sensitive>
+```
+
+Because API Secret is sensitive, it can be printed with a command `terraform output`:
+
+```console
+terraform output my_api_key
+"ABC..."
+```
+
+We can now use our API Key to access dbaas service `my-dbaas-service`:
+
+```console
+exo dbaas show my-dbaas-instance
+┼───────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼
+│   DATABASE SERVICE    │                                                                                                                                            │
+┼───────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼
+│ Zone                  │ ch-dk-2                                                                                                                                    │
+│ Name                  │ my-dbaas-instance                                                                                                                          │
+│ Type                  │ pg                                                                                                                                         │
+│ Plan                  │ hobbyist-2                                                                                                                                 │
+│ Disk Size             │ 8.0 GiB                                                                                                                                    │
+│ State                 │ running                                                                                                                                    │
+│ Creation Date         │ 2023-11-13 14:58:31 +0000 UTC                                                                                                              │
+│ Update Date           │ 2023-11-13 15:59:33 +0000 UTC                                                                                                              │
+│ Nodes                 │ 1                                                                                                                                          │
+│ Node CPUs             │ 2                                                                                                                                          │
+│ Node Memory           │ 2.0 GiB                                                                                                                                    │
+│ Termination Protected │ false                                                                                                                                      │
+│ Maintenance           │ sunday (00:16:44)                                                                                                                          │
+│ Version               │ 15.4                                                                                                                                       │
+│ Backup Schedule       │ 19:29                                                                                                                                      │
+│ URI                   │ postgres://avnadmin:xxxxx@my-dbaas-instance-exoscale-9f21ec06-ab34-44e1-a8de-1714e4120c91.a.aivencloud.com:21699/defaultdb?sslmode=require │
+│ IP Filter             │ 1.2.3.4/32                                                                                                                                 │
+│ Components            │                                                                                                                                            │
+│                       │   pg          my-dbaas-instance-exoscale-9f21ec06-ab34-44e1-a8de-1714e4120c91.a.aivencloud.com:21699   route:dynamic   usage:primary       │
+│                       │   pgbouncer   my-dbaas-instance-exoscale-9f21ec06-ab34-44e1-a8de-1714e4120c91.a.aivencloud.com:21700   route:dynamic   usage:primary       │
+│                       │                                                                                                                                            │
+│ Users                 │ avnadmin (primary)                                                                                                                         │
+┼───────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼
+```
+
+If we try the DBaaS instance that is not `my-dbaas-service` we get error:
+
+```console
+$ exo dbaas show my-other-dbaas-instance
+error: Get "https://api-ch-dk-2.exoscale.com/v2/dbaas-postgres/my-other-dbaas-instance": invalid request: Forbidden by role policy for dbaas - A deny rule matched. Rule index: 0
+```

--- a/examples/iam-dbaas-instance/main.tf
+++ b/examples/iam-dbaas-instance/main.tf
@@ -1,0 +1,41 @@
+# Providers
+# -> providers.tf
+
+resource "exoscale_iam_role" "my_api_role" {
+  name        = "my-api-role"
+  description = "Role that allows only deploying private instances."
+  editable    = true
+
+  policy = {
+    default_service_strategy = "deny"
+    services = {
+      dbaas = {
+        type = "rules"
+        rules = [
+          {
+            expression = "resources.dbaas_service.name != 'my-dbaas-instance'"
+            action     = "deny"
+          },
+          {
+            expression = "true"
+            action     = "allow"
+          }
+        ]
+      }
+    }
+  }
+}
+
+resource "exoscale_iam_api_key" "my_api_key" {
+  name    = "my-api-key"
+  role_id = exoscale_iam_role.my_api_role.id
+}
+
+# Outputs
+output "my_api_key" {
+  value = exoscale_iam_api_key.my_api_key.key
+}
+output "my_api_secret" {
+  value     = exoscale_iam_api_key.my_api_key.secret
+  sensitive = true
+}

--- a/examples/iam-dbaas-instance/providers.tf
+++ b/examples/iam-dbaas-instance/providers.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_providers {
+    exoscale = {
+      source = "exoscale/exoscale"
+    }
+  }
+}
+
+variable "exoscale_api_key" { type = string }
+variable "exoscale_api_secret" { type = string }
+provider "exoscale" {
+  key    = var.exoscale_api_key
+  secret = var.exoscale_api_secret
+}

--- a/examples/iam-priv-instance/README.md
+++ b/examples/iam-priv-instance/README.md
@@ -1,0 +1,68 @@
+# IAM API Key Compute
+
+This example demonstrates how to provision
+[IAM](https://community.exoscale.com/documentation/iam/iam-api-key-roles-policies)
+Roles and API Keys using `exoscale_iam_role` and `exoscale_iam_api_key` resources.
+
+In our configuration we will restrict access to Compute service to only allow deploying private instances.
+
+Please refer to the [main.tf](./main.tf) Terraform configuration file.
+
+```console
+terraform init
+terraform apply \
+  -var exoscale_api_key=$EXOSCALE_API_KEY \
+  -var exoscale_api_secret=$EXOSCALE_API_SECRET
+
+...
+
+Outputs:
+
+my_api_key = "EXO238a7fc2c438815bc71e9bc3"
+my_api_secret = <sensitive>
+```
+
+Because API Secret is sensitive, it can be printed with a command `terraform output`:
+
+```console
+terraform output my_api_key
+"ABC..."c
+```
+
+Now if we use our new API key and  try to create compute instance with a public IP address assignment we will get error:
+
+```console
+$ exo c i create my-instance 
+ ✔ Creating instance "my-instance"... 0s
+error: Post "https://api-ch-dk-2.exoscale.com/v2/instance": invalid request: Forbidden by role policy for compute - A deny rule matched. Rule index: 0
+```
+
+But we can create a private instance:
+
+```console
+$ exo c i create my-instance --private-instance
+✔ Creating instance "my-instance"... 12s
+┼──────────────────────┼──────────────────────────────────────┼
+│   COMPUTE INSTANCE   │                                      │
+┼──────────────────────┼──────────────────────────────────────┼
+│ ID                   │ f5bd99f6-fdc3-42e9-aec2-cc95d7e22ac7 │
+│ Name                 │ my-instance                          │
+│ Creation Date        │ 2023-11-13 12:27:20 +0000 UTC        │
+│ Instance Type        │ standard.medium                      │
+│ Template             │ Linux Ubuntu 22.04 LTS 64-bit        │
+│ Zone                 │ ch-dk-2                              │
+│ Anti-Affinity Groups │ n/a                                  │
+│ Deploy Target        │ -                                    │
+│ Security Groups      │ n/a                                  │
+│ Private Instance     │ Yes                                  │
+│ Private Networks     │ n/a                                  │
+│ Elastic IPs          │ n/a                                  │
+│ IP Address           │ -                                    │
+│ IPv6 Address         │ -                                    │
+│ SSH Key              │ -                                    │
+│ Disk Size            │ 50 GiB                               │
+│ State                │ running                              │
+│ Labels               │ n/a                                  │
+│ Reverse DNS          │                                      │
+┼──────────────────────┼──────────────────────────────────────┼
+```

--- a/examples/iam-priv-instance/main.tf
+++ b/examples/iam-priv-instance/main.tf
@@ -18,7 +18,7 @@ resource "exoscale_iam_role" "my_api_role" {
           },
           {
             expression = "true"
-            action = "allow"
+            action     = "allow"
           }
         ]
       }

--- a/examples/iam-priv-instance/main.tf
+++ b/examples/iam-priv-instance/main.tf
@@ -1,0 +1,44 @@
+# Providers
+# -> providers.tf
+
+resource "exoscale_iam_role" "my_api_role" {
+  name        = "my-api-role"
+  description = "Role that allows only deploying private instances."
+  editable    = true
+
+  policy = {
+    default_service_strategy = "allow"
+    services = {
+      compute = {
+        type = "rules"
+        rules = [
+          {
+            expression = "operation == 'create-instance' && (!parameters.has('public_ip_assignment') || parameters.public_ip_assignment != 'none')"
+            action     = "deny"
+          },
+          {
+            expression = "true"
+            action = "allow"
+          }
+        ]
+      }
+      "compute-legacy" = {
+        type = "deny"
+      }
+    }
+  }
+}
+
+resource "exoscale_iam_api_key" "my_api_key" {
+  name    = "my-api-key"
+  role_id = exoscale_iam_role.my_api_role.id
+}
+
+# Outputs
+output "my_api_key" {
+  value = exoscale_iam_api_key.my_api_key.key
+}
+output "my_api_secret" {
+  value     = exoscale_iam_api_key.my_api_key.secret
+  sensitive = true
+}

--- a/examples/iam-priv-instance/providers.tf
+++ b/examples/iam-priv-instance/providers.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_providers {
+    exoscale = {
+      source = "exoscale/exoscale"
+    }
+  }
+}
+
+variable "exoscale_api_key" { type = string }
+variable "exoscale_api_secret" { type = string }
+provider "exoscale" {
+  key    = var.exoscale_api_key
+  secret = var.exoscale_api_secret
+}


### PR DESCRIPTION
# Description
Adds examples for IAM API Key:

- RO bucket access,
- RW for 2 buckets,
- single DBaaS instance access,
- restricted instance deploy to private instances only.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Acceptance tests OK
* [x] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing

Tested locally.
