### PR TITLE
Examples : add csi parameter in the example for SKS

### DIFF
--- a/examples/sks/main.tf
+++ b/examples/sks/main.tf
@@ -15,6 +15,8 @@ data "exoscale_security_group" "default" {
 resource "exoscale_sks_cluster" "my_sks_cluster" {
   zone = local.my_zone
   name = "my-sks-cluster"
+  auto_upgrade = true
+  exoscale_csi = true
 }
 
 # (ad-hoc anti-affinity group)


### PR DESCRIPTION
# Description
This PR follows a customer feedback. He used the example to create a SKS Cluster and then struggled with the PVC.
This, because the CSI addon is **NOT** deployed by default. 

Note : metrics_server and exoscale_ccm both default to true. 

As the auto_upgrade should not break, I suggest to set the boolean to true. 

<!--
* Prefix: the title with the component name being changed. Add a short and self describing sentence to ease the review
* Please add a few lines providing context and describing the change
* Please self comment changes whenever applicable to help with the review process
* Please keep the checklist as part of the PR. Tick what applies to this change.
-->

## Checklist
(For exoscale contributors)

* [ ] Changelog updated (under *Unreleased* block)
* [ ] Acceptance tests OK
* [ ] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing

<!--
Describe the tests you did
-->
