### PR TITLE
dbaas: secrets via dedicated endpoints

### DIFF
--- a/pkg/resources/database/datasource_uri.go
+++ b/pkg/resources/database/datasource_uri.go
@@ -45,7 +45,7 @@ func uriWithPassword(uri string, username string, password string) (string, erro
 	matches := re.FindStringSubmatch(uri)
 
 	if len(matches) != 4 {
-		return "", fmt.Errorf("URI must contain username (format: protocol://username@some-host.com)")
+		return "", fmt.Errorf("uri must contain username (format: protocol://username@some-host.com)")
 	}
 
 	return fmt.Sprintf("%s://%s:%s@%s",

--- a/pkg/resources/database/datasource_uri.go
+++ b/pkg/resources/database/datasource_uri.go
@@ -225,7 +225,7 @@ func (d *DataSourceURI) Read(ctx context.Context, req datasource.ReadRequest, re
 	}
 
 	// Set timeout
-	t, diags := data.Timeouts.Read(ctx, 2*config.DefaultTimeout)
+	t, diags := data.Timeouts.Read(ctx, config.DefaultTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/pkg/resources/database/datasource_uri.go
+++ b/pkg/resources/database/datasource_uri.go
@@ -225,7 +225,7 @@ func (d *DataSourceURI) Read(ctx context.Context, req datasource.ReadRequest, re
 	}
 
 	// Set timeout
-	t, diags := data.Timeouts.Read(ctx, 2 * config.DefaultTimeout)
+	t, diags := data.Timeouts.Read(ctx, 2*config.DefaultTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/pkg/resources/database/datasource_uri.go
+++ b/pkg/resources/database/datasource_uri.go
@@ -211,6 +211,7 @@ func (d *DataSourceURI) Read(ctx context.Context, req datasource.ReadRequest, re
 	data.Id = data.Name
 
 	var uri string
+	var password string
 	var params map[string]interface{}
 
 	const adminUsername = "avnadmin"
@@ -227,11 +228,19 @@ func (d *DataSourceURI) Read(ctx context.Context, req datasource.ReadRequest, re
 		}
 
 		creds, err := client.RevealDBAASKafkaUserPassword(ctx, data.Name.ValueString(), adminUsername)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Client Error",
+				fmt.Sprintf("Unable to reveal Database Service kafka secret: %s", err),
+			)
+			return
+		}
+		password = creds.Password
 		uri, err = uriWithPassword(res.URI, creds.Username, creds.Password)
 
 		if err != nil {
 			resp.Diagnostics.AddError("Client Error",
-				fmt.Sprintf("Unable to get Database Service kafka secret: %s", err),
+				fmt.Sprintf("Unable to parse Database Service kafka secret: %s", err),
 			)
 			return
 		}
@@ -251,14 +260,23 @@ func (d *DataSourceURI) Read(ctx context.Context, req datasource.ReadRequest, re
 		data.Schema = types.StringValue("mysql")
 
 		creds, err := client.RevealDBAASMysqlUserPassword(ctx, data.Name.ValueString(), adminUsername)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Client Error",
+				fmt.Sprintf("Unable to reveal Database Service MySQL secret: %s", err),
+			)
+			return
+		}
+		password = creds.Password
 		uri, err = uriWithPassword(res.URI, creds.Username, creds.Password)
 
 		if err != nil {
 			resp.Diagnostics.AddError("Client Error",
-				fmt.Sprintf("Unable to get Database Service MySQL secret: %s", err),
+				fmt.Sprintf("Unable to parse Database Service MySQL secret: %s", err),
 			)
 			return
 		}
+
 		params = res.URIParams
 		params["password"] = creds.Password
 	case "pg":
@@ -274,6 +292,14 @@ func (d *DataSourceURI) Read(ctx context.Context, req datasource.ReadRequest, re
 		data.Schema = types.StringValue("postgres")
 
 		creds, err := client.RevealDBAASPostgresUserPassword(ctx, data.Name.ValueString(), adminUsername)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Client Error",
+				fmt.Sprintf("Unable to fetch Database Service Postgres: %s", err),
+			)
+			return
+		}
+		password = creds.Password
 		uri, err = uriWithPassword(res.URI, creds.Username, creds.Password)
 
 		if err != nil {
@@ -297,11 +323,19 @@ func (d *DataSourceURI) Read(ctx context.Context, req datasource.ReadRequest, re
 		data.Schema = types.StringValue("rediss")
 
 		creds, err := client.RevealDBAASRedisUserPassword(ctx, data.Name.ValueString(), adminUsername)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Client Error",
+				fmt.Sprintf("Unable to reveal Database Service Redis secret: %s", err),
+			)
+			return
+		}
+		password = creds.Password
 		uri, err = uriWithPassword(res.URI, creds.Username, creds.Password)
 
 		if err != nil {
 			resp.Diagnostics.AddError("Client Error",
-				fmt.Sprintf("Unable to get Database Service Redis secret: %s", err),
+				fmt.Sprintf("Unable to parse Database Service Redis secret: %s", err),
 			)
 			return
 		}
@@ -319,13 +353,20 @@ func (d *DataSourceURI) Read(ctx context.Context, req datasource.ReadRequest, re
 
 		data.Schema = types.StringValue("https")
 
-		uri = res.URI
 		creds, err := client.RevealDBAASOpensearchUserPassword(ctx, data.Name.ValueString(), adminUsername)
-		uri, err = uriWithPassword(res.URI, creds.Username, creds.Password)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Client Error",
+				fmt.Sprintf("Unable to reveal Database Service OpenSearch secret: %s", err),
+			)
+			return
+		}
+		password = creds.Password
 
