### PR TITLE
Don't validate addons attribute in SKS cluster resource test 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ BUG FIXES:
 BUG FIXES:
 
 - Bump default timeout to 1h #398
+- Don't validate addons attribute in SKS cluster resource test #399
 
 ## 0.62.1
 

--- a/exoscale/resource_exoscale_sks_cluster_test.go
+++ b/exoscale/resource_exoscale_sks_cluster_test.go
@@ -263,6 +263,7 @@ func TestAccResourceSKSCluster(t *testing.T) {
 				ImportStateVerifyIgnore: []string{
 					"oidc.#",
 					"oidc.0.%",
+					"addons",
 					resSKSClusterAttrOIDC(resSKSClusterAttrOIDCClientID),
 					resSKSClusterAttrOIDC(resSKSClusterAttrOIDCGroupsClaim),
 					resSKSClusterAttrOIDC(resSKSClusterAttrOIDCGroupsPrefix),


### PR DESCRIPTION
Attribute `addons` is [deprecated](https://registry.terraform.io/providers/exoscale/exoscale/latest/docs/resources/sks_cluster#addons-1) and breaks our tests due to not being in sync with individual addon attributes. This PR removes the check from the test as it is not relevant.

# Description
<!--
* Prefix: the title with the component name being changed. Add a short and self describing sentence to ease the review
* Please add a few lines providing context and describing the change
* Please self comment changes whenever applicable to help with the review process
* Please keep the checklist as part of the PR. Tick what applies to this change.
-->

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Acceptance tests OK
* [x] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing

Before:
```
=== RUN   TestAccResourceSKSCluster
    resource_exoscale_sks_cluster_test.go:183: Step 3/3 error running import: ImportStateVerify attributes not equivalent. Difference is shown below. The - symbol indicates attributes missing after import.
        
          map[string]string{
        - 	"addons.#": "1",
        + 	"addons.#": "2",
        + 	"addons.1": "exoscale-container-storage-interface",
          }
--- FAIL: TestAccResourceSKSCluster (186.10s)
```
Now:
```
=== RUN   TestAccResourceSKSCluster                                                                                                                                                          
--- PASS: TestAccResourceSKSCluster (375.81s)
```
