### PR TITLE
Deprecate database opensearch max_index_count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ BUG FIXES:
 - Ignore block storage detach error when already detached #393
 - Remove hardcoded timeout from db redis test #403
 - Use dedicated endpoint for fetching database user credentials #416
+- Deprecate database opensearch max_index_count #414
 
 ## 0.62.3
 

--- a/docs/resources/database.md
+++ b/docs/resources/database.md
@@ -131,7 +131,7 @@ Optional:
 - `index_template` (Block, Optional) Template settings for all new indexes (see [below for nested schema](#nestedblock--opensearch--index_template))
 - `ip_filter` (Set of String) Allow incoming connections from this list of CIDR address block, e.g. `["10.20.0.0/16"]
 - `keep_index_refresh_interval` (Boolean) Aiven automation resets index.refresh_interval to default value for every index to be sure that indices are always visible to search. If it doesn't fit your case, you can disable this by setting up this flag to true.
-- `max_index_count` (Number) Maximum number of indexes to keep (Minimum value is `0`)
+- `max_index_count` (Number, Deprecated) Maximum number of indexes to keep (Minimum value is `0`)
 - `recovery_backup_name` (String) ❗ Name of a backup to recover from
 - `settings` (String) OpenSearch-specific settings, in json. e.g.`jsonencode({thread_pool_search_size: 64})`. Use `exo x get-dbaas-settings-opensearch` to get a list of available settings.
 - `version` (String) ❗ OpenSearch major version (`exo dbaas type show opensearch` for reference)

--- a/pkg/resources/database/resource_opensearch.go
+++ b/pkg/resources/database/resource_opensearch.go
@@ -79,6 +79,7 @@ var ResourceOpensearchSchema = schema.SingleNestedBlock{
 		"max_index_count": schema.Int64Attribute{
 			MarkdownDescription: "Maximum number of indexes to keep (Minimum value is `0`)",
 			Optional:            true,
+			DeprecationMessage:  "This attribute is deprecated and is ignored",
 		},
 		"settings": schema.StringAttribute{
 			MarkdownDescription: "OpenSearch-specific settings, in json. e.g.`jsonencode({thread_pool_search_size: 64})`. Use `exo x get-dbaas-settings-opensearch` to get a list of available settings.",
@@ -167,7 +168,6 @@ func (r *Resource) createOpensearch(ctx context.Context, data *ResourceModel, di
 	service := oapi.CreateDbaasServiceOpensearchJSONRequestBody{
 		Plan:                     data.Plan.ValueString(),
 		TerminationProtection:    data.TerminationProtection.ValueBoolPointer(),
-		MaxIndexCount:            data.Opensearch.MaxIndexCount.ValueInt64Pointer(),
 		ForkFromService:          (*oapi.DbaasServiceName)(data.Opensearch.ForkFromService.ValueStringPointer()),
 		RecoveryBackupName:       data.Opensearch.RecoveryBackupName.ValueStringPointer(),
 		KeepIndexRefreshInterval: data.Opensearch.KeepIndexRefreshInterval.ValueBoolPointer(),
@@ -409,10 +409,6 @@ func (r *Resource) readOpensearch(ctx context.Context, data *ResourceModel, diag
 		data.Opensearch.KeepIndexRefreshInterval = types.BoolPointerValue(apiService.KeepIndexRefreshInterval)
 	}
 
-	if !data.Opensearch.MaxIndexCount.IsNull() || isImport {
-		data.Opensearch.MaxIndexCount = types.Int64PointerValue(apiService.MaxIndexCount)
-	}
-
 	data.Opensearch.Version = types.StringNull()
 	if apiService.Version != nil {
 		data.Opensearch.Version = types.StringValue(strings.SplitN(*apiService.Version, ".", 2)[0])
@@ -536,11 +532,6 @@ func (r *Resource) updateOpensearch(ctx context.Context, stateData *ResourceMode
 
 		if !planData.Opensearch.KeepIndexRefreshInterval.IsNull() && !planData.Opensearch.KeepIndexRefreshInterval.Equal(stateData.Opensearch.KeepIndexRefreshInterval) {
 			service.KeepIndexRefreshInterval = planData.Opensearch.KeepIndexRefreshInterval.ValueBoolPointer()
-			updated = true
-		}
-
-		if !planData.Opensearch.MaxIndexCount.IsNull() && !planData.Opensearch.MaxIndexCount.Equal(stateData.Opensearch.MaxIndexCount) {
-			service.MaxIndexCount = planData.Opensearch.MaxIndexCount.ValueInt64Pointer()
 			updated = true
 		}
 

--- a/pkg/resources/database/resource_opensearch_test.go
+++ b/pkg/resources/database/resource_opensearch_test.go
@@ -180,7 +180,6 @@ func testResourceOpensearch(t *testing.T) {
 						return nil
 					},
 					// User
-					resource.TestCheckResourceAttrSet(userFullResourceName, "password"),
 					resource.TestCheckResourceAttrSet(userFullResourceName, "type"),
 					func(s *terraform.State) error {
 						err := CheckExistsOpensearchUser(serviceDataBase.Name, userDataBase.Username, &userDataCreate)
@@ -234,7 +233,7 @@ func testResourceOpensearch(t *testing.T) {
 				}(),
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: strings.Fields("updated_at state"),
+				ImportStateVerifyIgnore: strings.Fields("updated_at state opensearch.max_index_count"),
 			},
 			{
 				ResourceName: userFullResourceName,
@@ -289,10 +288,6 @@ func CheckExistsOpensearch(name string, data *TemplateModelOpensearch) error {
 
 	if data.KeepIndexRefreshInterval != *service.KeepIndexRefreshInterval {
 		return fmt.Errorf("keep_index_refresh_interval: expected %v, got %v", data.KeepIndexRefreshInterval, *service.KeepIndexRefreshInterval)
-	}
-
-	if data.MaxIndexCount != strconv.FormatInt(*service.MaxIndexCount, 10) {
-		return fmt.Errorf("max_index_count: expected %v, got %v", data.MaxIndexCount, *service.MaxIndexCount)
 	}
 
 	if len(data.IndexPatterns) != len(*service.IndexPatterns) {

--- a/pkg/resources/database/resource_opensearch_test.go
+++ b/pkg/resources/database/resource_opensearch_test.go
@@ -181,6 +181,7 @@ func testResourceOpensearch(t *testing.T) {
 					},
 					// User
 					resource.TestCheckResourceAttrSet(userFullResourceName, "type"),
+					resource.TestCheckResourceAttrSet(userFullResourceName, "password"),
 					func(s *terraform.State) error {
 						err := CheckExistsOpensearchUser(serviceDataBase.Name, userDataBase.Username, &userDataCreate)
 						if err != nil {


### PR DESCRIPTION
# Description

OpenSearch top level `max_index_count` is noop in API, this PR marks it as deprecated and makes it noop in provider as well.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Acceptance tests OK
* [x] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing

```bash
$ TF_ACC=1 go test ./... -run TestDatabase/ResourceOpensearch 
?       github.com/exoscale/terraform-provider-exoscale [no test files]                                  
ok      github.com/exoscale/terraform-provider-exoscale/exoscale        (cached) [no tests to run]                                                                                                                 
?       github.com/exoscale/terraform-provider-exoscale/pkg/config      [no test files]                  
ok      github.com/exoscale/terraform-provider-exoscale/pkg/filter      (cached) [no tests to run]       
?       github.com/exoscale/terraform-provider-exoscale/pkg/general     [no test files]                  
ok      github.com/exoscale/terraform-provider-exoscale/pkg/list        (cached) [no tests to run]       
?       github.com/exoscale/terraform-provider-exoscale/pkg/provider    [no test files]                                                                                                                            
?       github.com/exoscale/terraform-provider-exoscale/pkg/provider/config     [no test files]          
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/anti_affinity_group       (cached) [no tests to run]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/block_storage     (cached) [no tests to run]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/database  29.790s
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/iam       (cached) [no tests to run]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/instance  (cached) [no tests to run]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/instance_pool     (cached) [no tests to run]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/nlb_service       (cached) [no tests to run]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/sos_bucket_policy (cached) [no tests to run]
?       github.com/exoscale/terraform-provider-exoscale/pkg/resources/zones     [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/sos [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/testutils   [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/utils       [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/validators  [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/version     [no test files]
?       github.com/exoscale/terraform-provider-exoscale/version [no test files]
```