+		uri, err = uriWithPassword(res.URI, creds.Username, creds.Password)
 		if err != nil {
 			resp.Diagnostics.AddError("Client Error",
-				fmt.Sprintf("Unable to get Database Service OpenSearch secret: %s", err),
+				fmt.Sprintf("Unable to parse Database Service OpenSearch secret: %s", err),
 			)
 			return
 		}
@@ -344,11 +385,19 @@ func (d *DataSourceURI) Read(ctx context.Context, req datasource.ReadRequest, re
 		data.Schema = types.StringValue("https")
 
 		creds, err := client.RevealDBAASGrafanaUserPassword(ctx, data.Name.ValueString(), adminUsername)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Client Error",
+				fmt.Sprintf("Unable to reveal Database Service Grafana secret: %s", err),
+			)
+			return
+		}
+		password = creds.Password
 		uri, err = uriWithPassword(res.URI, creds.Username, creds.Password)
 
 		if err != nil {
 			resp.Diagnostics.AddError("Client Error",
-				fmt.Sprintf("Unable to get Database Service Grafana secret: %s", err),
+				fmt.Sprintf("Unable to parse Database Service Grafana secret: %s", err),
 			)
 			return
 		}

--- a/pkg/resources/database/datasource_uri.go
+++ b/pkg/resources/database/datasource_uri.go
@@ -271,19 +271,13 @@ func (d *DataSourceURI) Read(ctx context.Context, req datasource.ReadRequest, re
 			return
 		}
 
+		uri = res.URI
+
 		creds, err := client.RevealDBAASKafkaUserPassword(ctx, data.Name.ValueString(), adminUsername)
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Client Error",
 				fmt.Sprintf("Unable to reveal Database Service kafka secret: %s", err),
-			)
-			return
-		}
-		uri, err = uriWithPassword(res.URI, creds.Username, creds.Password)
-
-		if err != nil {
-			resp.Diagnostics.AddError("Client Error",
-				fmt.Sprintf("Unable to parse Database Service kafka secret: %s", err),
 			)
 			return
 		}
@@ -448,6 +442,7 @@ func (d *DataSourceURI) Read(ctx context.Context, req datasource.ReadRequest, re
 			return
 		}
 
+		uri = res.URI
 		data.Schema = types.StringValue("https")
 
 		creds, err := client.RevealDBAASGrafanaUserPassword(ctx, data.Name.ValueString(), adminUsername)
@@ -458,14 +453,7 @@ func (d *DataSourceURI) Read(ctx context.Context, req datasource.ReadRequest, re
 			)
 			return
 		}
-		uri, err = uriWithPassword(res.URI, creds.Username, creds.Password)
 
