### PR TITLE
Fix panic on empty reverse DNS in instance datasources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+BUG FIXES:
+
+- Fix panic on empty reverse DNS in instance datasources #421
+
 ## 0.63.0
 
 FEATURES:

--- a/pkg/resources/instance/datasource.go
+++ b/pkg/resources/instance/datasource.go
@@ -247,7 +247,9 @@ func dsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.
 	if err != nil && !errors.Is(err, v3.ErrNotFound) {
 		return diag.Errorf("unable to retrieve instance reverse-dns: %s", err)
 	}
-	data[AttrReverseDNS] = strings.TrimSuffix(string(rdns.DomainName), ".")
+	if rdns != nil {
+		data[AttrReverseDNS] = strings.TrimSuffix(string(rdns.DomainName), ".")
+	}
 
 	for key, value := range data {
 		err := d.Set(key, value)


### PR DESCRIPTION
# Description

Fixes regression introduced with egoscale v3 migration.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Acceptance tests OK
* [x] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing

<!--
Describe the tests you did
-->
