### PR TITLE
Remove skip_s3_checksum

### DIFF
--- a/examples/sos-backend/providers.tf
+++ b/examples/sos-backend/providers.tf
@@ -18,7 +18,6 @@ terraform {
     skip_credentials_validation = true
     skip_region_validation      = true
     skip_requesting_account_id  = true
-    skip_s3_checksum            = true
   }
 }
 

--- a/examples/sos/providers.tf
+++ b/examples/sos/providers.tf
@@ -21,5 +21,4 @@ provider "aws" {
   skip_credentials_validation = true
   skip_region_validation      = true
   skip_requesting_account_id  = true
-  skip_s3_checksum            = true
 }


### PR DESCRIPTION
# Description

`x-amz-sdk-checksum-algorithm` was not supported on SOS [1] (no longer the case anymore), so we had to add `skip_s3_checksum` as part of the examples.

I'm creating this PR to create awareness and I will let @exoscale/giza to take over (to commit on top of this PR and merge it).

[1] : https://github.com/hashicorp/terraform/pull/34127

## Checklist
(For exoscale contributors)

* [ ] Changelog updated (under *Unreleased* block)
* [ ] Acceptance tests OK
* [ ] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing

None
