### PR TITLE
sks_cluster: enable CSI addon on existing clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ FEATURES:
 - Add Kubelet Image GC support for SKS nodepools
 - Block storage volume resource & data source #341
 - Block storage volume snapshot resource & data source #344
+- sks_cluster: enable CSI addon on existing clusters #350 
 
 BUG FIXES:
 

--- a/exoscale/resource_exoscale_sks_cluster.go
+++ b/exoscale/resource_exoscale_sks_cluster.go
@@ -519,6 +519,23 @@ func resourceSKSClusterUpdate(ctx context.Context, d *schema.ResourceData, meta 
 		updated = true
 	}
 
+	if d.HasChange(resSKSClusterAttrExoscaleCSI) {
+		enableCSI := d.Get(resSKSClusterAttrExoscaleCSI).(bool)
+		if !enableCSI {
+			return diag.Errorf("disabling the CSI addon is not supported")
+		}
+
+		addons := d.Get(resSKSClusterAttrAddons).(*schema.Set)
+		if enableCSI && !addons.Contains(sksClusterAddonExoscaleCSI) {
+			addonStrings := make([]string, 0, addons.Len())
+			for _, v := range addons.List() {
+				addonStrings = append(addonStrings, v.(string))
+			}
+			updateReq.Addons = append(addonStrings, sksClusterAddonExoscaleCSI)
+			updated = true
+		}
+	}
+
 	if updated {
 		// due to a bug it's possible for the update operation
 		// to remain in pending state forever

--- a/exoscale/resource_exoscale_sks_cluster.go
+++ b/exoscale/resource_exoscale_sks_cluster.go
@@ -531,6 +531,7 @@ func resourceSKSClusterUpdate(ctx context.Context, d *schema.ResourceData, meta 
 			for _, v := range addons.List() {
 				addonStrings = append(addonStrings, v.(string))
 			}
+			//nolint:gocritic
 			updateReq.Addons = append(addonStrings, sksClusterAddonExoscaleCSI)
 			updated = true
 		}

--- a/exoscale/resource_exoscale_sks_cluster_test.go
+++ b/exoscale/resource_exoscale_sks_cluster_test.go
@@ -283,7 +283,7 @@ func TestAccResourceSKSCluster(t *testing.T) {
 							resSKSClusterAttrExoscaleCCM:        validateString("true"),
 							resSKSClusterAttrKubeletCA:          validation.ToDiagFunc(validation.StringMatch(testPemCertificateFormatRegex, "Kubelet CA must be a PEM certificate")),
 							resSKSClusterAttrMetricsServer:      validateString("false"),
-							resSKSClusterAttrExoscaleCSI:        validateString("false"),
+							resSKSClusterAttrExoscaleCSI:        validateString("true"),
 							resSKSClusterAttrLabels + ".test":   validateString(testAccResourceSKSClusterLabelValueUpdated),
 							resSKSClusterAttrName:               validateString(testAccResourceSKSClusterNameUpdated),
 							resSKSClusterAttrServiceLevel:       validateString(defaultSKSClusterServiceLevel),

--- a/exoscale/resource_exoscale_sks_cluster_test.go
+++ b/exoscale/resource_exoscale_sks_cluster_test.go
@@ -99,6 +99,7 @@ resource "exoscale_sks_cluster" "test" {
   name = "%s"
   description = "%s"
   exoscale_ccm = true
+  exoscale_csi = true
   metrics_server = false
   auto_upgrade = true
   labels = {
@@ -240,7 +241,7 @@ func TestAccResourceSKSCluster(t *testing.T) {
 						resSKSClusterAttrExoscaleCCM:        validateString("true"),
 						resSKSClusterAttrKubeletCA:          validation.ToDiagFunc(validation.StringMatch(testPemCertificateFormatRegex, "Kubelet CA must be a PEM certificate")),
 						resSKSClusterAttrMetricsServer:      validateString("false"),
-						resSKSClusterAttrExoscaleCSI:        validateString("false"),
+						resSKSClusterAttrExoscaleCSI:        validateString("true"),
 						resSKSClusterAttrLabels + ".test":   validateString(testAccResourceSKSClusterLabelValueUpdated),
 						resSKSClusterAttrName:               validateString(testAccResourceSKSClusterNameUpdated),
 						resSKSClusterAttrServiceLevel:       validateString(defaultSKSClusterServiceLevel),

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,11 +1,13 @@
 package config
 
 import (
+	"context"
 	"errors"
 	"time"
 
 	egoscale "github.com/exoscale/egoscale/v2"
 	exov3 "github.com/exoscale/egoscale/v3"
+	v3 "github.com/exoscale/egoscale/v3"
 )
 
 const (
@@ -48,6 +50,20 @@ func GetClientV3(meta interface{}) (*exov3.Client, error) {
 		return client.(*exov3.Client), nil
 	}
 	return nil, errors.New("API client not found")
+}
+
+func GetClientV3WithZone(ctx context.Context, meta interface{}, zone string) (*v3.Client, error) {
+	client, err := GetClientV3(meta)
+	if err != nil {
+		return nil, err
+	}
+
+	endpoint, err := client.GetZoneAPIEndpoint(ctx, v3.ZoneName(zone))
+	if err != nil {
+		return nil, err
+	}
+
+	return client.WithEndpoint(endpoint), nil
 }
 
 // GetEnvironment returns current environment


### PR DESCRIPTION
# Description
We make it possible to enable the `exoscale_csi` on an existing cluster. Disabling it again is not supported.
The resource had to be refactored to egoscale v3 as v2 doesn't pass the addons slice for sks cluster updates.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Acceptance tests OK
* [x] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing

```shell
# setting exoscale_csi to true on an existing cluster
❯ terraform apply \
              -var exoscale_api_key=$EXOSCALE_API_KEY \
              -var exoscale_api_secret=$EXOSCALE_API_SECRET

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the
following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # exoscale_sks_cluster.test_cluster will be updated in-place
  ~ resource "exoscale_sks_cluster" "test_cluster" {
      ~ exoscale_csi     = false -> true
        id               = "d7c1ada6-aee3-4b45-bf1f-44060354b849"
        name             = "test-cluster"
        # (16 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.

❯ exo c sks show -z ch-gva-2 test-cluster
┼───────────────┼──────────────────────────────────────────────────────────────────┼
│  SKS CLUSTER  │                                                                  │
┼───────────────┼──────────────────────────────────────────────────────────────────┼
...
│ Version       │ 1.29.4                                                           │
│ Service Level │ pro                                                              │
│ CNI           │ calico                                                           │
│ Add-Ons       │ exoscale-cloud-controller                                        │
│               │ exoscale-container-storage-interface                             │
│               │ metrics-server                                                   │
│ State         │ running                                                          │
│ Labels        │ n/a                                                              │
...
┼───────────────┼──────────────────────────────────────────────────────────────────┼

❯ kubectl get pods -A
NAMESPACE     NAME                                       READY   STATUS    RESTARTS   AGE
...
kube-system   exoscale-csi-controller-67c9d7ddb-mgvdd    7/7     Running   0          19m
kube-system   exoscale-csi-controller-67c9d7ddb-zplqj    7/7     Running   0          19m
kube-system   exoscale-csi-node-5js7n                    3/3     Running   0          19m
kube-system   exoscale-csi-node-7x4r7                    3/3     Running   0          19m
kube-system   exoscale-csi-node-lpbnc                    3/3     Running   0          19m


# after setting exoscale_csi to false again
❯ terraform apply \
              -var exoscale_api_key=$EXOSCALE_API_KEY \
              -var exoscale_api_secret=$EXOSCALE_API_SECRET


Terraform will perform the following actions:

  # exoscale_sks_cluster.test_cluster will be updated in-place
  ~ resource "exoscale_sks_cluster" "test_cluster" {
      ~ exoscale_csi     = true -> false
        id               = "d7c1ada6-aee3-4b45-bf1f-44060354b849"
        name             = "test-cluster"
        # (16 unchanged attributes hidden)
    }
...

exoscale_sks_cluster.test_cluster: Modifying... [id=d7c1ada6-aee3-4b45-bf1f-44060354b849]
╷
│ Error: disabling the CSI addon is not supported
│
│   with exoscale_sks_cluster.test_cluster,
│   on main.tf line 9, in resource "exoscale_sks_cluster" "test_cluster":
│    9: resource "exoscale_sks_cluster" "test_cluster" {
│
╵
```
