### PR TITLE
Use dedicated endpoint for fetching database user credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ BUG FIXES:
 
 - Ignore block storage detach error when already detached #393
 - Remove hardcoded timeout from db redis test #403
+- Use dedicated endpoint for fetching database user credentials #416
 
 ## 0.62.3
 

--- a/pkg/resources/database/datasource_uri_test.go
+++ b/pkg/resources/database/datasource_uri_test.go
@@ -128,53 +128,6 @@ func testDataSourceURI(t *testing.T) {
 		},
 	})
 
-	// Test database Redis URI
-	tplResourceRedis, err := template.ParseFiles("testdata/resource_redis.tmpl")
-	if err != nil {
-		t.Fatal(err)
-	}
-	resourceRedis := TemplateModelRedis{
-		ResourceName:          "test",
-		Name:                  acctest.RandomWithPrefix(testutils.Prefix),
-		Plan:                  "hobbyist-2",
-		Zone:                  testutils.TestZoneName,
-		TerminationProtection: false,
-	}
-	buf = &bytes.Buffer{}
-	err = tplResourceRedis.Execute(buf, &resourceRedis)
-	if err != nil {
-		t.Fatal(err)
-	}
-	part = buf.String()
-
-	data.Type = "redis"
-	buf = &bytes.Buffer{}
-	err = tplData.Execute(buf, &data)
-	if err != nil {
-		t.Fatal(err)
-	}
-	config = fmt.Sprintf("%s\n%s", part, buf.String())
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testutils.AccPreCheck(t) },
-		CheckDestroy:             CheckServiceDestroy("redis", resourceRedis.Name),
-		ProtoV6ProviderFactories: testutils.TestAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: config,
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet(fullResourceName, "uri"),
-					resource.TestCheckResourceAttr(fullResourceName, "schema", "rediss"),
-					resource.TestCheckResourceAttr(fullResourceName, "username", "default"),
-					resource.TestCheckResourceAttrSet(fullResourceName, "password"),
-					resource.TestCheckResourceAttrSet(fullResourceName, "host"),
-					resource.TestCheckResourceAttrSet(fullResourceName, "port"),
-					resource.TestCheckNoResourceAttr(fullResourceName, "db_name"),
-				),
-			},
-		},
-	})
-
 	// Test database Kafka URI
 	tplResourceKafka, err := template.ParseFiles("testdata/resource_kafka.tmpl")
 	if err != nil {

--- a/pkg/resources/database/main_test.go
+++ b/pkg/resources/database/main_test.go
@@ -18,7 +18,9 @@ import (
 func TestDatabase(t *testing.T) {
 	t.Run("ResourcePg", testResourcePg)
 	t.Run("ResourceMysql", testResourceMysql)
-	t.Run("ResourceRedis", testResourceRedis)
+	// Redis is EOL and creating a service is no longer possible.
+	// TODO: Clean up this test.
+	//t.Run("ResourceRedis", testResourceRedis)
 	t.Run("ResourceKafka", testResourceKafka)
 	t.Run("ResourceOpensearch", testResourceOpensearch)
 	t.Run("ResourceGrafana", testResourceGrafana)

--- a/pkg/resources/database/resource_redis_test.go
+++ b/pkg/resources/database/resource_redis_test.go
@@ -38,6 +38,7 @@ type TemplateModelRedis struct {
 	RedisSettings string
 }
 
+//lint:ignore U1000 redis EOL
 func testResourceRedis(t *testing.T) {
 	tpl, err := template.ParseFiles("testdata/resource_redis.tmpl")
 	if err != nil {

--- a/pkg/resources/database/resource_user_kafka.go
+++ b/pkg/resources/database/resource_user_kafka.go
@@ -173,11 +173,19 @@ func (data *KafkaUserResourceModel) CreateResource(ctx context.Context, client *
 
 	for _, user := range svc.Users {
 		if user.Username == data.Username.ValueString() {
-			data.Password = basetypes.NewStringValue(user.Password)
 			data.Type = basetypes.NewStringValue(user.Type)
-			data.AccessCert = basetypes.NewStringValue(user.AccessCert)
-			data.AccessKey = basetypes.NewStringValue(user.AccessKey)
-			data.AccessCertExpiry = basetypes.NewStringValue(user.AccessCertExpiry.String())
+
+			pass, err := client.RevealDBAASKafkaUserPassword(ctx, data.Service.ValueString(), data.Username.ValueString())
+			if err != nil {
+				diagnostics.AddError("Client Error", fmt.Sprintf("Unable to reveal pg user password, got error: %s", err))
+				return
+			}
+
+			data.Password = basetypes.NewStringValue(pass.Password)
+			data.AccessCert = basetypes.NewStringValue(pass.AccessCert)
+			data.AccessKey = basetypes.NewStringValue(pass.AccessKey)
+			data.AccessCertExpiry = basetypes.NewStringValue(pass.AccessCertExpiry.String())
+
 			return
 		}
 	}
@@ -216,11 +224,19 @@ func (data *KafkaUserResourceModel) ReadResource(ctx context.Context, client *ex
 
 	for _, user := range svc.Users {
 		if user.Username == data.Username.ValueString() {
-			data.Password = basetypes.NewStringValue(user.Password)
 			data.Type = basetypes.NewStringValue(user.Type)
-			data.AccessCert = basetypes.NewStringValue(user.AccessCert)
-			data.AccessKey = basetypes.NewStringValue(user.AccessKey)
-			data.AccessCertExpiry = basetypes.NewStringValue(user.AccessCertExpiry.String())
+
+			pass, err := client.RevealDBAASKafkaUserPassword(ctx, data.Service.ValueString(), data.Username.ValueString())
+			if err != nil {
+				diagnostics.AddError("Client Error", fmt.Sprintf("Unable to reveal pg user password, got error: %s", err))
+				return
+			}
+
+			data.Password = basetypes.NewStringValue(pass.Password)
+			data.AccessCert = basetypes.NewStringValue(pass.AccessCert)
+			data.AccessKey = basetypes.NewStringValue(pass.AccessKey)
+			data.AccessCertExpiry = basetypes.NewStringValue(pass.AccessCertExpiry.String())
+
 			return
 		}
 	}

--- a/pkg/resources/database/resource_user_mysql.go
+++ b/pkg/resources/database/resource_user_mysql.go
@@ -177,9 +177,17 @@ func (data *MysqlUserResourceModel) CreateResource(ctx context.Context, client *
 
 	for _, user := range svc.Users {
 		if user.Username == data.Username.ValueString() {
-			data.Password = basetypes.NewStringValue(user.Password)
 			data.Type = basetypes.NewStringValue(user.Type)
 			data.Authentication = basetypes.NewStringValue(user.Authentication)
+
+			pass, err := client.RevealDBAASMysqlUserPassword(ctx, data.Service.ValueString(), data.Username.ValueString())
+			if err != nil {
+				diagnostics.AddError("Client Error", fmt.Sprintf("Unable to reveal pg user password, got error: %s", err))
+				return
+			}
+
+			data.Password = basetypes.NewStringValue(pass.Password)
+
 			return
 		}
 	}
@@ -218,9 +226,17 @@ func (data *MysqlUserResourceModel) ReadResource(ctx context.Context, client *ex
 
 	for _, user := range svc.Users {
 		if user.Username == data.Username.ValueString() {
-			data.Password = basetypes.NewStringValue(user.Password)
 			data.Type = basetypes.NewStringValue(user.Type)
 			data.Authentication = basetypes.NewStringValue(user.Authentication)
+
+			pass, err := client.RevealDBAASMysqlUserPassword(ctx, data.Service.ValueString(), data.Username.ValueString())
+			if err != nil {
+				diagnostics.AddError("Client Error", fmt.Sprintf("Unable to reveal pg user password, got error: %s", err))
+				return
+			}
+
+			data.Password = basetypes.NewStringValue(pass.Password)
+
 			return
 		}
 	}

--- a/pkg/resources/database/resource_user_opensearch.go
+++ b/pkg/resources/database/resource_user_opensearch.go
@@ -154,8 +154,16 @@ func (data *OpensearchUserResourceModel) CreateResource(ctx context.Context, cli
 
 	for _, user := range svc.Users {
 		if user.Username == data.Username.ValueString() {
-			data.Password = basetypes.NewStringValue(user.Password)
 			data.Type = basetypes.NewStringValue(user.Type)
+
+			pass, err := client.RevealDBAASOpensearchUserPassword(ctx, data.Service.ValueString(), data.Username.ValueString())
+			if err != nil {
+				diagnostics.AddError("Client Error", fmt.Sprintf("Unable to reveal pg user password, got error: %s", err))
+				return
+			}
+
+			data.Password = basetypes.NewStringValue(pass.Password)
+
 			return
 		}
 	}
@@ -194,8 +202,16 @@ func (data *OpensearchUserResourceModel) ReadResource(ctx context.Context, clien
 
 	for _, user := range svc.Users {
 		if user.Username == data.Username.ValueString() {
-			data.Password = basetypes.NewStringValue(user.Password)
 			data.Type = basetypes.NewStringValue(user.Type)
+
+			pass, err := client.RevealDBAASOpensearchUserPassword(ctx, data.Service.ValueString(), data.Username.ValueString())
+			if err != nil {
+				diagnostics.AddError("Client Error", fmt.Sprintf("Unable to reveal pg user password, got error: %s", err))
+				return
+			}
+
+			data.Password = basetypes.NewStringValue(pass.Password)
+
 			return
 		}
 	}

--- a/pkg/resources/database/resource_user_pg.go
+++ b/pkg/resources/database/resource_user_pg.go
@@ -172,11 +172,19 @@ func (data *PGUserResourceModel) CreateResource(ctx context.Context, client *exo
 
 	for _, user := range svc.Users {
 		if user.Username == data.Username.ValueString() {
-			data.Password = basetypes.NewStringValue(user.Password)
 			data.Type = basetypes.NewStringValue(user.Type)
 			if user.AllowReplication != nil {
 				data.AllowReplication = basetypes.NewBoolValue(*user.AllowReplication)
 			}
+
+			pass, err := client.RevealDBAASPostgresUserPassword(ctx, data.Service.ValueString(), data.Username.ValueString())
+			if err != nil {
+				diagnostics.AddError("Client Error", fmt.Sprintf("Unable to reveal pg user password, got error: %s", err))
+				return
+			}
+
+			data.Password = basetypes.NewStringValue(pass.Password)
+
 			return
 		}
 	}
@@ -206,7 +214,6 @@ func (data *PGUserResourceModel) Delete(ctx context.Context, client *exoscale.Cl
 }
 
 func (data *PGUserResourceModel) ReadResource(ctx context.Context, client *exoscale.Client, diagnostics *diag.Diagnostics) {
-
 	svc, err := client.GetDBAASServicePG(ctx, data.Service.ValueString())
 	if err != nil {
 		diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read service pg user, got error: %s", err))
@@ -215,11 +222,19 @@ func (data *PGUserResourceModel) ReadResource(ctx context.Context, client *exosc
 
 	for _, user := range svc.Users {
 		if user.Username == data.Username.ValueString() {
-			data.Password = basetypes.NewStringValue(user.Password)
 			data.Type = basetypes.NewStringValue(user.Type)
 			if user.AllowReplication != nil {
 				data.AllowReplication = basetypes.NewBoolValue(*user.AllowReplication)
 			}
+
+			pass, err := client.RevealDBAASPostgresUserPassword(ctx, data.Service.ValueString(), data.Username.ValueString())
+			if err != nil {
+				diagnostics.AddError("Client Error", fmt.Sprintf("Unable to reveal pg user password, got error: %s", err))
+				return
+			}
+
+			data.Password = basetypes.NewStringValue(pass.Password)
+
 			return
 		}
 	}


### PR DESCRIPTION
# Description

- Fetch user credentials from dedicated EPs;
- Disable Redis tests (EOL).

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Acceptance tests OK
* [ ] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing

```bash
$ TF_ACC=1 go test ./... -v -run TestDatabase/Resource
...
=== RUN   TestDatabase
=== RUN   TestDatabase/ResourcePg
=== RUN   TestDatabase/ResourceMysql
=== RUN   TestDatabase/ResourceKafka
=== RUN   TestDatabase/ResourceOpensearch
=== RUN   TestDatabase/ResourceGrafana
--- PASS: TestDatabase (364.10s)
    --- PASS: TestDatabase/ResourcePg (138.64s)
    --- PASS: TestDatabase/ResourceMysql (162.29s)
    --- PASS: TestDatabase/ResourceKafka (26.25s)
    --- PASS: TestDatabase/ResourceOpensearch (25.08s)
    --- PASS: TestDatabase/ResourceGrafana (11.85s)
...
```