### PR TITLE
Ignore block storage detach error when already detached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+BUG FIXES:
+
+- Ignore block storage detach error when already detached #393
+
 ## 0.62.3
 
 BUG FIXES:

--- a/pkg/resources/database/testdata/datasource.tmpl
+++ b/pkg/resources/database/testdata/datasource.tmpl
@@ -2,7 +2,4 @@ data "exoscale_database_uri" "{{ .ResourceName }}" {
 	name = {{ .Name }}
 	type = "{{ .Type }}"
 	zone = "{{ .Zone }}"
-    timeouts {
-        read = "20m"
-    }
 }

--- a/pkg/resources/database/testdata/datasource.tmpl
+++ b/pkg/resources/database/testdata/datasource.tmpl
@@ -2,4 +2,7 @@ data "exoscale_database_uri" "{{ .ResourceName }}" {
 	name = {{ .Name }}
 	type = "{{ .Type }}"
 	zone = "{{ .Zone }}"
+    timeouts {
+        read = "20m"
+    }
 }

--- a/pkg/resources/instance/resource.go
+++ b/pkg/resources/instance/resource.go
@@ -617,11 +617,13 @@ func rUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag
 					bid,
 				)
 				if err != nil {
-					if !errors.Is(err, v3.ErrNotFound) {
+					// Ideally we would have a custom error defined in OpenAPI spec & egoscale.
+					// For now we just check the error text.
+					if strings.HasSuffix(err.Error(), "Volume not attached") {
+						tflog.Debug(ctx, "volume not attached")
+					} else {
 						return diag.Errorf("failed to detach block storage: %s", err)
 					}
-
-					continue
 				}
 
 				_, err = clientV3.Wait(ctx, op, v3.OperationStateSuccess)

--- a/pkg/resources/instance/resource.go
+++ b/pkg/resources/instance/resource.go
@@ -620,10 +620,11 @@ func rUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag
 					// Ideally we would have a custom error defined in OpenAPI spec & egoscale.
 					// For now we just check the error text.
 					if strings.HasSuffix(err.Error(), "Volume not attached") {
-						tflog.Debug(ctx, "volume not attached")
-					} else {
-						return diag.Errorf("failed to detach block storage: %s", err)
+						tflog.Info(ctx, "volume not attached")
+						continue
 					}
+
+					return diag.Errorf("failed to detach block storage: %s", err)
 				}
 
 				_, err = clientV3.Wait(ctx, op, v3.OperationStateSuccess)


### PR DESCRIPTION
# Description
Fixes a bug when block storage volume is manually detached.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Acceptance tests OK
* [ ] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing

Before this change detach would throw following error:
```
Error: failed to detach block storage: DetachBlockStorageVolume: http response: Bad Request: Volume not attached
```
Now action succeeds with INFO level message notice:
```
2024-12-10T14:00:35.744Z [INFO]  provider.terraform-provider-exoscale: volume not attached: tf_provider_addr=registry.terraform.io/exoscale/exoscale tf_req_id=d378d4aa-41c9-48ad-6002-0ecbc3
8e3df4 tf_resource_type=exoscale_compute_instance @caller=/home/user/src/github.com/exoscale/terraform-provider-exoscale/pkg/resources/instance/resource.go:623 @module=exoscale t
f_mux_provider=tf5to6server.v5tov6Server tf_rpc=ApplyResourceChange timestamp=2024-12-10T14:00:35.744Z 
```

Tests are passing:
```bash
$ TF_ACC=1 go test ./... -run '^TestBlock'
?       github.com/exoscale/terraform-provider-exoscale [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/config      [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/general     [no test files]
ok      github.com/exoscale/terraform-provider-exoscale/exoscale        0.018s [no tests to run]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/filter      0.005s [no tests to run]
?       github.com/exoscale/terraform-provider-exoscale/pkg/provider    [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/provider/config     [no test files]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/list        0.025s [no tests to run]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/anti_affinity_group       0.033s [no tests to run]
?       github.com/exoscale/terraform-provider-exoscale/pkg/resources/zones     [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/sos [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/testutils   [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/utils       [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/validators  [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/version     [no test files]
?       github.com/exoscale/terraform-provider-exoscale/version [no test files]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/block_storage     117.245s
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/database  0.027s [no tests to run]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/iam       0.023s [no tests to run]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/instance  0.021s [no tests to run]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/instance_pool     0.021s [no tests to run]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/nlb_service       0.024s [no tests to run]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/sos_bucket_policy 0.014s [no tests to run]
```