### PR TITLE
Add example for sks nodepool `kubelet_image_gc.min_age`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ IMPROVEMENTS:
 
 - Bump dependency google.golang.org/protobuf from 1.31.0 to 1.33.0 #370
 - egoscale/v3: use separate module v3.1.0 #374
+- Add example for sks nodepool kubelet_image_gc.min_age #377
 
 ## 0.59.2 (June 13, 2024)
 

--- a/docs/data-sources/sks_nodepool.md
+++ b/docs/data-sources/sks_nodepool.md
@@ -53,6 +53,6 @@ Optional:
 
 - `high_threshold` (Number) The percent of disk usage after which image garbage collection is always run
 - `low_threshold` (Number) The percent of disk usage before which image garbage collection is never run
-- `min_age` (String) The minimum age for an unused image before it is garbage collected
+- `min_age` (String) The minimum age for an unused image before it is garbage collected (k8s duration format, eg. 1h)
 
 

--- a/docs/resources/sks_nodepool.md
+++ b/docs/resources/sks_nodepool.md
@@ -72,7 +72,7 @@ Optional:
 
 - `high_threshold` (Number) The percent of disk usage after which image garbage collection is always run
 - `low_threshold` (Number) The percent of disk usage before which image garbage collection is never run
-- `min_age` (String) The minimum age for an unused image before it is garbage collected
+- `min_age` (String) The minimum age for an unused image before it is garbage collected (k8s duration format, eg. 1h)
 
 
 <a id="nestedblock--timeouts"></a>

--- a/exoscale/resource_exoscale_sks_nodepool.go
+++ b/exoscale/resource_exoscale_sks_nodepool.go
@@ -117,7 +117,7 @@ func resourceSKSNodepool() *schema.Resource {
 					resSKSNodepoolAttrKubeletGCMinAge: {
 						Type:        schema.TypeString,
 						Optional:    true,
-						Description: "The minimum age for an unused image before it is garbage collected",
+						Description: "The minimum age for an unused image before it is garbage collected (k8s duration format, eg. 1h)",
 					},
 					resSKSNodepoolAttrKubeletGCHighThreshold: {
 						Type:        schema.TypeInt,


### PR DESCRIPTION
# Description

Describes format used by `kubelet_image_gc.min_age` attribute of resource `exoscale_sks_nodepool`.

Fixes #376 

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Acceptance tests OK
* [ ] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing

<!--
Describe the tests you did
-->
