### PR TITLE
Block storage: don't error on remove resource deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ IMPROVEMENTS:
 - compute_instance: make disk_size a required field #419
 - docs: note that domain_record.content format depnds on record type #429
 
+BUG FIXES:
+
+- Block storage: don't error on remove resource deleted #432
+
 ## 0.64.1
 
 FEATURES:

--- a/pkg/resources/block_storage/resource_volume.go
+++ b/pkg/resources/block_storage/resource_volume.go
@@ -2,6 +2,7 @@ package block_storage
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -333,6 +334,13 @@ func (r *ResourceVolume) Read(ctx context.Context, req resource.ReadRequest, res
 		id,
 	)
 	if err != nil {
+
+		if errors.Is(err, exoscale.ErrNotFound) {
+			// Resource doesn't exist anymore, signaling the core to remove it from the state.
+			resp.State.RemoveResource(ctx)
+			return
+		}
+
 		resp.Diagnostics.AddError(
 			"unable to get storage volume",
 			err.Error(),


### PR DESCRIPTION
# Description
<!--
* Prefix: the title with the component name being changed. Add a short and self describing sentence to ease the review
* Please add a few lines providing context and describing the change
* Please self comment changes whenever applicable to help with the review process
* Please keep the checklist as part of the PR. Tick what applies to this change.
-->

Correctly inform the state that a block storage volume has been deleted from the remote state and attempt to recreate it

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Acceptance tests OK
* [ ] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing

<!--
Describe the tests you did
-->

```
│ Error: unable to get storage volume
│ 
│   with exoscale_block_storage_volume.test,
│   on main.tf line 30, in resource "exoscale_block_storage_volume" "test":
│   30: resource "exoscale_block_storage_volume" "test" {
│ 
│ GetBlockStorageVolume: http response: Not Found: not found


now:

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # exoscale_block_storage_volume.test will be created
  + resource "exoscale_block_storage_volume" "test" {
      + blocksize  = (known after apply)
      + created_at = (known after apply)
      + id         = (known after apply)
      + name       = "test"
      + state      = (known after apply)
      + zone       = "ch-gva-2"
    }

Plan: 1 to add, 0 to change, 0 to destroy.
```
