### PR TITLE
docs: fix example in index.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ FEATURES:
 BUG FIXES:
 
 - Fix dbaas bugs causing accepteance tests to fail #346
+- docs: fix example in index.md #345 
 
 ## 0.57.0 (April 3, 2024)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -97,7 +97,7 @@ locals {
   my_template = "Linux Ubuntu 22.04 LTS 64-bit"
 }
 
-data "exoscale_compute_template" "my_template" {
+data "exoscale_template" "my_template" {
   zone = local.my_zone
   name = local.my_template
 }
@@ -106,7 +106,7 @@ resource "exoscale_compute_instance" "my_instance" {
   zone        = local.my_zone
   name        = "my-instance"
 
-  template_id = data.exoscale_compute_template.my_template.id
+  template_id = data.exoscale_template.my_template.id
   type        = "standard.medium"
   disk_size   = 10
 

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -88,7 +88,7 @@ locals {
   my_template = "Linux Ubuntu 22.04 LTS 64-bit"
 }
 
-data "exoscale_compute_template" "my_template" {
+data "exoscale_template" "my_template" {
   zone = local.my_zone
   name = local.my_template
 }
@@ -97,7 +97,7 @@ resource "exoscale_compute_instance" "my_instance" {
   zone        = local.my_zone
   name        = "my-instance"
 
-  template_id = data.exoscale_compute_template.my_template.id
+  template_id = data.exoscale_template.my_template.id
   type        = "standard.medium"
   disk_size   = 10
 


### PR DESCRIPTION
# Description
Example on main page in registry is using deprecated data source (`exoscale_compute_template`).
This PR replaces it with current data source.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Acceptance tests OK
* [ ] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing

<!--
Describe the tests you did
-->
