### PR TITLE
Fix typo that prevented running in preprod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+BUG FIXES:
+
+- Fix typo that prevented running in preprod #400
+
 ## 0.62.2
 
 BUG FIXES:

--- a/exoscale/provider.go
+++ b/exoscale/provider.go
@@ -189,7 +189,7 @@ func ProviderConfigure(_ context.Context, d *schema.ResourceData) (interface{}, 
 
 	sosEndpoint, sosEndpointOK := d.GetOk("sos_endpoint")
 	if !sosEndpointOK {
-		environment = providerConfig.GetEnvDefault(
+		sosEndpoint = providerConfig.GetEnvDefault(
 			"EXOSCALE_SOS_ENDPOINT",
 			providerConfig.GetEnvDefault("EXOSCALE_STORAGE_API_ENDPOINT", ""))
 	}


### PR DESCRIPTION
# Description

FIxes a bug where `sosEndpoint` was overriding `environment` configuration. 

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [ ] Acceptance tests OK
* [ ] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing

Before:
```
exoscale_security_group.mysg: Creating...                                                                                                                                                                          
╷          
│ Error: Post "https://api-ch-gva-2.exoscale.com/v2/security-group": invalid request: Invalid key or request signature
│                                            
│   with exoscale_security_group.mysg,
│   on main.tf line 10, in resource "exoscale_security_group" "mysg":
│   10: resource "exoscale_security_group" "mysg" {
│                                                                                                        
╵  
```
After:
```
exoscale_security_group.mysg: Creating...
exoscale_security_group.mysg: Creation complete after 4s [id=f4fa2daf-9a2f-40ef-9b5c-cc5c338653f1]
```