### PR TITLE
fix(docs): Ensure templates generate valid markdown frontmatter

### DIFF
--- a/docs/data-sources/nlb_service_list.md
+++ b/docs/data-sources/nlb_service_list.md
@@ -2,9 +2,8 @@
 page_title: "exoscale_nlb_service_list Data Source - terraform-provider-exoscale"
 subcategory: ""
 description: |-
-Fetch Exoscale [Network Load Balancers (NLB)](https://community.exoscale.com/documentation/compute/network-load-balancer/) Services.
-
-Corresponding resource: [exoscale_nlb](../resources/nlb.md).
+  Fetch Exoscale Network Load Balancers (NLB) https://community.exoscale.com/documentation/compute/network-load-balancer/ Services.
+  Corresponding resource: exoscale_nlb ../resources/nlb.md.
 ---
 
 # exoscale_nlb_service_list (Data Source)

--- a/docs/data-sources/zones.md
+++ b/docs/data-sources/zones.md
@@ -2,7 +2,7 @@
 page_title: "exoscale_zones Data Source - terraform-provider-exoscale"
 subcategory: ""
 description: |-
-Lists all zones.
+  Lists all zones.
 ---
 
 # exoscale_zones (Data Source)

--- a/templates/data-sources/nlb_service_list.md.tmpl
+++ b/templates/data-sources/nlb_service_list.md.tmpl
@@ -2,7 +2,7 @@
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
 subcategory: ""
 description: |-
-{{ .Description }}
+{{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---
 
 # {{.Name}} ({{.Type}})

--- a/templates/data-sources/zones.md.tmpl
+++ b/templates/data-sources/zones.md.tmpl
@@ -2,7 +2,7 @@
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
 subcategory: ""
 description: |-
-{{ .Description }}
+{{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---
 
 # {{.Name}} ({{.Type}})


### PR DESCRIPTION
# Description
The template for these two pages generate frontmatter that is not correctly indented.

## Checklist
(For exoscale contributors)

* [ ] Changelog updated (under *Unreleased* block)
* [ ] Acceptance tests OK
* [ ] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing

<!--
Describe the tests you did
-->