-		if err != nil {
-			resp.Diagnostics.AddError("Client Error",
-				fmt.Sprintf("Unable to parse Database Service Grafana secret: %s", err),
-			)
-			return
-		}
 		params = res.URIParams
 		params["password"] = creds.Password
 	}

--- a/pkg/resources/database/datasource_uri.go
+++ b/pkg/resources/database/datasource_uri.go
@@ -257,7 +257,7 @@ func (d *DataSourceURI) Read(ctx context.Context, req datasource.ReadRequest, re
 
 	switch data.Type.ValueString() {
 	case "kafka":
-        res, err := client.GetDBAASServiceKafka(ctx, data.Name.ValueString())
+		res, err := client.GetDBAASServiceKafka(ctx, data.Name.ValueString())
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Client Error",

--- a/pkg/resources/database/datasource_uri.go
+++ b/pkg/resources/database/datasource_uri.go
@@ -225,7 +225,7 @@ func (d *DataSourceURI) Read(ctx context.Context, req datasource.ReadRequest, re
 	}
 
 	// Set timeout
-	t, diags := data.Timeouts.Read(ctx, config.DefaultTimeout)
+	t, diags := data.Timeouts.Read(ctx, 2 * config.DefaultTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/pkg/resources/database/datasource_uri.go
+++ b/pkg/resources/database/datasource_uri.go
@@ -211,7 +211,6 @@ func (d *DataSourceURI) Read(ctx context.Context, req datasource.ReadRequest, re
 	data.Id = data.Name
 
 	var uri string
-	var password string
 	var params map[string]interface{}
 
 	const adminUsername = "avnadmin"
@@ -235,7 +234,6 @@ func (d *DataSourceURI) Read(ctx context.Context, req datasource.ReadRequest, re
 			)
 			return
 		}
-		password = creds.Password
 		uri, err = uriWithPassword(res.URI, creds.Username, creds.Password)
 
 		if err != nil {
@@ -267,7 +265,6 @@ func (d *DataSourceURI) Read(ctx context.Context, req datasource.ReadRequest, re
 			)
 			return
 		}
-		password = creds.Password
 		uri, err = uriWithPassword(res.URI, creds.Username, creds.Password)
 
 		if err != nil {
@@ -299,7 +296,6 @@ func (d *DataSourceURI) Read(ctx context.Context, req datasource.ReadRequest, re
 			)
 			return
 		}
-		password = creds.Password
 		uri, err = uriWithPassword(res.URI, creds.Username, creds.Password)
 
 		if err != nil {
@@ -330,7 +326,6 @@ func (d *DataSourceURI) Read(ctx context.Context, req datasource.ReadRequest, re
 			)
 			return
 		}
-		password = creds.Password
 		uri, err = uriWithPassword(res.URI, creds.Username, creds.Password)
 
 		if err != nil {
@@ -361,7 +356,6 @@ func (d *DataSourceURI) Read(ctx context.Context, req datasource.ReadRequest, re
 			)
 			return
 		}
-		password = creds.Password
 
 		uri, err = uriWithPassword(res.URI, creds.Username, creds.Password)
 		if err != nil {
@@ -370,6 +364,7 @@ func (d *DataSourceURI) Read(ctx context.Context, req datasource.ReadRequest, re
 			)
 			return
 		}
+
 		params = res.URIParams
 		params["password"] = creds.Password
 	case "grafana":
@@ -392,7 +387,6 @@ func (d *DataSourceURI) Read(ctx context.Context, req datasource.ReadRequest, re
 			)
 			return
 		}
-		password = creds.Password
 		uri, err = uriWithPassword(res.URI, creds.Username, creds.Password)
 
 		if err != nil {

--- a/pkg/resources/database/datasource_uri.go
+++ b/pkg/resources/database/datasource_uri.go
@@ -377,8 +377,9 @@ func (d *DataSourceURI) Read(ctx context.Context, req datasource.ReadRequest, re
 		}
 
 		data.Schema = types.StringValue("rediss")
+		const redisDefaultUsername = "default"
 
-		creds, err := client.RevealDBAASRedisUserPassword(ctx, data.Name.ValueString(), adminUsername)
+		creds, err := client.RevealDBAASRedisUserPassword(ctx, data.Name.ValueString(), redisDefaultUsername)
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Client Error",

--- a/pkg/resources/database/datasource_uri.go
+++ b/pkg/resources/database/datasource_uri.go
@@ -257,12 +257,7 @@ func (d *DataSourceURI) Read(ctx context.Context, req datasource.ReadRequest, re
 
 	switch data.Type.ValueString() {
 	case "kafka":
-		res, err := waitForDBAASService(
-			ctx,
-			client.GetDBAASServiceKafka,
-			data.Name.ValueString(),
-			func(s *exoscale.DBAASServiceKafka) string { return string(s.State) },
-		)
+        res, err := client.GetDBAASServiceKafka(ctx, data.Name.ValueString())
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Client Error",
@@ -272,18 +267,7 @@ func (d *DataSourceURI) Read(ctx context.Context, req datasource.ReadRequest, re
 		}
 
 		uri = res.URI
-
-		creds, err := client.RevealDBAASKafkaUserPassword(ctx, data.Name.ValueString(), adminUsername)
-		if err != nil {
-			resp.Diagnostics.AddError(
-				"Client Error",
-				fmt.Sprintf("Unable to reveal Database Service kafka secret: %s", err),
-			)
-			return
-		}
-
 		params = res.URIParams
-		params["password"] = creds.Password
 	case "mysql":
 		res, err := waitForDBAASService(
 			ctx,
@@ -401,7 +385,7 @@ func (d *DataSourceURI) Read(ctx context.Context, req datasource.ReadRequest, re
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Client Error",
-				fmt.Sprintf("Unable to read Database Service kafka: %s", err),
+				fmt.Sprintf("Unable to read Database Service Opensearch: %s", err),
 			)
 			return
 		}

--- a/pkg/resources/database/resource_mysql_test.go
+++ b/pkg/resources/database/resource_mysql_test.go
@@ -62,7 +62,7 @@ func testResourceMysql(t *testing.T) {
 	dataCreate.MaintenanceTime = "01:23:00"
 	dataCreate.BackupSchedule = "01:23"
 	dataCreate.IpFilter = []string{"1.2.3.4/32"}
-	dataCreate.MysqlSettings = strconv.Quote(`{"long_query_time":1,"slow_query_log":true,"sql_mode":"ANSI,TRADITIONAL","sql_require_primary_key":true}`)
+	dataCreate.MysqlSettings = strconv.Quote(`{"long_query_time":1,"slow_query_log":true,log_output":"INSIGHTS","sql_mode":"ANSI,TRADITIONAL","sql_require_primary_key":true}`)
 	buf := &bytes.Buffer{}
 	err = tpl.Execute(buf, &dataCreate)
 	if err != nil {
@@ -75,7 +75,7 @@ func testResourceMysql(t *testing.T) {
 	dataUpdate.MaintenanceTime = "02:34:00"
 	dataUpdate.BackupSchedule = "23:45"
 	dataUpdate.IpFilter = nil
-	dataUpdate.MysqlSettings = strconv.Quote(`{"long_query_time":5,"slow_query_log":true,"sql_mode":"ANSI,TRADITIONAL","sql_require_primary_key":true}`)
+	dataUpdate.MysqlSettings = strconv.Quote(`{"long_query_time":5,"slow_query_log":true,"log_output":"INSIGHTS","sql_mode":"ANSI,TRADITIONAL","sql_require_primary_key":true}`)
 	buf = &bytes.Buffer{}
 	err = tpl.Execute(buf, &dataUpdate)
 	if err != nil {

--- a/pkg/resources/database/resource_mysql_test.go
+++ b/pkg/resources/database/resource_mysql_test.go
@@ -62,7 +62,7 @@ func testResourceMysql(t *testing.T) {
 	dataCreate.MaintenanceTime = "01:23:00"
 	dataCreate.BackupSchedule = "01:23"
 	dataCreate.IpFilter = []string{"1.2.3.4/32"}
-	dataCreate.MysqlSettings = strconv.Quote(`{"long_query_time":1,"slow_query_log":true,log_output":"INSIGHTS","sql_mode":"ANSI,TRADITIONAL","sql_require_primary_key":true}`)
+	dataCreate.MysqlSettings = strconv.Quote(`{"long_query_time":1,"slow_query_log":true,"log_output":"INSIGHTS","sql_mode":"ANSI,TRADITIONAL","sql_require_primary_key":true}`)
 	buf := &bytes.Buffer{}
 	err = tpl.Execute(buf, &dataCreate)
 	if err != nil {

--- a/pkg/resources/database/resource_mysql_test.go
+++ b/pkg/resources/database/resource_mysql_test.go
@@ -62,7 +62,7 @@ func testResourceMysql(t *testing.T) {
 	dataCreate.MaintenanceTime = "01:23:00"
 	dataCreate.BackupSchedule = "01:23"
 	dataCreate.IpFilter = []string{"1.2.3.4/32"}
-	dataCreate.MysqlSettings = strconv.Quote(`{"long_query_time":1,"slow_query_log":true,"log_output":"INSIGHTS","sql_mode":"ANSI,TRADITIONAL","sql_require_primary_key":true}`)
+	dataCreate.MysqlSettings = strconv.Quote(`{"log_output":"INSIGHTS","long_query_time":1,"slow_query_log":true,"sql_mode":"ANSI,TRADITIONAL","sql_require_primary_key":true}`)
 	buf := &bytes.Buffer{}
 	err = tpl.Execute(buf, &dataCreate)
 	if err != nil {

--- a/pkg/resources/database/resource_mysql_test.go
+++ b/pkg/resources/database/resource_mysql_test.go
@@ -75,7 +75,7 @@ func testResourceMysql(t *testing.T) {
 	dataUpdate.MaintenanceTime = "02:34:00"
 	dataUpdate.BackupSchedule = "23:45"
 	dataUpdate.IpFilter = nil
-	dataUpdate.MysqlSettings = strconv.Quote(`{"long_query_time":5,"slow_query_log":true,"log_output":"INSIGHTS","sql_mode":"ANSI,TRADITIONAL","sql_require_primary_key":true}`)
+	dataUpdate.MysqlSettings = strconv.Quote(`{"log_output":"INSIGHTS","long_query_time":5,"slow_query_log":true,"sql_mode":"ANSI,TRADITIONAL","sql_require_primary_key":true}`)
 	buf = &bytes.Buffer{}
 	err = tpl.Execute(buf, &dataUpdate)
 	if err != nil {

--- a/pkg/resources/database/testdata/datasource.tmpl
+++ b/pkg/resources/database/testdata/datasource.tmpl
@@ -2,7 +2,7 @@ data "exoscale_database_uri" "{{ .ResourceName }}" {
 	name = {{ .Name }}
 	type = "{{ .Type }}"
 	zone = "{{ .Zone }}"
-    timeout = {
+    timeout {
         read = "20m"
     }
 }

--- a/pkg/resources/database/testdata/datasource.tmpl
+++ b/pkg/resources/database/testdata/datasource.tmpl
@@ -2,4 +2,7 @@ data "exoscale_database_uri" "{{ .ResourceName }}" {
 	name = {{ .Name }}
 	type = "{{ .Type }}"
 	zone = "{{ .Zone }}"
+    timeout = {
+        read = "20m"
+    }
 }

--- a/pkg/resources/database/testdata/datasource.tmpl
+++ b/pkg/resources/database/testdata/datasource.tmpl
@@ -2,7 +2,7 @@ data "exoscale_database_uri" "{{ .ResourceName }}" {
 	name = {{ .Name }}
 	type = "{{ .Type }}"
 	zone = "{{ .Zone }}"
-    timeout {
+    timeouts {
         read = "20m"
     }
 }


### PR DESCRIPTION
# Description
<!--
* Prefix: the title with the component name being changed. Add a short and self describing sentence to ease the review
* Please add a few lines providing context and describing the change
* Please self comment changes whenever applicable to help with the review process
* Please keep the checklist as part of the PR. Tick what applies to this change.
-->

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] [Acceptance tests OK](https://github.com/exoscale/terraform-provider-exoscale/actions/runs/11891475396/job/33132300928)

## Testing

Tested with pre-prod credentials locally and diffed the output against master. 
DatasourceURIs show an identical format.

```hcl
# Providers
# -> providers.tf

# Customizable parameters
locals {
  my_zone = "ch-gva-2"
}

# Read local IP address
data "http" "myip" {
  url = "https://ifconfig.me/ip"
}

# PostgreSQL
resource "exoscale_database" "tf_pg" {
  zone = local.my_zone
  name = "tf-test-pg"
  type = "pg"
  plan = "hobbyist-2"
  termination_protection = false

  pg {
    ip_filter = ["${data.http.myip.response_body}/32"]
  }
}

# MySQL
resource "exoscale_database" "tf_mysql" {
  zone = local.my_zone
  name = "tf-test-mysql"
  type = "mysql"
  plan = "hobbyist-2"
  termination_protection = false

  mysql {
    ip_filter = ["${data.http.myip.response_body}/32"]
  }
}

# Kafka
resource "exoscale_database" "tf_kafka" {
  zone = local.my_zone
  name = "tf-test-kafka"
  type = "kafka"
  plan = "business-4"  # Kafka requires at least business-4 plan
  termination_protection = false

  kafka {
    ip_filter = ["${data.http.myip.response_body}/32"]
  }
}

# OpenSearch
resource "exoscale_database" "tf_opensearch" {
  zone = local.my_zone
  name = "tf-test-opensearch"
  type = "opensearch"
  plan = "hobbyist-2"
  termination_protection = false

  opensearch {
    ip_filter = ["${data.http.myip.response_body}/32"]
  }
}

# Grafana
resource "exoscale_database" "tf_grafana" {
  zone = local.my_zone
  name = "tf-test-grafana"
  type = "grafana"
  plan = "hobbyist-2"
  termination_protection = false

  grafana {
    ip_filter = ["${data.http.myip.response_body}/32"]
  }
}

# Data sources for URIs
data "exoscale_database_uri" "tf_pg" {
  zone = local.my_zone
  name = exoscale_database.tf_pg.name
  type = "pg"
}

data "exoscale_database_uri" "tf_mysql" {
  zone = local.my_zone
  name = exoscale_database.tf_mysql.name
  type = "mysql"
}

data "exoscale_database_uri" "tf_kafka" {
  zone = local.my_zone
  name = exoscale_database.tf_kafka.name
  type = "kafka"
}

data "exoscale_database_uri" "tf_opensearch" {
  zone = local.my_zone
  name = exoscale_database.tf_opensearch.name
  type = "opensearch"
}

data "exoscale_database_uri" "tf_grafana" {
  zone = local.my_zone
  name = exoscale_database.tf_grafana.name
  type = "grafana"
}

# Outputs
# output "postgresql_uri" {
#   value     = data.exoscale_database_uri.tf_pg.uri
#   sensitive = true
# }

# output "mysql_uri" {
#   value     = data.exoscale_database_uri.tf_mysql.uri
#   sensitive = true
# }

# output "kafka_uri" {
#   value     = data.exoscale_database_uri.tf_kafka.uri
#   sensitive = true
# }

# output "opensearch_uri" {
#   value     = data.exoscale_database_uri.tf_opensearch.uri
#   sensitive = true
# }

# output "grafana_uri" {
#   value     = data.exoscale_database_uri.tf_grafana.uri
#   sensitive = true
# }

output "show_postgresql_uri" {
  value = nonsensitive(data.exoscale_database_uri.tf_pg.uri)
  description = "This output will show the sensitive PostgreSQL URI value after apply"
}

output "show_mysql_uri" {
  value = nonsensitive(data.exoscale_database_uri.tf_mysql.uri)
  description = "This output will show the sensitive MySQL URI value after apply"
}

output "show_kafka_uri" {
  value = nonsensitive(data.exoscale_database_uri.tf_kafka.uri)
  description = "This output will show the sensitive Kafka password value after apply"
}

output "show_opensearch_uri" {
  value = nonsensitive(data.exoscale_database_uri.tf_opensearch.uri)
  description = "This output will show the sensitive OpenSearch URI value after apply"
}

output "show_grafana_password" {
  value = nonsensitive(data.exoscale_database_uri.tf_grafana.password)
  description = "This output will show the sensitive Grafana URI value after apply"
}
```
