### PR TITLE
Bump go version in go.mod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ IMPROVEMENTS:
 - compute_instance: make disk_size a required field #419
 - docs: note that domain_record.content format depnds on record type #429
 - sks-cluster: support for feature-gates #431
+- Bump go version in go.mod #433
 
 BUG FIXES:
 

--- a/go.mod
+++ b/go.mod
@@ -127,4 +127,4 @@ require (
 	gopkg.in/ini.v1 v1.67.0 // indirect
 )
 
-go 1.23
+go 1.24


### PR DESCRIPTION
# Description
Switch to latest minor (1.24) Go version.

## Checklist
(For exoscale contributors)

* [ ] Changelog updated (under *Unreleased* block)
* [ ] Acceptance tests OK
* [ ] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing

<!--
Describe the tests you did
-->
