### PR TITLE
compute_instance: make disk_size a required field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+IMPROVEMENTS:
+-  compute_instance: make disk_size a required field #419
+
 ## 0.64.1
 
 FEATURES:

--- a/docs/resources/compute_instance.md
+++ b/docs/resources/compute_instance.md
@@ -42,6 +42,7 @@ directory for complete configuration examples.
 
 ### Required
 
+- `disk_size` (Number) The instance disk size (GiB; at least `10`). Can not be decreased after creation. **WARNING**: updating this attribute stops/restarts the instance.
 - `name` (String) The compute instance name.
 - `template_id` (String) ❗ The [exoscale_template](../data-sources/template.md) (ID) to use when creating the instance.
 - `type` (String) The instance type (`<family>.<size>`, e.g. `standard.medium`; use the [Exoscale CLI](https://github.com/exoscale/cli/) - `exo compute instance-type list` - for the list of available types). **WARNING**: updating this attribute stops/restarts the instance.
@@ -53,7 +54,6 @@ directory for complete configuration examples.
 - `block_storage_volume_ids` (Set of String) A list of [exoscale_block_storage_volume](./block_storage_volume.md) (ID) to attach to the instance.
 - `deploy_target_id` (String) ❗ A deploy target ID.
 - `destroy_protected` (Boolean) Mark the instance as protected, the Exoscale API will refuse to delete the instance until the protection is removed (boolean; default: `false`).
-- `disk_size` (Number) The instance disk size (GiB; at least `10`). Can not be decreased after creation. **WARNING**: updating this attribute stops/restarts the instance.
 - `elastic_ip_ids` (Set of String) A list of [exoscale_elastic_ip](./elastic_ip.md) (IDs) to attach to the instance.
 - `ipv6` (Boolean) Enable IPv6 on the instance (boolean; default: `false`).
 - `labels` (Map of String) A map of key/value labels.

--- a/examples/sks/main.tf
+++ b/examples/sks/main.tf
@@ -13,8 +13,8 @@ data "exoscale_security_group" "default" {
 
 # Sample SKS cluster
 resource "exoscale_sks_cluster" "my_sks_cluster" {
-  zone = local.my_zone
-  name = "my-sks-cluster"
+  zone         = local.my_zone
+  name         = "my-sks-cluster"
   auto_upgrade = true
   exoscale_csi = true
 }

--- a/pkg/resources/instance/resource.go
+++ b/pkg/resources/instance/resource.go
@@ -47,8 +47,7 @@ func Resource() *schema.Resource {
 		AttrDiskSize: {
 			Description:  "The instance disk size (GiB; at least `10`). Can not be decreased after creation. **WARNING**: updating this attribute stops/restarts the instance.",
 			Type:         schema.TypeInt,
-			Computed:     true,
-			Optional:     true,
+			Required:     true,
 			ValidateFunc: validation.IntAtLeast(10),
 		},
 		AttrElasticIPIDs: {


### PR DESCRIPTION
# Description

fixes #356

`disk-size` is a required field, however it wasn't required by the provider. https://openapi-v2.exoscale.com/operation/operation-create-instance#operation-create-instance-body-application-json-disk-size

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Acceptance tests OK
* [ ] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing

When I applied the following
```terraform
data "exoscale_template" "my_template" {
  zone = "ch-gva-2"
  name = "Linux Ubuntu 22.04 LTS 64-bit"
}

resource "exoscale_compute_instance" "my_instance" {
  zone = "ch-gva-2"
  name = "my-instance"

  template_id = data.exoscale_template.my_template.id
  type        = "standard.medium"
}
```

I got
```
╷
│ Error: CreateInstance: http response: Bad Request: Invalid value in disk-size (description: `Instance disk size in GiB`) - should be an Integer between 10 51200
│
│
│   with exoscale_compute_instance.my_instance,
│   on resource.tf line 6, in resource "exoscale_compute_instance" "my_instance":
│    6: resource "exoscale_compute_instance" "my_instance" {
│
╵
```

after this fix

```
╷
│ Error: Missing required argument
│
│   on resource.tf line 6, in resource "exoscale_compute_instance" "my_instance":
│    6: resource "exoscale_compute_instance" "my_instance" {
│
│ The argument "disk_size" is required, but no definition was found.
╵
```

Adding `disk_size = 10` creates an instance.