### PR TITLE
Set zone when attaching blockstorage volume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ IMPROVEMENTS
 
 - SKS: document dependency of CSI on CCM #359 
 
+BUG FIXES
+
+- Set zone when attaching blockstorage volume #362
+
 ## 0.59.0 (May 13, 2024)
 
 FEATURES:

--- a/pkg/resources/block_storage/main_test.go
+++ b/pkg/resources/block_storage/main_test.go
@@ -20,7 +20,7 @@ func TestBlockStorage(t *testing.T) {
 
 	testdataSpec := testutils.TestdataSpec{
 		ID:   time.Now().UnixNano(),
-		Zone: "ch-gva-2", // to be replaced by global testutils.TestZoneName when BS reaches GA.
+		Zone: "at-vie-1", // to be replaced by global testutils.TestZoneName when BS reaches GA.
 	}
 
 	resource.Test(t, resource.TestCase{
@@ -333,7 +333,7 @@ func TestBlockStorage(t *testing.T) {
 				ResourceName: volumeResourceName,
 				ImportStateIdFunc: func() resource.ImportStateIdFunc {
 					return func(s *terraform.State) (string, error) {
-						return fmt.Sprintf("%s@%s", s.RootModule().Resources[volumeResourceName].Primary.ID, "ch-gva-2"), nil
+						return fmt.Sprintf("%s@%s", s.RootModule().Resources[volumeResourceName].Primary.ID, testdataSpec.Zone), nil
 					}
 				}(),
 				ImportState: true,

--- a/pkg/resources/instance/resource.go
+++ b/pkg/resources/instance/resource.go
@@ -225,7 +225,15 @@ func rCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag
 
 	// Use egoscale V3 for BlockStorage API.
 	// This is a temporary workaround until this resource is migrate to tf framework.
-	clientV3, err := config.GetClientV3(meta)
+	defaultClientV3, err := config.GetClientV3(meta)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	clientV3, err := utils.SwitchClientZone(
+		ctx,
+		defaultClientV3,
+		egoscaleV3.ZoneName(zone),
+	)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -477,7 +485,15 @@ func rUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag
 
 	// Use egoscale V3 for BlockStorage API.
 	// This is a temporary workaround until this resource is migrate to tf framework.
-	clientV3, err := config.GetClientV3(meta)
+	defaultClientV3, err := config.GetClientV3(meta)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	clientV3, err := utils.SwitchClientZone(
+		ctx,
+		defaultClientV3,
+		egoscaleV3.ZoneName(zone),
+	)
 	if err != nil {
 		return diag.FromErr(err)
 	}


### PR DESCRIPTION
# Description
Fixes the bug where blockstorage attach always uses default (`ch-gva-2`) zone.
Changes the zone where blockstorage tests run to `at-vie-1` so the fix can be tested.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [ ] Acceptance tests OK
* [x] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing

```bash
$ TF_ACC=1 go test ./... -run TestBlockStorage
?       github.com/exoscale/terraform-provider-exoscale [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/config      [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/general     [no test files]
ok      github.com/exoscale/terraform-provider-exoscale/exoscale        0.020s [no tests to run]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/filter      0.006s [no tests to run]
?       github.com/exoscale/terraform-provider-exoscale/pkg/provider    [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/provider/config     [no test files]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/list        0.025s [no tests to run]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/anti_affinity_group       0.026s [no tests to run]
?       github.com/exoscale/terraform-provider-exoscale/pkg/resources/zones     [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/testutils   [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/utils       [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/validators  [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/version     [no test files]
?       github.com/exoscale/terraform-provider-exoscale/version [no test files]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/block_storage     149.874s
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/database  0.016s [no tests to run]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/iam       0.016s [no tests to run]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/instance  0.016s [no tests to run]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/instance_pool     0.018s [no tests to run]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/nlb_service       0.015s [no tests to run]
```