### PR TITLE
Remove hardcoded timeout from db redis test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 BUG FIXES:
 
 - Ignore block storage detach error when already detached #393
+- Remove hardcoded timeout from db redis test #403
 
 ## 0.62.3
 

--- a/pkg/resources/database/testdata/datasource.tmpl
+++ b/pkg/resources/database/testdata/datasource.tmpl
@@ -2,7 +2,4 @@ data "exoscale_database_uri" "{{ .ResourceName }}" {
 	name = {{ .Name }}
 	type = "{{ .Type }}"
 	zone = "{{ .Zone }}"
-    timeouts {
-        read = "20m"
-    }
 }


### PR DESCRIPTION
# Description

Global timeout was bumped in #398 , we no longer need custom timeout in database tests.
## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [ ] Acceptance tests OK
* [ ] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing

<!--
Describe the tests you did
-->
