### PR TITLE
IAM: fix bug in datasouces by always init null values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+BUG FIXES:
+
+- IAM: fix bug in datasouces by always init null values #353
+
 ## 0.58.0 (April 29, 2024)
 
 FEATURES:

--- a/pkg/resources/iam/datasource_org_policy.go
+++ b/pkg/resources/iam/datasource_org_policy.go
@@ -161,6 +161,12 @@ func (d *DataSourceOrgPolicy) Read(ctx context.Context, req datasource.ReadReque
 	}
 
 	data.DefaultServiceStrategy = types.StringValue(policy.DefaultServiceStrategy)
+
+	data.Services = types.MapNull(
+		types.ObjectType{
+			AttrTypes: PolicyServiceModel{}.Types(),
+		},
+	)
 	if len(policy.Services) > 0 {
 		services := map[string]PolicyServiceModel{}
 		for name, service := range policy.Services {
@@ -168,6 +174,11 @@ func (d *DataSourceOrgPolicy) Read(ctx context.Context, req datasource.ReadReque
 				Type: types.StringPointerValue(service.Type),
 			}
 
+			serviceModel.Rules = types.ListNull(
+				types.ObjectType{
+					PolicyServiceRuleModel{}.Types(),
+				},
+			)
 			if len(service.Rules) > 0 {
 				rules := []PolicyServiceRuleModel{}
 				for _, rule := range service.Rules {

--- a/pkg/resources/iam/datasource_org_policy.go
+++ b/pkg/resources/iam/datasource_org_policy.go
@@ -176,7 +176,7 @@ func (d *DataSourceOrgPolicy) Read(ctx context.Context, req datasource.ReadReque
 
 			serviceModel.Rules = types.ListNull(
 				types.ObjectType{
-					PolicyServiceRuleModel{}.Types(),
+					AttrTypes: PolicyServiceRuleModel{}.Types(),
 				},
 			)
 			if len(service.Rules) > 0 {

--- a/pkg/resources/iam/datasource_role.go
+++ b/pkg/resources/iam/datasource_role.go
@@ -258,10 +258,17 @@ func (d *DataSourceRole) Read(ctx context.Context, req datasource.ReadRequest, r
 		data.Permissions = t
 	}
 
+	data.Policy = types.ObjectNull(PolicyModel{}.Types())
 	if role.Policy != nil {
 		policy := PolicyModel{}
 
 		policy.DefaultServiceStrategy = types.StringValue(role.Policy.DefaultServiceStrategy)
+
+		policy.Services = types.MapNull(
+			types.ObjectType{
+				AttrTypes: PolicyServiceModel{}.Types(),
+			},
+		)
 		if len(role.Policy.Services) > 0 {
 			services := map[string]PolicyServiceModel{}
 			for name, service := range role.Policy.Services {
@@ -269,6 +276,11 @@ func (d *DataSourceRole) Read(ctx context.Context, req datasource.ReadRequest, r
 					Type: types.StringPointerValue(service.Type),
 				}
 
+				serviceModel.Rules = types.ListNull(
+					types.ObjectType{
+						PolicyServiceRuleModel{}.Types(),
+					},
+				)
 				if len(service.Rules) > 0 {
 					rules := []PolicyServiceRuleModel{}
 					for _, rule := range service.Rules {

--- a/pkg/resources/iam/datasource_role.go
+++ b/pkg/resources/iam/datasource_role.go
@@ -278,7 +278,7 @@ func (d *DataSourceRole) Read(ctx context.Context, req datasource.ReadRequest, r
 
 				serviceModel.Rules = types.ListNull(
 					types.ObjectType{
-						PolicyServiceRuleModel{}.Types(),
+						AttrTypes: PolicyServiceRuleModel{}.Types(),
 					},
 				)
 				if len(service.Rules) > 0 {


### PR DESCRIPTION
# Description

Fixes the #352 

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Acceptance tests OK
* [x] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing

```
$ TF_ACC=1 go test ./... -run TestIAM 
?       github.com/exoscale/terraform-provider-exoscale [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/config      [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/general     [no test files]
ok      github.com/exoscale/terraform-provider-exoscale/exoscale        0.010s [no tests to run]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/filter      0.004s [no tests to run]
?       github.com/exoscale/terraform-provider-exoscale/pkg/provider    [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/provider/config     [no test files]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/list        0.011s [no tests to run]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/anti_affinity_group       0.039s [no tests to run]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/block_storage     0.010s [no tests to run]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/database  0.008s [no tests to run]
?       github.com/exoscale/terraform-provider-exoscale/pkg/resources/zones     [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/testutils   [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/utils       [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/validators  [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/version     [no test files]
?       github.com/exoscale/terraform-provider-exoscale/version [no test files]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/iam       63.155s
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/instance  0.010s [no tests to run]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/instance_pool     0.009s [no tests to run]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/nlb_service       0.009s [no tests to run]
```
