### PR TITLE
Remove invalid ALL protocol in security group rule

### DIFF
--- a/docs/resources/security_group_rule.md
+++ b/docs/resources/security_group_rule.md
@@ -44,7 +44,7 @@ directory for complete configuration examples.
 - `end_port` (Number) ❗ A `TCP`/`UDP` port range to match.
 - `icmp_code` (Number) ❗ An ICMP/ICMPv6 [type/code](https://en.wikipedia.org/wiki/Internet_Control_Message_Protocol#Control_messages) to match.
 - `icmp_type` (Number) ❗ An ICMP/ICMPv6 [type/code](https://en.wikipedia.org/wiki/Internet_Control_Message_Protocol#Control_messages) to match.
-- `protocol` (String) ❗ The network protocol to match (`TCP`, `UDP`, `ICMP`, `ICMPv6`, `AH`, `ESP`, `GRE`, `IPIP` or `ALL`)
+- `protocol` (String) ❗ The network protocol to match (`TCP`, `UDP`, `ICMP`, `ICMPv6`, `AH`, `ESP`, `GRE` or  `IPIP`)
 - `public_security_group` (String) ❗ An (`INGRESS`) source / (`EGRESS`) destination public security group name to match (conflicts with `cidr`/`user_security_group`/`user_security_group_id`).
 - `security_group` (String, Deprecated) ❗ The parent security group name. Please use the `security_group_id` argument along the [exoscale_security_group](../data-sources/security_group.md) data source instead.
 - `security_group_id` (String) ❗ The parent [exoscale_security_group](./security_group.md) ID.

--- a/exoscale/resource_exoscale_security_group_rule.go
+++ b/exoscale/resource_exoscale_security_group_rule.go
@@ -36,6 +36,10 @@ const (
 
 var securityGroupRuleProtocols = []string{
 	"AH",
+	// Even though public API don't support creating ALL rules. Some customer might have terraform
+	// code that references such rule that was created via obwald. So we need to keep support for it
+	// to not break customers.
+	"ALL",
 	"ESP",
 	"GRE",
 	"ICMP",
@@ -119,7 +123,7 @@ func resourceSecurityGroupRule() *schema.Resource {
 				ValidateFunc: validation.StringInSlice(securityGroupRuleProtocols, true),
 				// Ignore case differences
 				DiffSuppressFunc: suppressCaseDiff,
-				Description:      "The network protocol to match (`TCP`, `UDP`, `ICMP`, `ICMPv6`, `AH`, `ESP`, `GRE` or `IPIP`)",
+				Description:      "The network protocol to match (`TCP`, `UDP`, `ICMP`, `ICMPv6`, `AH`, `ESP`, `GRE`, `IPIP` or `ALL`)",
 			},
 			resSecurityGroupRuleAttrPublicSecurityGroup: {
 				Type:        schema.TypeString,

--- a/exoscale/resource_exoscale_security_group_rule.go
+++ b/exoscale/resource_exoscale_security_group_rule.go
@@ -36,7 +36,7 @@ const (
 
 var securityGroupRuleProtocols = []string{
 	"AH",
-	// Even though public API don't support creating ALL rules. Some customer might have terraform
+	// Even though public API doesn't support creating ALL rules. Some customer might have terraform
 	// code that references such rule that was created via obwald. So we need to keep support for it
 	// to not break customers.
 	"ALL",

--- a/exoscale/resource_exoscale_security_group_rule.go
+++ b/exoscale/resource_exoscale_security_group_rule.go
@@ -36,7 +36,6 @@ const (
 
 var securityGroupRuleProtocols = []string{
 	"AH",
-	"ALL",
 	"ESP",
 	"GRE",
 	"ICMP",
@@ -120,7 +119,7 @@ func resourceSecurityGroupRule() *schema.Resource {
 				ValidateFunc: validation.StringInSlice(securityGroupRuleProtocols, true),
 				// Ignore case differences
 				DiffSuppressFunc: suppressCaseDiff,
-				Description:      "The network protocol to match (`TCP`, `UDP`, `ICMP`, `ICMPv6`, `AH`, `ESP`, `GRE`, `IPIP` or `ALL`)",
+				Description:      "The network protocol to match (`TCP`, `UDP`, `ICMP`, `ICMPv6`, `AH`, `ESP`, `GRE` or `IPIP`)",
 			},
 			resSecurityGroupRuleAttrPublicSecurityGroup: {
 				Type:        schema.TypeString,


### PR DESCRIPTION
# Description
`ALL` is not a valid protocol to pass when creating a security group https://openapi-v2.exoscale.com/operation/operation-add-rule-to-security-group#operation-add-rule-to-security-group-body-application-json-protocol

Trying to use it is rejected by public API:
```tf
resource "exoscale_security_group_rule" "my_security_group_rule" {
  security_group_id = exoscale_security_group.tf-test.id
  type              = "INGRESS"
  protocol          = "ALL"
  cidr              = "0.0.0.0/0"
}
```

```sh
exoscale_security_group.tf-test: Creating...
exoscale_security_group.tf-test: Creation complete after 4s [id=03f8e0aa-786e-4fc9-a777-cad3079da861]
exoscale_security_group_rule.my_security_group_rule: Creating...
╷
│ Error: Post "https://api-ch-gva-2.exoscale.com/v2/security-group/03f8e0aa-786e-4fc9-a777-cad3079da861/rules": invalid request: Invalid value in protocol (description: `Network protocol`) - should be one of :ah, :esp, :gre, :icmp, :icmpv6, :ipip, :tcp, :udp
│ 
│ 
│   with exoscale_security_group_rule.my_security_group_rule,
│   on main.tf line 19, in resource "exoscale_security_group_rule" "my_security_group_rule":
│   19: resource "exoscale_security_group_rule" "my_security_group_rule" {
│ 
╵
```

According to git blame this `"ALL"` protocol in the terraform provider predates the switch to the V2 API. Maybe it used to be possible to set this protocol in the V1 api, but it's not the case anymore
## Checklist
(For exoscale contributors)

* [ ] Changelog updated (under *Unreleased* block)
* [x] Acceptance tests OK
* [x] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing

<!--
Describe the tests you did
-->
