### PR TITLE
compute_instance: add `destroy_protected` attr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+FEATURES:
+
+- compute_instance: add destroy_protected attr #337 
 IMPROVEMENTS:
 
 - Add note about multiple ports rules in security group migration guide #333

--- a/docs/resources/compute_instance.md
+++ b/docs/resources/compute_instance.md
@@ -51,6 +51,7 @@ directory for complete configuration examples.
 
 - `anti_affinity_group_ids` (Set of String) ❗ A list of [exoscale_anti_affinity_group](./anti_affinity_group.md) (IDs) to attach to the instance (may only be set at creation time).
 - `deploy_target_id` (String) ❗ A deploy target ID.
+- `destroy_protected` (Boolean) Mark the instance as protected, the Exoscale API will refuse to delete the instance until the protection is removed (boolean; default: `false`).
 - `disk_size` (Number) The instance disk size (GiB; at least `10`). Can not be decreased after creation. **WARNING**: updating this attribute stops/restarts the instance.
 - `elastic_ip_ids` (Set of String) A list of [exoscale_elastic_ip](./elastic_ip.md) (IDs) to attach to the instance.
 - `ipv6` (Boolean) Enable IPv6 on the instance (boolean; default: `false`).

--- a/pkg/resources/instance/attributes.go
+++ b/pkg/resources/instance/attributes.go
@@ -6,6 +6,7 @@ const (
 
 	AttrAntiAffinityGroupIDs = "anti_affinity_group_ids"
 	AttrCreatedAt            = "created_at"
+	AttrDestroyProtected     = "destroy_protected"
 	AttrDeployTargetID       = "deploy_target_id"
 	AttrDiskSize             = "disk_size"
 	AttrElasticIPIDs         = "elastic_ip_ids"

--- a/pkg/resources/instance/destroy_protection_test.go
+++ b/pkg/resources/instance/destroy_protection_test.go
@@ -1,0 +1,116 @@
+package instance_test
+
+import (
+	"bytes"
+	"fmt"
+	"regexp"
+	"testing"
+	"text/template"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+
+	"github.com/exoscale/terraform-provider-exoscale/pkg/testutils"
+)
+
+var computeInstanceResource = `
+data "exoscale_template" "my_template" {
+  zone = "{{.Zone}}"
+  name = "Linux Ubuntu 22.04 LTS 64-bit"
+}
+
+{{ if .DeleteInstanceResource }}
+resource "exoscale_compute_instance" "my_instance" {
+  zone = "{{.Zone}}"
+  name = "{{.Name}}"
+
+  template_id = data.exoscale_template.my_template.id
+  type        = "standard.micro"
+  disk_size   = 10
+
+  destroy_protected = {{.DestroyProtected}}
+}
+{{ end }}
+`
+
+func testDestroyProtection(t *testing.T) {
+	tmpl := template.Must(template.New("compute_instance").Parse(computeInstanceResource))
+
+	type TestData struct {
+		Zone                   string
+		DestroyProtected       bool
+		Name                   string
+		DeleteInstanceResource bool
+	}
+
+	buildTestConfig := func(testData TestData) string {
+		var tmplBuf bytes.Buffer
+
+		err := tmpl.Execute(&tmplBuf, testData)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		return tmplBuf.String()
+	}
+
+	instanceName := acctest.RandomWithPrefix(testutils.Prefix)
+
+	checkDestroyProtection := func(expected string) func(s *terraform.State) error {
+		return func(s *terraform.State) error {
+			isDestroyProtected, err := testutils.AttrFromState(s, "resource.exoscale_compute_instance.my-instance", "destroy_protected")
+			if err != nil {
+				return err
+			}
+
+			if expected != isDestroyProtected {
+				return fmt.Errorf("destroy_protected does not match expected value: %q; is %q", expected, isDestroyProtected)
+			}
+
+			return nil
+		}
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testutils.AccPreCheck(t) },
+		ProviderFactories: testutils.Providers(),
+		Steps: []resource.TestStep{
+			{
+				Config: buildTestConfig(TestData{
+					Zone:             testutils.TestZoneName,
+					DestroyProtected: true,
+					Name:             instanceName,
+				}),
+				Check: checkDestroyProtection("true"),
+			},
+			{
+				Config: buildTestConfig(TestData{
+					Zone:                   testutils.TestZoneName,
+					DestroyProtected:       false,
+					Name:                   instanceName,
+					DeleteInstanceResource: true,
+				}),
+				Check:       checkDestroyProtection("true"),
+				ExpectError: regexp.MustCompile(`invalid request: Operation delete-instance on resource .* is forbidden - reason: manual instance protection`),
+			},
+			{
+				Config: buildTestConfig(TestData{
+					Zone:             testutils.TestZoneName,
+					DestroyProtected: false,
+					Name:             instanceName,
+				}),
+				Check: checkDestroyProtection("false"),
+			},
+			{
+				Config: buildTestConfig(TestData{
+					Zone:                   testutils.TestZoneName,
+					DestroyProtected:       false,
+					Name:                   instanceName,
+					DeleteInstanceResource: true,
+				}),
+				Check: checkDestroyProtection("false"),
+			},
+		},
+	})
+}

