### PR TITLE
sks: acceptance test for CSI addon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+FEATURES:
+
+- sks: CSI addon (#335)
+
 IMPROVEMENTS:
 
 - Add note about multiple ports rules in security group migration guide #333

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ FEATURES:
 
 IMPROVEMENTS:
 
+- sks: acceptance test for CSI addon #336
 - Add note about multiple ports rules in security group migration guide #333
 
 ## 0.55.0 (January 26, 2024)

--- a/exoscale/resource_exoscale_sks_cluster.go
+++ b/exoscale/resource_exoscale_sks_cluster.go
@@ -23,6 +23,7 @@ const (
 	defaultSKSClusterServiceLevel = "pro"
 
 	sksClusterAddonExoscaleCCM = "exoscale-cloud-controller"
+	sksClusterAddonExoscaleCSI = "exoscale-container-storage-interface"
 	sksClusterAddonMS          = "metrics-server"
 
 	resSKSClusterAttrAddons             = "addons"
@@ -34,6 +35,7 @@ const (
 	resSKSClusterAttrDescription        = "description"
 	resSKSClusterAttrEndpoint           = "endpoint"
 	resSKSClusterAttrExoscaleCCM        = "exoscale_ccm"
+	resSKSClusterAttrExoscaleCSI        = "exoscale_csi"
 	resSKSClusterAttrKubeletCA          = "kubelet_ca"
 	resSKSClusterAttrLabels             = "labels"
 	resSKSClusterAttrMetricsServer      = "metrics_server"
@@ -121,6 +123,12 @@ func resourceSKSCluster() *schema.Resource {
 			Optional:    true,
 			Default:     true,
 			Description: "Deploy the [Kubernetes Metrics Server](https://github.com/kubernetes-sigs/metrics-server/) in the control plane (boolean; default: `true`; may only be set at creation time).",
+		},
+		resSKSClusterAttrExoscaleCSI: {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     false,
+			Description: "Deploy the Exoscale [Container Storage Interface](https://github.com/exoscale/exoscale-csi-driver/) on worker nodes (boolean; default: `false`; may only be set at creation time).",
 		},
 		resSKSClusterAttrLabels: {
 			Type:        schema.TypeMap,
@@ -267,6 +275,9 @@ func resourceSKSClusterCreate(ctx context.Context, d *schema.ResourceData, meta 
 	}
 	if enableMS := d.Get(resSKSClusterAttrMetricsServer).(bool); enableMS && !in(addOns, sksClusterAddonMS) {
 		addOns = append(addOns, sksClusterAddonMS)
+	}
+	if enableCSI := d.Get(resSKSClusterAttrExoscaleCSI).(bool); enableCSI && !in(addOns, sksClusterAddonExoscaleCSI) {
+		addOns = append(addOns, sksClusterAddonExoscaleCSI)
 	}
 	if len(addOns) > 0 {
 		sksCluster.AddOns = &addOns

--- a/exoscale/resource_exoscale_sks_cluster_test.go
+++ b/exoscale/resource_exoscale_sks_cluster_test.go
@@ -42,6 +42,7 @@ resource "exoscale_sks_cluster" "test" {
   name = "%s"
   description = "%s"
   exoscale_ccm = true
+  exoscale_csi = true
   metrics_server = false
   auto_upgrade = true
   labels = {
@@ -67,9 +68,11 @@ resource "exoscale_sks_nodepool" "test" {
   zone = local.zone
   cluster_id = exoscale_sks_cluster.test.id
   name = "test"
-  instance_type = "standard.small"
   disk_size = 20
-  size = 1
+
+  # standard.medium and a minimum size of 2 is required for the CSI
+  instance_type = "standard.medium"
+  size = 2
 
   timeouts {
     delete = "10m"
@@ -193,7 +196,7 @@ func TestAccResourceSKSCluster(t *testing.T) {
 
 						latestVersion := versions[0]
 
-						a.Equal([]string{sksClusterAddonExoscaleCCM}, *sksCluster.AddOns)
+						a.Equal([]string{sksClusterAddonExoscaleCCM, sksClusterAddonExoscaleCSI}, *sksCluster.AddOns)
 						a.True(defaultBool(sksCluster.AutoUpgrade, false))
 						a.Equal(defaultSKSClusterCNI, *sksCluster.CNI)
 						a.Equal(testAccResourceSKSClusterDescription, *sksCluster.Description)
@@ -213,6 +216,7 @@ func TestAccResourceSKSCluster(t *testing.T) {
 						resSKSClusterAttrDescription:        validateString(testAccResourceSKSClusterDescription),
 						resSKSClusterAttrEndpoint:           validation.ToDiagFunc(validation.IsURLWithHTTPS),
 						resSKSClusterAttrExoscaleCCM:        validateString("true"),
+						resSKSClusterAttrExoscaleCSI:        validateString("true"),
 						resSKSClusterAttrKubeletCA:          validation.ToDiagFunc(validation.StringMatch(testPemCertificateFormatRegex, "Kubelet CA must be a PEM certificate")),
 						resSKSClusterAttrMetricsServer:      validateString("false"),
 						resSKSClusterAttrLabels + ".test":   validateString(testAccResourceSKSClusterLabelValue),
@@ -237,6 +241,7 @@ func TestAccResourceSKSCluster(t *testing.T) {
 						resSKSClusterAttrDescription:        validateString(testAccResourceSKSClusterDescriptionUpdated),
 						resSKSClusterAttrEndpoint:           validation.ToDiagFunc(validation.IsURLWithHTTPS),
 						resSKSClusterAttrExoscaleCCM:        validateString("true"),
+						resSKSClusterAttrExoscaleCSI:        validateString("true"),
 						resSKSClusterAttrKubeletCA:          validation.ToDiagFunc(validation.StringMatch(testPemCertificateFormatRegex, "Kubelet CA must be a PEM certificate")),
 						resSKSClusterAttrMetricsServer:      validateString("false"),
 						resSKSClusterAttrLabels + ".test":   validateString(testAccResourceSKSClusterLabelValueUpdated),


### PR DESCRIPTION
# Description

We extend the acceptance tests of the `exoscale_sks_cluster` resource to test the `exoscale_csi` attribute.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [ ] Acceptance tests OK
* [x] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing

