### PR TITLE
exoscale_database: change of plan should not recreate resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@
 IMPROVEMENTS:
 
 - Bump golang.org/x/crypto from 0.14.0 to 0.17.0 (#323)
-- sks_nodepool: add an example for taints #324 
+- sks_nodepool: add an example for taints #324
+
+BUG FIXES:
+- database: change of plan should not recreate resource (#327)
 
 ## 0.54.1 (December 6, 2023)
 

--- a/pkg/resources/database/resource.go
+++ b/pkg/resources/database/resource.go
@@ -158,9 +158,6 @@ func (r *Resource) Schema(ctx context.Context, req resource.SchemaRequest, resp 
 			"plan": schema.StringAttribute{
 				MarkdownDescription: "The plan of the database service (use the [Exoscale CLI](https://github.com/exoscale/cli/) - `exo dbaas type show <TYPE> --plans` - for reference).",
 				Required:            true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
-				},
 			},
 			"state": schema.StringAttribute{
 				MarkdownDescription: "The current state of the database service.",


### PR DESCRIPTION
# Description
<!--
* Prefix: the title with the component name being changed. Add a short and self describing sentence to ease the review
* Please add a few lines providing context and describing the change
* Please self comment changes whenever applicable to help with the review process
* Please keep the checklist as part of the PR. Tick what applies to this change.
-->

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Acceptance tests OK
* [ ] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing

<!--
Describe the tests you did
-->
```
=== RUN   TestDatabase
=== RUN   TestDatabase/ResourcePg
=== RUN   TestDatabase/ResourceMysql
=== RUN   TestDatabase/ResourceRedis
=== RUN   TestDatabase/ResourceKafka
=== RUN   TestDatabase/ResourceOpensearch
=== RUN   TestDatabase/ResourceGrafana
=== RUN   TestDatabase/DataSourceURI
--- PASS: TestDatabase (118.41s)
    --- PASS: TestDatabase/ResourcePg (14.39s)
    --- PASS: TestDatabase/ResourceMysql (11.49s)
    --- PASS: TestDatabase/ResourceRedis (10.47s)
    --- PASS: TestDatabase/ResourceKafka (12.21s)
    --- PASS: TestDatabase/ResourceOpensearch (13.83s)
    --- PASS: TestDatabase/ResourceGrafana (12.51s)
    --- PASS: TestDatabase/DataSourceURI (43.50s)
PASS
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/database  119.500s

```

Change of plan with 0.54.1
```

  # exoscale_database.my_database must be replaced
-/+ resource "exoscale_database" "my_database" {
      ~ ca_certificate         = <<-EOT
            -----BEGIN CERTIFICATE-----
            MIIEQTCCAqmgAwIBAgIULBB7vkP38en9loZXwdbNk68c0sEwDQYJKoZIhvcNAQEM
            BQAwOjE4MDYGA1UEAwwvMGRiNjRiMjEtZGNkNi00MjM3LWI0MjMtM2M1OGE3Zjhj
            MDFkIFByb2plY3QgQ0EwHhcNMjIwMTI4MTYxMTUxWhcNMzIwMTI2MTYxMTUxWjA6
            MTgwNgYDVQQDDC8wZGI2NGIyMS1kY2Q2LTQyMzctYjQyMy0zYzU4YTdmOGMwMWQg
            UHJvamVjdCBDQTCCAaIwDQYJKoZIhvcNAQEBBQADggGPADCCAYoCggGBALqEhwlo
            gvl/TS7SWuyWoCiAovMFlkFgymEWBqMMbkurG2tlNwdBpE6mxrm2SY6F0RQXAVtm
            n1MGivcJBiAFFPCqkDptXqlQ/NuiT6V9rECSLFZ0G+af0+dgTjnX0B6u/+6U69y7
            mYOEHywGT5T0NJUe9NXPr6iAIq2jiAbA7m0oma68cu36v8fIL19gcetmHmseuKHX
            8UildQ+6hWLwKo2qD7Er1y+DPUqVtll+4UVrI5ZiEBrEUAlHopRXWRaO0T24AsnC
            MuzLTaqRYy+ysn/z+H+j3c4otQdUbF+RboPlsO3WSvJLZQAikY9r/JJkP9muYhSn
            MgVrYJS5sA1JcYjwweaXxpTo6bSerHBPcL0QRKHhbj688VNFLWC6cwBT+zElI8cN
            kSN2tqMriztI9kKniSKWkFju1esNyq3BBxtRGJdL6i6EXsbwS7ECsm703zk7h1+a
            loSohDvHHGIO+ktLAFmH0fcIBFpc9UaTdkwgOkNCiUnSE3ZpNMlXX+ZBewIDAQAB
            oz8wPTAdBgNVHQ4EFgQUvqe0gW0sHonYpyamaWVBtu0nfZ4wDwYDVR0TBAgwBgEB
            /wIBADALBgNVHQ8EBAMCAQYwDQYJKoZIhvcNAQEMBQADggGBAHiXV/BclcRUPZR0
            HDCVgH53IovQYOnuN7580FoVuxYh5lD4lsKQGjLZ0X7BnmaqWYvsrG/T2b4nXA8G
            AyV7OPqfctALS2vEMbAjTH/M8WkQmZGsUyQFjlMjiGBHfic5D6jFxP9TziM7ZFye
            BbNFg5tvw6Ciwo9UojXYoASCM08wqOQNWcMGeEmanzguNfZ2/r2TDmQrcN1mkmk0
            ZaJZAULB03r5c5msfZ8NHEqaloqPCtliEOPh/y0bRCuo4SylAjPi6y5/V/TqrQZm
            0hDOIMYXlITEqVXT0IWkFN9uHoboADkcdejF3IuJCHQzMzZcs3UOXXbbc3vVO3UW
            Jvp7kZkvGUnmqE3W3ojX709J1m2S98+4zmqGjXbIURIBCKjvlSanypOV0AyW9ZXr
            NC/UivImbmJXsc7f90eB9IzFy+hC91CcOeU61vBKf9lY+210klz4YciZUC/Y/MnW
            kbNjkRPVggOjpgawshkWAOMLHgfz4450eVgEBAUgMjFgWanNyw==
            -----END CERTIFICATE-----
        EOT -> (known after apply)
      ~ created_at             = "2024-01-10 14:09:46 +0000 UTC" -> (known after apply)
      ~ disk_size              = 0 -> (known after apply)
      ~ id                     = "my-database" -> (known after apply)
      ~ maintenance_dow        = "saturday" -> (known after apply)
      ~ maintenance_time       = "10:41:14" -> (known after apply)
        name                   = "my-database"
      ~ node_cpus              = 2 -> (known after apply)
      ~ node_memory            = 2147483648 -> (known after apply)
      ~ nodes                  = 1 -> (known after apply)
      ~ plan                   = "hobbyist-2" -> "startup-4" # forces replacement
      ~ state                  = "running" -> (known after apply)
      ~ updated_at             = "2024-01-10 14:15:16 +0000 UTC" -> (known after apply)
        # (3 unchanged attributes hidden)

      ~ grafana {
          + grafana_settings = (known after apply)
            # (1 unchanged attribute hidden)
        }
    }

Plan: 1 to add, 0 to change, 1 to destroy.
```
Change of plan with this version
```
  # exoscale_database.my_database will be updated in-place
  ~ resource "exoscale_database" "my_database" {
        id                     = "my-database"
      ~ maintenance_dow        = "saturday" -> (known after apply)
      ~ maintenance_time       = "10:41:14" -> (known after apply)
        name                   = "my-database"
      ~ plan                   = "hobbyist-2" -> "startup-4"
      ~ state                  = "running" -> (known after apply)
      ~ updated_at             = "2024-01-10 14:15:16 +0000 UTC" -> (known after apply)
        # (9 unchanged attributes hidden)

      ~ grafana {
          + grafana_settings = (known after apply)
            # (1 unchanged attribute hidden)
        }
    }
```