### PR TITLE
Fix accepteance tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ IMPROVEMENTS:
 
 - go.mk: upgrade to v2.0.3 #383
 
+BUG FIXES:
+
+- Fix tests for database redis resource #388
+
 ## 0.60.0
 
 FEATURES:

--- a/pkg/resources/database/resource_opensearch.go
+++ b/pkg/resources/database/resource_opensearch.go
@@ -475,7 +475,7 @@ func (r *Resource) updateOpensearch(ctx context.Context, stateData *ResourceMode
 			updated = true
 		}
 
-		if planData.Opensearch.IndexPatterns != nil && len(planData.Opensearch.IndexPatterns) > 0 {
+		if len(planData.Opensearch.IndexPatterns) > 0 {
 			patterns := []struct {
 				MaxIndexCount    *int64                                                                  `json:"max-index-count,omitempty"`
 				Pattern          *string                                                                 `json:"pattern,omitempty"`

--- a/pkg/resources/database/resource_redis_test.go
+++ b/pkg/resources/database/resource_redis_test.go
@@ -56,7 +56,7 @@ func testResourceRedis(t *testing.T) {
 	dataCreate.MaintenanceDow = "monday"
 	dataCreate.MaintenanceTime = "01:23:00"
 	dataCreate.IpFilter = []string{"1.2.3.4/32"}
-	dataCreate.RedisSettings = strconv.Quote(`{"lfu_decay_time":1,"lfu_log_factor":10,"maxmemory_policy":"noeviction","notify_keyspace_events":"","persistence":"rdb","ssl":true,"timeout":300}`)
+	dataCreate.RedisSettings = strconv.Quote(`{"io_threads":1,"lfu_decay_time":1,"lfu_log_factor":10,"maxmemory_policy":"noeviction","notify_keyspace_events":"","persistence":"rdb","ssl":true,"timeout":300}`)
 	buf := &bytes.Buffer{}
 	err = tpl.Execute(buf, &dataCreate)
 	if err != nil {
@@ -68,8 +68,7 @@ func testResourceRedis(t *testing.T) {
 	dataUpdate.MaintenanceDow = "tuesday"
 	dataUpdate.MaintenanceTime = "02:34:00"
 	dataUpdate.IpFilter = nil
-	dataUpdate.RedisSettings = strconv.Quote(`{"long_query_time":5,"sql_mode":"ANSI,TRADITIONAL","sql_require_primary_key":true}`)
-	dataUpdate.RedisSettings = strconv.Quote(`{"lfu_decay_time":1,"lfu_log_factor":10,"maxmemory_policy":"noeviction","notify_keyspace_events":"","persistence":"rdb","pubsub_client_output_buffer_limit":64,"ssl":true,"timeout":300}`)
+	dataUpdate.RedisSettings = strconv.Quote(`{"io_threads":1,"lfu_decay_time":1,"lfu_log_factor":10,"maxmemory_policy":"noeviction","notify_keyspace_events":"","persistence":"rdb","pubsub_client_output_buffer_limit":64,"ssl":true,"timeout":300}`)
 	buf = &bytes.Buffer{}
 	err = tpl.Execute(buf, &dataUpdate)
 	if err != nil {

--- a/pkg/resources/instance_pool/resource_test.go
+++ b/pkg/resources/instance_pool/resource_test.go
@@ -96,7 +96,7 @@ locals {
 
 data "exoscale_template" "debian" {
   zone = local.zone
-  name = "Linux Debian 10 (Buster) 64-bit"
+  name = "Linux Debian 12 (Bookworm) 64-bit"
 }
 
 resource "exoscale_private_network" "test" {


### PR DESCRIPTION
# Description

- Update database resource Redis tests with new default value for Redis settings;
- Remove redundant check in OpenSearch resource (reported by `staticcheck`);
- Update instance template used by instance pool resource test.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Acceptance tests OK
* [x] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing

```bash
$ TF_ACC=1 go test ./... -run TestDatabase/ResourceRedis
?       github.com/exoscale/terraform-provider-exoscale [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/config      [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/general     [no test files]
ok      github.com/exoscale/terraform-provider-exoscale/exoscale        0.020s [no tests to run]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/filter      0.008s [no tests to run]
?       github.com/exoscale/terraform-provider-exoscale/pkg/provider    [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/provider/config     [no test files]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/list        (cached) [no tests to run]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/anti_affinity_group       (cached) [no tests to run]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/block_storage     (cached) [no tests to run]
?       github.com/exoscale/terraform-provider-exoscale/pkg/resources/zones     [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/testutils   [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/utils       [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/validators  [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/version     [no test files]
?       github.com/exoscale/terraform-provider-exoscale/version [no test files]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/database  18.778s
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/iam       (cached) [no tests to run]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/instance  (cached) [no tests to run]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/instance_pool     (cached) [no tests to run]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/nlb_service       (cached) [no tests to run]
```
