### PR TITLE
Handle DNS record normalization in upstream provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ IMPROVEMENTS:
 - sks_nodepool: add an example for taints #324 
 - SKS tests: renable cluster update test as upstream bug is fixed (#309)
 - Make `iam_role.name` attribute require replace as per API behaviour (#330)
+- Handle DNS record normalization #332
 
 
 BUG FIXES:

--- a/docs/resources/domain_record.md
+++ b/docs/resources/domain_record.md
@@ -56,6 +56,7 @@ directory for complete configuration examples.
 
 ### Read-Only
 
+- `content_normalized` (String) The normalized value of the record
 - `hostname` (String) The record *Fully Qualified Domain Name* (FQDN). Useful for aliasing `A`/`AAAA` records with `CNAME`.
 - `id` (String) The ID of this resource.
 

--- a/exoscale/resource_exoscale_domain_record_test.go
+++ b/exoscale/resource_exoscale_domain_record_test.go
@@ -15,16 +15,18 @@ import (
 )
 
 var (
-	testAccResourceDomainRecordDomainName     = acctest.RandomWithPrefix(testPrefix) + ".net"
-	testAccResourceDomainRecordName           = "mail1"
-	testAccResourceDomainRecordNameUpdated    = "mail2"
-	testAccResourceDomainRecordType           = "MX"
-	testAccResourceDomainRecordContent        = "mta1." + testAccResourceDomainRecordDomainName
-	testAccResourceDomainRecordContentUpdated = "mta2." + testAccResourceDomainRecordDomainName
-	testAccResourceDomainRecordPrio           = 10
-	testAccResourceDomainRecordPrioUpdated    = 20
-	testAccResourceDomainRecordTTL            = 10
-	testAccResourceDomainRecordTTLUpdated     = 20
+	testAccResourceDomainRecordDomainName           = acctest.RandomWithPrefix(testPrefix) + ".net"
+	testAccResourceDomainRecordName                 = "mail1"
+	testAccResourceDomainRecordNameUpdated          = "mail2"
+	testAccResourceDomainRecordType                 = "MX"
+	testAccResourceDomainRecordContent              = "mta1." + testAccResourceDomainRecordDomainName
+	testAccResourceDomainRecordContentUpdated       = "mta2." + testAccResourceDomainRecordDomainName
+	testAccResourceDomainRecordTXTContent           = "test value for TXT record"
+	testAccResourceDomainRecordTXTContentNormalized = "\"test value for TXT record\""
+	testAccResourceDomainRecordPrio                 = 10
+	testAccResourceDomainRecordPrioUpdated          = 20
+	testAccResourceDomainRecordTTL                  = 10
+	testAccResourceDomainRecordTTLUpdated           = 20
 
 	testAccResourceDomainRecordConfigCreate = fmt.Sprintf(`
 resource "exoscale_domain" "exo" {
@@ -46,6 +48,13 @@ resource "exoscale_domain_record" "a" {
   record_type = "A"
   content     = "1.2.3.4"
 }
+
+resource "exoscale_domain_record" "txt" {
+  domain      = exoscale_domain.exo.id
+  name        = "test"
+  record_type = "TXT"
+  content     = "%s"
+}
 `,
 		testAccResourceDomainRecordDomainName,
 		testAccResourceDomainRecordName,
@@ -53,6 +62,7 @@ resource "exoscale_domain_record" "a" {
 		testAccResourceDomainRecordContent,
 		testAccResourceDomainRecordPrio,
 		testAccResourceDomainRecordTTL,
+		testAccResourceDomainRecordTXTContent,
 	)
 
 	testAccResourceDomainRecordConfigUpdate = fmt.Sprintf(`
@@ -74,6 +84,13 @@ resource "exoscale_domain_record" "a" {
   name        = ""
   record_type = "A"
   content     = "1.2.3.4"
+}
+
+resource "exoscale_domain_record" "txt" {
+  domain      = exoscale_domain.exo.id
+  name        = "test"
+  record_type = "TXT"
+  content     = "\"test value for TXT record\""
 }
 `,
 		testAccResourceDomainRecordDomainName,
@@ -109,6 +126,10 @@ func TestAccResourceDomainRecord(t *testing.T) {
 						"prio":        validateString(fmt.Sprint(testAccResourceDomainRecordPrio)),
 						"ttl":         validateString(fmt.Sprint(testAccResourceDomainRecordTTL)),
 					}),
+					testAccCheckResourceDomainRecordAttributes("exoscale_domain_record.txt", testAttrs{
+						"content":            validateString(testAccResourceDomainRecordTXTContent),
+						"content_normalized": validateString(testAccResourceDomainRecordTXTContentNormalized),
+					}),
 					testAccCheckResourceDomainRecordStateUpgradeV1("exoscale_domain.exo", "exoscale_domain_record.mx"),
 				),
 			},
@@ -124,6 +145,10 @@ func TestAccResourceDomainRecord(t *testing.T) {
 						"content":     validateString(testAccResourceDomainRecordContentUpdated),
 						"prio":        validateString(fmt.Sprint(testAccResourceDomainRecordPrioUpdated)),
 						"ttl":         validateString(fmt.Sprint(testAccResourceDomainRecordTTLUpdated)),
+					}),
+					testAccCheckResourceDomainRecordAttributes("exoscale_domain_record.txt", testAttrs{
+						"content":            validateString(testAccResourceDomainRecordTXTContentNormalized),
+						"content_normalized": validateString(testAccResourceDomainRecordTXTContentNormalized),
 					}),
 				),
 			},


### PR DESCRIPTION
# Description
This PR prevents terraform from reporting changes due to record normalization done by upstream provider (DNSimple).

Record normalization is easily triggered by TXT records as they need to have inline quotes (eg. `"\"text\"'`).

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Acceptance tests OK
* [x] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing

```bash
$  terraform apply                                                                                                                                                                                                                                                                                                                             
data.exoscale_domain.my_domain: Reading...                                                                                                                                                   
data.exoscale_domain.my_domain: Read complete after 1s [id=<id>]                                                                                             
                                                                                                                                                                                             
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:                                                   
  + create                                                                                                                                                                                   
                                               
Terraform will perform the following actions:

  # exoscale_domain_record.my_record will be created          
  + resource "exoscale_domain_record" "my_record" {                                                                                                                                          
      + content            = "%[2]q"                                                                                                                                                         
      + content_normalized = (known after apply)
      + domain             = "<id>"
      + hostname           = (known after apply)
      + id                 = (known after apply)
      + name               = "test-dnsimple-normalization"
      + prio               = (known after apply)
      + record_type        = "TXT"
      + ttl                = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

exoscale_domain_record.my_record: Creating...
exoscale_domain_record.my_record: Creation complete after 5s [id=<id>]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

$  terraform plan
data.exoscale_domain.my_domain: Reading...
data.exoscale_domain.my_domain: Read complete after 1s [id=<id>]
exoscale_domain_record.my_record: Refreshing state... [id=<id>]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.

$ terraform state show exoscale_domain_record.my_record      
# exoscale_domain_record.my_record:
resource "exoscale_domain_record" "my_record" { 
    content            = "%[2]q"
    content_normalized = "\"%[2]q\""
    domain             = "<id>"
    hostname           = "test.example.net"
    id                 = "<id>"
    name               = "test-dnsimple-normalization"
    prio               = 0
    record_type        = "TXT"
    ttl                = 3600
}
```