### PR TITLE
SKS: document dependency of CSI on CCM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+IMPROVEMENTS
+
+- SKS: document dependency of CSI on CCM #359 
+
 ## 0.59.0 (May 13, 2024)
 
 FEATURES:

--- a/docs/data-sources/sks_cluster.md
+++ b/docs/data-sources/sks_cluster.md
@@ -30,7 +30,7 @@ description: |-
 - `description` (String) A free-form text describing the cluster.
 - `endpoint` (String) The cluster API endpoint.
 - `exoscale_ccm` (Boolean) Deploy the Exoscale [Cloud Controller Manager](https://github.com/exoscale/exoscale-cloud-controller-manager/) in the control plane (boolean; default: `true`; may only be set at creation time).
-- `exoscale_csi` (Boolean) Deploy the Exoscale [Container Storage Interface](https://github.com/exoscale/exoscale-csi-driver/) on worker nodes (boolean; default: `false`; may only be set at creation time).
+- `exoscale_csi` (Boolean) Deploy the Exoscale [Container Storage Interface](https://github.com/exoscale/exoscale-csi-driver/) on worker nodes (boolean; default: `false`; requires the CCM to be enabled).
 - `kubelet_ca` (String) The CA certificate (in PEM format) for TLS communications between kubelets and the control plane.
 - `labels` (Map of String) A map of key/value labels.
 - `metrics_server` (Boolean) Deploy the [Kubernetes Metrics Server](https://github.com/kubernetes-sigs/metrics-server/) in the control plane (boolean; default: `true`; may only be set at creation time).

--- a/docs/resources/sks_cluster.md
+++ b/docs/resources/sks_cluster.md
@@ -42,7 +42,7 @@ directory for complete configuration examples.
 - `cni` (String) The CNI plugin that is to be used. Available options are "calico" or "cilium". Defaults to "calico". Setting empty string will result in a cluster with no CNI.
 - `description` (String) A free-form text describing the cluster.
 - `exoscale_ccm` (Boolean) Deploy the Exoscale [Cloud Controller Manager](https://github.com/exoscale/exoscale-cloud-controller-manager/) in the control plane (boolean; default: `true`; may only be set at creation time).
-- `exoscale_csi` (Boolean) Deploy the Exoscale [Container Storage Interface](https://github.com/exoscale/exoscale-csi-driver/) on worker nodes (boolean; default: `false`; may only be set at creation time).
+- `exoscale_csi` (Boolean) Deploy the Exoscale [Container Storage Interface](https://github.com/exoscale/exoscale-csi-driver/) on worker nodes (boolean; default: `false`; requires the CCM to be enabled).
 - `labels` (Map of String) A map of key/value labels.
 - `metrics_server` (Boolean) Deploy the [Kubernetes Metrics Server](https://github.com/kubernetes-sigs/metrics-server/) in the control plane (boolean; default: `true`; may only be set at creation time).
 - `oidc` (Block List, Max: 1) An OpenID Connect configuration to provide to the Kubernetes API server (may only be set at creation time). Structure is documented below. (see [below for nested schema](#nestedblock--oidc))

--- a/exoscale/resource_exoscale_sks_cluster.go
+++ b/exoscale/resource_exoscale_sks_cluster.go
@@ -126,7 +126,7 @@ func resourceSKSCluster() *schema.Resource {
 			Type:        schema.TypeBool,
 			Optional:    true,
 			Default:     false,
-			Description: "Deploy the Exoscale [Container Storage Interface](https://github.com/exoscale/exoscale-csi-driver/) on worker nodes (boolean; default: `false`; may only be set at creation time).",
+			Description: "Deploy the Exoscale [Container Storage Interface](https://github.com/exoscale/exoscale-csi-driver/) on worker nodes (boolean; default: `false`; requires the CCM to be enabled).",
 		},
 		resSKSClusterAttrLabels: {
 			Type:        schema.TypeMap,


### PR DESCRIPTION
# Description
The CSI can now be enabled on clusters after creation if the CCM has been enabled. We update the documentation to reflect this.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Acceptance tests OK
* [ ] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing

On a cluster with CCM I executed the following plan:
```
Terraform will perform the following actions:

  # exoscale_sks_cluster.test_cluster will be updated in-place
  ~ resource "exoscale_sks_cluster" "test_cluster" {
      ~ exoscale_csi     = false -> true
        id               = "184a80f0-8c0b-4b8f-8766-ac188519277d"
        name             = "test-cluster"
        # (16 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

It succeeded and the CSI pods were created.
```
❯ kubectl get pods -A
NAMESPACE     NAME                                       READY   STATUS    RESTARTS   AGE
...
kube-system   exoscale-csi-controller-7578c45864-vtphx   7/7     Running   0          78s
kube-system   exoscale-csi-controller-7578c45864-xr65g   7/7     Running   0          78s
kube-system   exoscale-csi-node-k4n9p                    3/3     Running   0          78s
kube-system   exoscale-csi-node-t9ncx                    3/3     Running   0          78s
kube-system   exoscale-csi-node-zrd6w                    3/3     Running   0          78s
...
```