### PR TITLE
go.mk: remove submodule and initialize through make

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - run: git submodule update --init --recursive go.mk
+      - run: make go.mk
       - uses: ./go.mk/.github/actions/setup
       - name: Check documentation is up to date
         run: './scripts/check-documentation-clean.sh'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - run: git submodule update --init --recursive go.mk
+      - run: make go.mk
         shell: bash
 
       - name: Import GPG key

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - run: git submodule update --init --recursive go.mk
+      - run: make go.mk
       - uses: ./go.mk/.github/actions/setup
 
       - uses: ./go.mk/.github/actions/pre-check

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ release
 /.vs
 
 /terraform-provider-exoscale
+
+/go.mk

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "go.mk"]
-	path = go.mk
-	url = https://github.com/exoscale/go.mk.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+IMPROVEMENTS:
+
+- go.mk: remove submodule and initialize through make #338 
+
 ## 0.56.0 (February 28, 2024)
 
 FEATURES:

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,46 @@
+GO_MK_REF := v1.0.0
+
+# make go.mk a dependency for all targets
+.EXTRA_PREREQS = go.mk
+
+ifndef MAKE_RESTARTS
+# This section will be processed the first time that make reads this file.
+
+# This causes make to re-read the Makefile and all included
+# makefiles after go.mk has been cloned.
+Makefile:
+	@touch Makefile
+endif
+
+.PHONY: go.mk
+.ONESHELL:
+go.mk:
+	@if [ ! -d "go.mk" ]; then
+		git clone https://github.com/exoscale/go.mk.git
+	fi
+	@cd go.mk
+	@if ! git show-ref --quiet --verify "refs/heads/${GO_MK_REF}"; then
+		git fetch
+	fi
+	@if ! git show-ref --quiet --verify "refs/tags/${GO_MK_REF}"; then
+		git fetch --tags
+	fi
+	git checkout --quiet ${GO_MK_REF}
+
 PACKAGE := github.com/exoscale/terraform-provider-exoscale
 PROJECT_URL = https://$(PACKAGE)
 GO_BUILD_EXTRA_ARGS = -v -trimpath
 GOLANGCI_LINT_CONFIG = .golangci.yml
 EXTRA_ARGS := -parallel=3 -count=1 -failfast
 
+go.mk/init.mk:
 include go.mk/init.mk
 
 GO_LD_FLAGS := "-s -w -X $(PACKAGE)/version.Version=${VERSION} \
 							-X $(PACKAGE)/version.Commit=${GIT_REVISION}"
 GO_BIN_OUTPUT_NAME = terraform-provider-exoscale_v$(VERSION)
 
+go.mk/public.mk:
 include go.mk/public.mk
 
 .PHONY: test-acc test-verbose test


### PR DESCRIPTION
## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Acceptance tests OK
* [ ] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing
```shell
❯ make go.mk
Cloning into 'go.mk'...
remote: Enumerating objects: 311, done.
remote: Counting objects: 100% (197/197), done.
remote: Compressing objects: 100% (95/95), done.
remote: Total 311 (delta 132), reused 138 (delta 93), pack-reused 114
Receiving objects: 100% (311/311), 62.32 KiB | 686.00 KiB/s, done.
Resolving deltas: 100% (175/175), done.
```
