### PR TITLE
feat(ci): Regenerate community docs for each release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,12 @@ on:
       - 'v[0-9]+\.[0-9]+\.[0-9]+'
 
 jobs:
+  community-docs:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.EXOSCALE_BUILD_GH_TOKEN }}
+    steps:
+      - run: gh workflow run gen-terraform.yaml -R exoscale/community-ng -f version=${{ github.ref_name }}
   goreleaser:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
# Description
Triggers the generation of the provider docs in the community repo for each release.

Requires https://github.com/exoscale/terraform-provider-exoscale/pull/402

## Checklist
(For exoscale contributors)

* [ ] Changelog updated (under *Unreleased* block)
* [ ] Acceptance tests OK
* [ ] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing

<!--
Describe the tests you did
-->
