### PR TITLE
Bump default timeout to 1h

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+BUG FIXES:
+
+- Bump default timeout to 1h #398
+
 ## 0.62.1
 
 BUG FIXES:

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,7 +52,7 @@ provider "exoscale" {
 - `key` (String) Exoscale API key
 - `secret` (String, Sensitive) Exoscale API secret
 - `sos_endpoint` (String)
-- `timeout` (Number) Timeout in seconds for waiting on compute resources to become available (by default: 300)
+- `timeout` (Number) Timeout in seconds for waiting on compute resources to become available (by default: 3600)
 
 ### Fine-tuning Timeout durations
 

--- a/go.mod
+++ b/go.mod
@@ -127,4 +127,4 @@ require (
 	gopkg.in/ini.v1 v1.67.0 // indirect
 )
 
-go 1.23.0
+go 1.23

--- a/go.mod
+++ b/go.mod
@@ -128,5 +128,3 @@ require (
 )
 
 go 1.23.0
-
-toolchain go1.23.0

--- a/go.mod
+++ b/go.mod
@@ -127,6 +127,6 @@ require (
 	gopkg.in/ini.v1 v1.67.0 // indirect
 )
 
-go 1.22.0
+go 1.23.0
 
 toolchain go1.23.0

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -18,7 +18,7 @@ const (
 	DefaultZone = "ch-gva-2"
 
 	DefaultEnvironment = "api"
-	DefaultTimeout     = 5 * time.Minute
+	DefaultTimeout     = 60 * time.Minute
 
 	ComputeMaxUserDataLength = 32768
 )


### PR DESCRIPTION
# Description

- Fixes issue of context deadline errors on some resources;
- Bumps go version in `go.mod` to fix govulncheck.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [ ] Acceptance tests OK
* [x] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing

```
exoscale_sks_nodepool.my_sks_nodepool: Creating...
exoscale_sks_nodepool.my_sks_nodepool: Still creating... [10s elapsed]
exoscale_sks_nodepool.my_sks_nodepool: Still creating... [20s elapsed]
exoscale_sks_nodepool.my_sks_nodepool: Still creating... [30s elapsed]
exoscale_sks_nodepool.my_sks_nodepool: Still creating... [40s elapsed]
exoscale_sks_nodepool.my_sks_nodepool: Still creating... [50s elapsed]
exoscale_sks_nodepool.my_sks_nodepool: Still creating... [1m0s elapsed]
exoscale_sks_nodepool.my_sks_nodepool: Still creating... [1m10s elapsed]
exoscale_sks_nodepool.my_sks_nodepool: Still creating... [1m20s elapsed]
exoscale_sks_nodepool.my_sks_nodepool: Still creating... [1m30s elapsed]
exoscale_sks_nodepool.my_sks_nodepool: Still creating... [1m40s elapsed]
exoscale_sks_nodepool.my_sks_nodepool: Still creating... [1m50s elapsed]
exoscale_sks_nodepool.my_sks_nodepool: Still creating... [2m0s elapsed]
exoscale_sks_nodepool.my_sks_nodepool: Still creating... [2m10s elapsed]
exoscale_sks_nodepool.my_sks_nodepool: Still creating... [2m20s elapsed]
exoscale_sks_nodepool.my_sks_nodepool: Still creating... [2m30s elapsed]
exoscale_sks_nodepool.my_sks_nodepool: Still creating... [2m40s elapsed]
exoscale_sks_nodepool.my_sks_nodepool: Still creating... [2m50s elapsed]
exoscale_sks_nodepool.my_sks_nodepool: Still creating... [3m0s elapsed]
exoscale_sks_nodepool.my_sks_nodepool: Still creating... [3m10s elapsed]
exoscale_sks_nodepool.my_sks_nodepool: Still creating... [3m20s elapsed]
exoscale_sks_nodepool.my_sks_nodepool: Still creating... [3m30s elapsed]
exoscale_sks_nodepool.my_sks_nodepool: Still creating... [3m40s elapsed]
exoscale_sks_nodepool.my_sks_nodepool: Still creating... [3m50s elapsed]
exoscale_sks_nodepool.my_sks_nodepool: Still creating... [4m0s elapsed]
exoscale_sks_nodepool.my_sks_nodepool: Still creating... [4m10s elapsed]
exoscale_sks_nodepool.my_sks_nodepool: Still creating... [4m20s elapsed]
exoscale_sks_nodepool.my_sks_nodepool: Still creating... [4m30s elapsed]
exoscale_sks_nodepool.my_sks_nodepool: Still creating... [4m40s elapsed]
exoscale_sks_nodepool.my_sks_nodepool: Still creating... [4m50s elapsed]
exoscale_sks_nodepool.my_sks_nodepool: Still creating... [5m0s elapsed]
exoscale_sks_nodepool.my_sks_nodepool: Still creating... [5m10s elapsed]
exoscale_sks_nodepool.my_sks_nodepool: Still creating... [5m20s elapsed]
exoscale_sks_nodepool.my_sks_nodepool: Still creating... [5m30s elapsed]
exoscale_sks_nodepool.my_sks_nodepool: Still creating... [5m40s elapsed]
exoscale_sks_nodepool.my_sks_nodepool: Still creating... [5m50s elapsed]
exoscale_sks_nodepool.my_sks_nodepool: Still creating... [6m0s elapsed]
exoscale_sks_nodepool.my_sks_nodepool: Still creating... [6m10s elapsed]
exoscale_sks_nodepool.my_sks_nodepool: Still creating... [6m20s elapsed]
exoscale_sks_nodepool.my_sks_nodepool: Creation complete after 6m30s
```