--- a/pkg/resources/instance/destroy_protection_test.go
+++ b/pkg/resources/instance/destroy_protection_test.go
@@ -184,8 +184,8 @@ func testDefaultDestroyProtection(t *testing.T) {
 				ExpectError: destroyProtectionError,
 			},
 
-			// test that removing the `destroy_protected` field does not remove the destroy protection
-			// it won't do anything and we have to set it to false explicitly to delete the instance later
+			// test that removing the `destroy_protected` field removes the destroy protection
+			// behaving as if false were the default value.
 			{
 				Config: buildTestConfig(t, destroyProtectionTestData{
 					Zone:                testutils.TestZoneName,
@@ -200,18 +200,6 @@ func testDefaultDestroyProtection(t *testing.T) {
 					Name:                   instanceName,
 					DeleteInstanceResource: true,
 				}),
-				ExpectError: destroyProtectionError,
-			},
-
-			{
-				// remove the destroy protection for cleanup
-				Config: buildTestConfig(t, destroyProtectionTestData{
-					Zone:                testutils.TestZoneName,
-					SetDestroyProtected: true,
-					DestroyProtected:    false,
-					Name:                instanceName,
-				}),
-				Check: checkDestroyProtection("false"),
 			},
 		},
 	})

--- a/pkg/resources/instance/main_test.go
+++ b/pkg/resources/instance/main_test.go
@@ -6,5 +6,6 @@ func TestInstance(t *testing.T) {
 	t.Run("DataSource", testDataSource)
 	t.Run("DataSourceList", testListDataSource)
 	t.Run("Resource", testResource)
-	t.Run("DestroyProtection", testDestroyProtection)
+	t.Run("DestroyProtection/ExplicitValue", testExplicitDestroyProtection)
+	t.Run("DestroyProtection/DefaultValue", testDefaultDestroyProtection)
 }

--- a/pkg/resources/instance/main_test.go
+++ b/pkg/resources/instance/main_test.go
@@ -6,4 +6,5 @@ func TestInstance(t *testing.T) {
 	t.Run("DataSource", testDataSource)
 	t.Run("DataSourceList", testListDataSource)
 	t.Run("Resource", testResource)
+	t.Run("DestroyProtection", testDestroyProtection)
 }

--- a/pkg/resources/instance/resource.go
+++ b/pkg/resources/instance/resource.go
@@ -38,7 +38,6 @@ func Resource() *schema.Resource {
 			Description: "Mark the instance as protected, the Exoscale API will refuse to delete the instance until the protection is removed (boolean; default: `false`).",
 			Type:        schema.TypeBool,
 			Optional:    true,
-			Computed:    true,
 		},
 		AttrDeployTargetID: {
 			Description: "A deploy target ID.",
@@ -649,7 +648,7 @@ func rUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag
 	// the tf state of the `destroy_protected` field cannot be reconciled
 	// and we cannot rely on d.HasChange to detect a change.
 	// Therefore we simply apply what the practitioner configured
-	// or do nothing if the field isn't set.
+	// If the field is absent, the protection will be removed
 	isDestroyProtected := d.Get(AttrDestroyProtected)
 	if isDestroyProtected != nil {
 		if isDestroyProtected.(bool) {


### PR DESCRIPTION
# Description
We add the attribute `destroy_protected` to the `exoscale_compute_instance` resource. By default it is set to false. If the attribute is set to true the API will return an error, if an attempt is made to delete the affected instance.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Acceptance tests OK
* [x] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing
Two new acceptance tests have been added that verify the feature. The failing acceptance tests in CI are not related to this feature in any way.
