### PR TITLE
Don't throw error if volume detach call fails due to volume not attached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 BUG FIXES:
 
 - Fix panic when ListSKSClusterVersions returns error #357
+- Don't throw error if volume detach call fails due to volume not attached #367
 
 IMPROVEMENTS:
 


### PR DESCRIPTION
# Description

This PR fixes the race condition that may trigger error when both volume and volume attached instance are destroyed at the same time. As instance deletion automatically detaches volume, API throws error when detach is called as part of volume destroy.

Originally there was a check for volume state before detach is called, but that has proven unreliable. Here we are executing detach, but ignoring error if it says that volume is not attached.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Acceptance tests OK
* [x] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing

<!--
Describe the tests you did
-->
