### PR TITLE
Docs fix

### DIFF
--- a/docs/data-sources/block_storage_volume_snapshot.md
+++ b/docs/data-sources/block_storage_volume_snapshot.md
@@ -5,7 +5,7 @@ subcategory: ""
 description: |-
   Fetch Exoscale Block Storage https://community.exoscale.com/documentation/block-storage/ Snapshot.
   Block Storage offers persistent externally attached volumes for your workloads.
-  Corresponding resource: exoscaleblockstorage_snapshot ../resources/block_storage_snapshot.md.
+  Corresponding resource: exoscaleblockstorage_snapshot ../resources/block_storage_volume_snapshot.md.
 ---
 
 # exoscale_block_storage_volume_snapshot (Data Source)
@@ -14,7 +14,7 @@ Fetch [Exoscale Block Storage](https://community.exoscale.com/documentation/bloc
 
 Block Storage offers persistent externally attached volumes for your workloads.
 
-Corresponding resource: [exoscale_block_storage_snapshot](../resources/block_storage_snapshot.md).
+Corresponding resource: [exoscale_block_storage_snapshot](../resources/block_storage_volume_snapshot.md).
 
 
 

--- a/docs/data-sources/database_uri.md
+++ b/docs/data-sources/database_uri.md
@@ -18,7 +18,7 @@ Corresponding resource: [exoscale_database](../resources/database.md).
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "exoscale_database" "my_database" {
   zone = "ch-gva-2"
   name = "my-database"

--- a/docs/data-sources/nlb_service_list.md
+++ b/docs/data-sources/nlb_service_list.md
@@ -14,7 +14,7 @@ Corresponding resource: [exoscale_nlb](../resources/nlb.md).
 
 ## Example Usage
 
-```hcl
+```terraform
 data "exoscale_nlb_service_list" "example_nlb_services" {
   name = "my-nlb"
 }

--- a/docs/data-sources/nlb_service_list.md
+++ b/docs/data-sources/nlb_service_list.md
@@ -44,7 +44,7 @@ directory for complete configuration examples.
 ### Read-Only
 
 - `id` (String) The ID of this resource.
-- `services` (Attributes List) The list of [exoscale_nlb_service](./nlb_service.md). (see [below for nested schema](#nestedatt--services))
+- `services` (Attributes List) The list of [exoscale_nlb_service](./nlb_service_list.md). (see [below for nested schema](#nestedatt--services))
 
 <a id="nestedblock--timeouts"></a>
 ### Nested Schema for `timeouts`

--- a/docs/data-sources/security_group.md
+++ b/docs/data-sources/security_group.md
@@ -38,6 +38,6 @@ directory for complete configuration examples.
 
 ### Read-Only
 
-- `external_sources` (Set of String) The list of external network sources, in [CIDR](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing#CIDR_notatio) notation.
+- `external_sources` (Set of String) The list of external network sources, in [CIDR](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing#CIDR_notation) notation.
 
 

--- a/docs/data-sources/zones.md
+++ b/docs/data-sources/zones.md
@@ -11,7 +11,7 @@ Lists all zones.
 
 ## Example Usage
 
-```hcl
+```terraform
 data "exoscale_zones" "example_zones" {}
 
 # Outputs

--- a/docs/guides/migration-of-compute.md
+++ b/docs/guides/migration-of-compute.md
@@ -22,7 +22,7 @@ Before proceeding, please:
 
 In this guide, we will assume the following configuration as an example:
 
-```hcl
+```terraform
 resource "exoscale_compute" "my_instance" {
   disk_size = 10
   display_name = "my-instance"
@@ -88,7 +88,7 @@ Now, these resources are removed from the state.
 
 Replace the `exoscale_network` block by the new `exoscale_private_network` resource:
 
-```hcl
+```terraform
 resource "exoscale_private_network" "my_network" {
   name = "privnet"
   description = "Private Network"
@@ -103,7 +103,7 @@ In this example we are using unmanaged private network, for managed network you 
 
 Now replace `exoscale_compute` and `exoscale_nic` blocks with `exoscale_compute_instance`:
 
-```hcl
+```terraform
 resource "exoscale_compute_instance" "my_instance" {
   disk_size = 10
   name = "my-instance"

--- a/docs/guides/migration-of-security-group-rules.md
+++ b/docs/guides/migration-of-security-group-rules.md
@@ -22,7 +22,7 @@ Before proceeding, please:
 
 In this guide, we will assume the following configuration as an example:
 
-```hcl
+```terraform
 resource "exoscale_security_group" "webapp" {
   name = "webapp"
   # ...
@@ -122,7 +122,7 @@ Now, these resources are removed from the state.
 
 Replace the `exoscale_security_group_rules` block by new `exoscale_security_group_rule` resources:
 
-```hcl
+```terraform
 resource "exoscale_security_group_rule" "webapp_ssh" {
   security_group_id = exoscale_security_group.webapp.id
   type = "INGRESS"

--- a/docs/guides/migration-of-ssh-keypair.md
+++ b/docs/guides/migration-of-ssh-keypair.md
@@ -18,7 +18,7 @@ Should you need to generate a key _pair_ (public and private key), we invite you
 [tls_private_key][tls_private_key] and the resource's `public_key_openssh` output along Exoscale
 `exoscale_ssh_key`. Example given:
 
-```hcl
+```terraform
 resource "tls_private_key" "my_ssh_key" {
   algorithm = "ED25519"
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,7 @@ use the Exoscale Terraform provider.
 
 ### Example
 
-```hcl
+```terraform
 terraform {
   required_providers {
     exoscale = {
@@ -59,7 +59,7 @@ provider "exoscale" {
 In addition of the global `timeout` provider setting, the waiting time of async
 operations can be fine-tuned per resource and per operation type:
 
-```hcl
+```terraform
 resource "exoscale_instance_pool" "web" {
   # ...
 
@@ -77,7 +77,7 @@ resource "exoscale_instance_pool" "web" {
 
 Here is a simple HCL configuration provisioning an Exoscale Compute instance:
 
-```hcl
+```terraform
 terraform {
   required_providers {
     exoscale = {

--- a/docs/resources/elastic_ip.md
+++ b/docs/resources/elastic_ip.md
@@ -15,7 +15,7 @@ Corresponding data source: [exoscale_elastic_ip](../data-sources/elastic_ip.md).
 
 *Unmanaged* EIPv4:
 
-```hcl
+```terraform
 resource "exoscale_elastic_ip" "my_elastic_ip" {
   zone = "ch-gva-2"
 }
@@ -23,7 +23,7 @@ resource "exoscale_elastic_ip" "my_elastic_ip" {
 
 *Managed* EIPv6:
 
-```hcl
+```terraform
 resource "exoscale_elastic_ip" "my_managed_elastic_ip" {
   zone = "ch-gva-2"
   address_family = "inet6"

--- a/docs/resources/iam_access_key.md
+++ b/docs/resources/iam_access_key.md
@@ -13,7 +13,7 @@ Manage Exoscale [IAM Access Keys](https://community.exoscale.com/documentation/i
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "exoscale_iam_access_key" "my_sos_access_key" {
   name       = "my-sos-access-key"
   operations = ["get-sos-object", "list-sos-bucket"]

--- a/docs/resources/iam_api_key.md
+++ b/docs/resources/iam_api_key.md
@@ -13,7 +13,7 @@ Manage Exoscale [IAM](https://community.exoscale.com/documentation/iam/) API Key
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "exoscale_iam_role" "my_role" {
   name = "my-role"
   description = "Example role"

--- a/docs/resources/iam_org_policy.md
+++ b/docs/resources/iam_org_policy.md
@@ -15,7 +15,7 @@ Manage Exoscale [IAM](https://community.exoscale.com/documentation/iam/) Org Pol
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "exoscale_iam_org_policy" "org_policy" {
   default_service_strategy = "allow"
   services = {

--- a/docs/resources/instance_pool.md
+++ b/docs/resources/instance_pool.md
@@ -60,7 +60,7 @@ directory for complete configuration examples.
 - `key_pair` (String) The [exoscale_ssh_key](./ssh_key.md) (name) to authorize in the managed instances.
 - `labels` (Map of String) A map of key/value labels.
 - `network_ids` (Set of String) A list of [exoscale_private_network](./private_network.md) (IDs).
-- `security_group_ids` (Set of String) A list of [exoscale_security_group](./security_groups.md) (IDs).
+- `security_group_ids` (Set of String) A list of [exoscale_security_group](./security_group.md) (IDs).
 - `service_offering` (String, Deprecated) The managed instances type. Please use the `instance_type` argument instead.
 - `state` (String)
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))

--- a/docs/resources/nlb.md
+++ b/docs/resources/nlb.md
@@ -13,7 +13,7 @@ Corresponding data source: [exoscale_nlb](../data-sources/nlb.md).
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "exoscale_nlb" "my_nlb" {
   zone = "ch-gva-2"
   name = "my-nlb"

--- a/docs/resources/private_network.md
+++ b/docs/resources/private_network.md
@@ -15,7 +15,7 @@ Corresponding data source: [exoscale_private_network](../data-sources/private_ne
 
 *Unmanaged* private network:
 
-```hcl
+```terraform
 resource "exoscale_private_network" "my_private_network" {
   zone = "ch-gva-2"
   name = "my-private-network"
@@ -24,7 +24,7 @@ resource "exoscale_private_network" "my_private_network" {
 
 *Managed* private network:
 
-```hcl
+```terraform
 resource "exoscale_private_network" "my_managed_private_network" {
   zone = "ch-gva-2"
   name = "my-managed-private-network"

--- a/docs/resources/security_group.md
+++ b/docs/resources/security_group.md
@@ -13,7 +13,7 @@ Corresponding data source: [exoscale_security_group](../data-sources/security_gr
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "exoscale_security_group" "my_security_group" {
   name = "my-security-group"
 }

--- a/docs/resources/security_group.md
+++ b/docs/resources/security_group.md
@@ -34,7 +34,7 @@ directory for complete configuration examples.
 ### Optional
 
 - `description` (String) ❗ A free-form text describing the group.
-- `external_sources` (Set of String) A list of external network sources, in [CIDR](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing#CIDR_notatio) notation.
+- `external_sources` (Set of String) A list of external network sources, in [CIDR](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing#CIDR_notation) notation.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only

--- a/docs/resources/sks_kubeconfig.md
+++ b/docs/resources/sks_kubeconfig.md
@@ -13,7 +13,7 @@ Manage Exoscale [Scalable Kubernetes Service (SKS)](https://community.exoscale.c
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "exoscale_sks_cluster" "my_sks_cluster" {
   zone = "ch-gva-2"
   name = "my-sks-cluster"

--- a/docs/resources/sks_nodepool.md
+++ b/docs/resources/sks_nodepool.md
@@ -11,7 +11,7 @@ Manage Exoscale [Scalable Kubernetes Service (SKS)](https://community.exoscale.c
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "exoscale_sks_cluster" "my_sks_cluster" {
   zone = "ch-gva-2"
   name = "my-sks-cluster"

--- a/docs/resources/ssh_key.md
+++ b/docs/resources/ssh_key.md
@@ -13,7 +13,7 @@ Manage Exoscale [SSH Keys](https://community.exoscale.com/documentation/compute/
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "exoscale_ssh_key" "my_ssh_key" {
   name       = "my-ssh-key"
   public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDGRY..."
@@ -24,7 +24,7 @@ Should you want to _create_ an SSH keypair (including *private* key) with Terraf
 [tls_private_key](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key)
 resource:
 
-```hcl
+```terraform
 resource "tls_private_key" "my_ssh_key" {
   algorithm = "ED25519"
 }

--- a/exoscale/datasource_exoscale_security_group.go
+++ b/exoscale/datasource_exoscale_security_group.go
@@ -40,7 +40,7 @@ Corresponding resource: [exoscale_security_group](../resources/security_group.md
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
-				Description: "The list of external network sources, in [CIDR](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing#CIDR_notatio) notation.",
+				Description: "The list of external network sources, in [CIDR](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing#CIDR_notation) notation.",
 			},
 		},
 

--- a/exoscale/resource_exoscale_security_group.go
+++ b/exoscale/resource_exoscale_security_group.go
@@ -42,7 +42,7 @@ func resourceSecurityGroupSchema() map[string]*schema.Schema {
 				Type:         schema.TypeString,
 				ValidateFunc: validation.IsCIDRNetwork(0, 128),
 			},
-			Description: "A list of external network sources, in [CIDR](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing#CIDR_notatio) notation.",
+			Description: "A list of external network sources, in [CIDR](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing#CIDR_notation) notation.",
 		},
 		resSecurityGroupAttrName: {
 			Type:     schema.TypeString,

--- a/pkg/resources/block_storage/datasource_snapshot.go
+++ b/pkg/resources/block_storage/datasource_snapshot.go
@@ -22,7 +22,7 @@ const DataSourceSnapshotDescription = `Fetch [Exoscale Block Storage](https://co
 
 Block Storage offers persistent externally attached volumes for your workloads.
 
-Corresponding resource: [exoscale_block_storage_snapshot](../resources/block_storage_snapshot.md).`
+Corresponding resource: [exoscale_block_storage_snapshot](../resources/block_storage_volume_snapshot.md).`
 
 // Ensure provider defined types fully satisfy framework interfaces.
 var _ datasource.DataSourceWithConfigure = &DataSourceSnapshot{}

--- a/pkg/resources/instance_pool/resource.go
+++ b/pkg/resources/instance_pool/resource.go
@@ -115,7 +115,7 @@ func Resource() *schema.Resource {
 			Elem:        &schema.Schema{Type: schema.TypeString},
 		},
 		AttrSecurityGroupIDs: {
-			Description: "A list of [exoscale_security_group](./security_groups.md) (IDs).",
+			Description: "A list of [exoscale_security_group](./security_group.md) (IDs).",
 			Type:        schema.TypeSet,
 			Optional:    true,
 			Set:         schema.HashString,

--- a/pkg/resources/nlb_service/datasource_list.go
+++ b/pkg/resources/nlb_service/datasource_list.go
@@ -129,7 +129,7 @@ Corresponding resource: [exoscale_nlb](../resources/nlb.md).`,
 				Optional:            true,
 			},
 			NLBServiceListAttrNLBServiceList: schema.ListNestedAttribute{
-				MarkdownDescription: "The list of [exoscale_nlb_service](./nlb_service.md).",
+				MarkdownDescription: "The list of [exoscale_nlb_service](./nlb_service_list.md).",
 				Computed:            true,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{

--- a/templates/data-sources/database_uri.md.tmpl
+++ b/templates/data-sources/database_uri.md.tmpl
@@ -15,7 +15,7 @@ Corresponding resource: [exoscale_database](../resources/database.md).
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "exoscale_database" "my_database" {
   zone = "ch-gva-2"
   name = "my-database"

--- a/templates/data-sources/nlb_service_list.md.tmpl
+++ b/templates/data-sources/nlb_service_list.md.tmpl
@@ -11,7 +11,7 @@ description: |-
 
 ## Example Usage
 
-```hcl
+```terraform
 data "exoscale_nlb_service_list" "example_nlb_services" {
   name = "my-nlb"
 }

--- a/templates/data-sources/zones.md.tmpl
+++ b/templates/data-sources/zones.md.tmpl
@@ -11,7 +11,7 @@ description: |-
 
 ## Example Usage
 
-```hcl
+```terraform
 data "exoscale_zones" "example_zones" {}
 
 # Outputs

--- a/templates/guides/migration-of-compute.md
+++ b/templates/guides/migration-of-compute.md
@@ -22,7 +22,7 @@ Before proceeding, please:
 
 In this guide, we will assume the following configuration as an example:
 
-```hcl
+```terraform
 resource "exoscale_compute" "my_instance" {
   disk_size = 10
   display_name = "my-instance"
@@ -88,7 +88,7 @@ Now, these resources are removed from the state.
 
 Replace the `exoscale_network` block by the new `exoscale_private_network` resource:
 
-```hcl
+```terraform
 resource "exoscale_private_network" "my_network" {
   name = "privnet"
   description = "Private Network"
@@ -103,7 +103,7 @@ In this example we are using unmanaged private network, for managed network you 
 
 Now replace `exoscale_compute` and `exoscale_nic` blocks with `exoscale_compute_instance`:
 
-```hcl
+```terraform
 resource "exoscale_compute_instance" "my_instance" {
   disk_size = 10
   name = "my-instance"

--- a/templates/guides/migration-of-security-group-rules.md
+++ b/templates/guides/migration-of-security-group-rules.md
@@ -22,7 +22,7 @@ Before proceeding, please:
 
 In this guide, we will assume the following configuration as an example:
 
-```hcl
+```terraform
 resource "exoscale_security_group" "webapp" {
   name = "webapp"
   # ...
@@ -122,7 +122,7 @@ Now, these resources are removed from the state.
 
 Replace the `exoscale_security_group_rules` block by new `exoscale_security_group_rule` resources:
 
-```hcl
+```terraform
 resource "exoscale_security_group_rule" "webapp_ssh" {
   security_group_id = exoscale_security_group.webapp.id
   type = "INGRESS"

--- a/templates/guides/migration-of-ssh-keypair.md
+++ b/templates/guides/migration-of-ssh-keypair.md
@@ -18,7 +18,7 @@ Should you need to generate a key _pair_ (public and private key), we invite you
 [tls_private_key][tls_private_key] and the resource's `public_key_openssh` output along Exoscale
 `exoscale_ssh_key`. Example given:
 
-```hcl
+```terraform
 resource "tls_private_key" "my_ssh_key" {
   algorithm = "ED25519"
 }

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -27,7 +27,7 @@ use the Exoscale Terraform provider.
 
 ### Example
 
-```hcl
+```terraform
 terraform {
   required_providers {
     exoscale = {
@@ -49,7 +49,7 @@ provider "exoscale" {
 In addition of the global `timeout` provider setting, the waiting time of async
 operations can be fine-tuned per resource and per operation type:
 
-```hcl
+```terraform
 resource "exoscale_instance_pool" "web" {
   # ...
 
@@ -67,7 +67,7 @@ resource "exoscale_instance_pool" "web" {
 
 Here is a simple HCL configuration provisioning an Exoscale Compute instance:
 
-```hcl
+```terraform
 terraform {
   required_providers {
     exoscale = {

--- a/templates/resources/elastic_ip.md.tmpl
+++ b/templates/resources/elastic_ip.md.tmpl
@@ -15,7 +15,7 @@ Corresponding data source: [exoscale_elastic_ip](../data-sources/elastic_ip.md).
 
 *Unmanaged* EIPv4:
 
-```hcl
+```terraform
 resource "exoscale_elastic_ip" "my_elastic_ip" {
   zone = "ch-gva-2"
 }
@@ -23,7 +23,7 @@ resource "exoscale_elastic_ip" "my_elastic_ip" {
 
 *Managed* EIPv6:
 
-```hcl
+```terraform
 resource "exoscale_elastic_ip" "my_managed_elastic_ip" {
   zone = "ch-gva-2"
   address_family = "inet6"

--- a/templates/resources/iam_access_key.md.tmpl
+++ b/templates/resources/iam_access_key.md.tmpl
@@ -13,7 +13,7 @@ Manage Exoscale [IAM Access Keys](https://community.exoscale.com/documentation/i
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "exoscale_iam_access_key" "my_sos_access_key" {
   name       = "my-sos-access-key"
   operations = ["get-sos-object", "list-sos-bucket"]

--- a/templates/resources/iam_api_key.md.tmpl
+++ b/templates/resources/iam_api_key.md.tmpl
@@ -13,7 +13,7 @@ Manage Exoscale [IAM](https://community.exoscale.com/documentation/iam/) API Key
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "exoscale_iam_role" "my_role" {
   name = "my-role"
   description = "Example role"

--- a/templates/resources/iam_org_policy.md.tmpl
+++ b/templates/resources/iam_org_policy.md.tmpl
@@ -15,7 +15,7 @@ Manage Exoscale [IAM](https://community.exoscale.com/documentation/iam/) Org Pol
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "exoscale_iam_org_policy" "org_policy" {
   default_service_strategy = "allow"
   services = {

--- a/templates/resources/nlb.md.tmpl
+++ b/templates/resources/nlb.md.tmpl
@@ -13,7 +13,7 @@ Corresponding data source: [exoscale_nlb](../data-sources/nlb.md).
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "exoscale_nlb" "my_nlb" {
   zone = "ch-gva-2"
   name = "my-nlb"

--- a/templates/resources/private_network.md.tmpl
+++ b/templates/resources/private_network.md.tmpl
@@ -15,7 +15,7 @@ Corresponding data source: [exoscale_private_network](../data-sources/private_ne
 
 *Unmanaged* private network:
 
-```hcl
+```terraform
 resource "exoscale_private_network" "my_private_network" {
   zone = "ch-gva-2"
   name = "my-private-network"
@@ -24,7 +24,7 @@ resource "exoscale_private_network" "my_private_network" {
 
 *Managed* private network:
 
-```hcl
+```terraform
 resource "exoscale_private_network" "my_managed_private_network" {
   zone = "ch-gva-2"
   name = "my-managed-private-network"

--- a/templates/resources/security_group.md.tmpl
+++ b/templates/resources/security_group.md.tmpl
@@ -13,7 +13,7 @@ Corresponding data source: [exoscale_security_group](../data-sources/security_gr
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "exoscale_security_group" "my_security_group" {
   name = "my-security-group"
 }

--- a/templates/resources/sks_kubeconfig.md.tmpl
+++ b/templates/resources/sks_kubeconfig.md.tmpl
@@ -13,7 +13,7 @@ Manage Exoscale [Scalable Kubernetes Service (SKS)](https://community.exoscale.c
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "exoscale_sks_cluster" "my_sks_cluster" {
   zone = "ch-gva-2"
   name = "my-sks-cluster"

--- a/templates/resources/sks_nodepool.md.tmpl
+++ b/templates/resources/sks_nodepool.md.tmpl
@@ -11,7 +11,7 @@ Manage Exoscale [Scalable Kubernetes Service (SKS)](https://community.exoscale.c
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "exoscale_sks_cluster" "my_sks_cluster" {
   zone = "ch-gva-2"
   name = "my-sks-cluster"

--- a/templates/resources/ssh_key.md.tmpl
+++ b/templates/resources/ssh_key.md.tmpl
@@ -13,7 +13,7 @@ Manage Exoscale [SSH Keys](https://community.exoscale.com/documentation/compute/
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "exoscale_ssh_key" "my_ssh_key" {
   name       = "my-ssh-key"
   public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDGRY..."
@@ -24,7 +24,7 @@ Should you want to _create_ an SSH keypair (including *private* key) with Terraf
 [tls_private_key](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key)
 resource:
 
-```hcl
+```terraform
 resource "tls_private_key" "my_ssh_key" {
   algorithm = "ED25519"
 }


### PR DESCRIPTION
# Description

* Uses `terraform` as language in code blocks. This results in better code highlighting in most renderers, including the one used on registry.terraform.io. It is also the language hint used by default by the docs framework.
* Fixes a number of broken links.

## Checklist
(For exoscale contributors)

* [ ] Changelog updated (under *Unreleased* block)
* [ ] Acceptance tests OK
* [ ] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing

<!--
Describe the tests you did
-->
