### PR TITLE
support for tpm and secureboot flags for compute_instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,12 +25,12 @@ IMPROVEMENTS:
 
 IMPROVEMENTS:
 - compute_instance: make disk_size a required field #419
-- compute_instance: support for tpm_enalbed and secure_boot_enabled flags #FIXME
+- compute_instance: support for tpm_enalbed and secure_boot_enabled flags #452
 - docs: note that domain_record.content format depnds on record type #429
 - sks-cluster: support for feature-gates #431
 - Bump go version in go.mod #433
 - Move DNS management to egoscale v3 #434
-- doc: fix broken links to community docs #440 
+- doc: fix broken links to community docs #440
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ IMPROVEMENTS:
 
 IMPROVEMENTS:
 - compute_instance: make disk_size a required field #419
+- compute_instance: support for tpm_enalbed and secure_boot_enabled flags #FIXME
 - docs: note that domain_record.content format depnds on record type #429
 - sks-cluster: support for feature-gates #431
 - Bump go version in go.mod #433

--- a/docs/data-sources/compute_instance.md
+++ b/docs/data-sources/compute_instance.md
@@ -48,6 +48,8 @@ directory for complete configuration examples.
 - `deploy_target_id` (String) A deploy target ID.
 - `disk_size` (Number) The instance disk size (GiB).
 - `elastic_ip_ids` (Set of String) The list of attached [exoscale_elastic_ip](../resources/elastic_ip.md) (IDs).
+- `enable_secure_boot` (Boolean) Whether secure boot is enabled on the instance.
+- `enable_tpm` (Boolean) Whether TPM is enabled on the instance.
 - `ipv6` (Boolean) Whether IPv6 is enabled on the instance.
 - `ipv6_address` (String) The instance (main network interface) IPv6 address (if enabled).
 - `labels` (Map of String) A map of key/value labels.

--- a/docs/data-sources/compute_instance_list.md
+++ b/docs/data-sources/compute_instance_list.md
@@ -80,6 +80,8 @@ Read-Only:
 - `deploy_target_id` (String)
 - `disk_size` (Number)
 - `elastic_ip_ids` (Set of String)
+- `enabled_secure_boot` (Boolean)
+- `enabled_tpm` (Boolean)
 - `id` (String)
 - `ipv6` (Boolean)
 - `ipv6_address` (String)

--- a/docs/resources/compute_instance.md
+++ b/docs/resources/compute_instance.md
@@ -55,8 +55,8 @@ directory for complete configuration examples.
 - `deploy_target_id` (String) ❗ A deploy target ID.
 - `destroy_protected` (Boolean) Mark the instance as protected, the Exoscale API will refuse to delete the instance until the protection is removed (boolean; default: `false`).
 - `elastic_ip_ids` (Set of String) A list of [exoscale_elastic_ip](./elastic_ip.md) (IDs) to attach to the instance.
-- `enable_secure_boot` (Boolean) Indicates whether secure boot is enabled for the instance.
-- `enable_tpm` (Boolean) Indicates whether tpm is enabled for the instance.
+- `enable_secure_boot` (Boolean) Indicates whether secure boot is enabled on the instance.
+- `enable_tpm` (Boolean) Indicates whether TPM is enabled on the instance.
 - `ipv6` (Boolean) Enable IPv6 on the instance (boolean; default: `false`).
 - `labels` (Map of String) A map of key/value labels.
 - `network_interface` (Block Set) Private network interfaces (may be specified multiple times). Structure is documented below. (see [below for nested schema](#nestedblock--network_interface))

--- a/docs/resources/compute_instance.md
+++ b/docs/resources/compute_instance.md
@@ -55,6 +55,8 @@ directory for complete configuration examples.
 - `deploy_target_id` (String) ❗ A deploy target ID.
 - `destroy_protected` (Boolean) Mark the instance as protected, the Exoscale API will refuse to delete the instance until the protection is removed (boolean; default: `false`).
 - `elastic_ip_ids` (Set of String) A list of [exoscale_elastic_ip](./elastic_ip.md) (IDs) to attach to the instance.
+- `enable_secure_boot` (Boolean) Indicates whether secure boot is enabled for the instance.
+- `enable_tpm` (Boolean) Indicates whether tpm is enabled for the instance.
 - `ipv6` (Boolean) Enable IPv6 on the instance (boolean; default: `false`).
 - `labels` (Map of String) A map of key/value labels.
 - `network_interface` (Block Set) Private network interfaces (may be specified multiple times). Structure is documented below. (see [below for nested schema](#nestedblock--network_interface))

--- a/pkg/resources/instance/attributes.go
+++ b/pkg/resources/instance/attributes.go
@@ -11,6 +11,8 @@ const (
 	AttrDestroyProtected      = "destroy_protected"
 	AttrDiskSize              = "disk_size"
 	AttrElasticIPIDs          = "elastic_ip_ids"
+	AttrEnableSecureBoot      = "enable_secure_boot"
+	AttrEnableTPM             = "enable_tpm"
 	AttrID                    = "id"
 	AttrIPv6                  = "ipv6"
 	AttrIPv6Address           = "ipv6_address"

--- a/pkg/resources/instance/datasource.go
+++ b/pkg/resources/instance/datasource.go
@@ -54,7 +54,7 @@ func DataSourceSchema() map[string]*schema.Schema {
 			Computed:    true,
 		},
 		AttrEnableTPM: {
-			Description: "Indicates if the instance has tpm enabled.",
+			Description: "Indicates if the instance has TPM enabled.",
 			Type:        schema.TypeBool,
 			Computed:    true,
 		},

--- a/pkg/resources/instance/datasource.go
+++ b/pkg/resources/instance/datasource.go
@@ -48,6 +48,16 @@ func DataSourceSchema() map[string]*schema.Schema {
 			Set:         schema.HashString,
 			Elem:        &schema.Schema{Type: schema.TypeString},
 		},
+		AttrEnableSecureBoot: {
+			Description: "Indicates if the instance has secure boot enabled.",
+			Type:        schema.TypeBool,
+			Computed:    true,
+		},
+		AttrEnableTPM: {
+			Description: "Indicates if the instance has tpm enabled.",
+			Type:        schema.TypeBool,
+			Computed:    true,
+		},
 		AttrID: {
 			Description: "The compute instance ID to match (conflicts with `name`).",
 			Type:        schema.TypeString,
@@ -274,6 +284,8 @@ func dsBuildData(instance *v3.Instance, zone string) (map[string]interface{}, er
 	data[AttrName] = instance.Name
 	data[AttrState] = instance.State
 	data[AttrZone] = zone
+	data[AttrEnableSecureBoot] = instance.SecurebootEnabled
+	data[AttrEnableTPM] = instance.TpmEnabled
 
 	data[AttrIPv6] = func() bool { return instance.PublicIPAssignment == v3.PublicIPAssignmentDual }()
 

--- a/pkg/resources/instance/resource.go
+++ b/pkg/resources/instance/resource.go
@@ -58,13 +58,13 @@ func Resource() *schema.Resource {
 			Elem:        &schema.Schema{Type: schema.TypeString},
 		},
 		AttrEnableSecureBoot: {
-			Description: "Enable secure boot on the instance (boolean; default: `false`). Can not be changed after instance is created.",
+			Description: "Enable secure boot on the instance (boolean; default: `false`). Can not be changed after the creation.",
 			Type:        schema.TypeBool,
 			Optional:    true,
 			ForceNew:    true,
 		},
 		AttrEnableTPM: {
-			Description: "Enable TPM on the instance (boolean; default: `false`). Can not be disabled after the creation. **WARNING**: updating this attribute stops/restarts the instance.",
+			Description: "Enable TPM on the instance (boolean; default: `false`). Can not be disabled after the creation. **WARNING**: enabling this attribute stops/restarts the instance.",
 			Type:        schema.TypeBool,
 			Optional:    true,
 			Default:     false,
@@ -809,11 +809,11 @@ func rUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag
 			return diag.Errorf("unable to scale down the disk size, use size > %v", instance.DiskSize)
 		}
 
-		// Compute instance scaling/disk resizing/tpm enabling API operations requires the instance to be stopped.
+		// Compute instance scaling/disk resizing/TPM enabling API operations requires the instance to be stopped.
 		if d.Get(AttrState) == "stopped" ||
 			d.HasChange(AttrDiskSize) ||
 			d.HasChange(AttrType) ||
-			d.HasChange(AttrEnableTPM) {
+			(d.HasChange(AttrEnableTPM) && d.Get(AttrEnableTPM).(bool)) {
 			op, err := client.StopInstance(ctx, instance.ID)
 			if err != nil {
 				return diag.Errorf("unable to stop instance: %s", err)
@@ -863,7 +863,7 @@ func rUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag
 					return diag.Errorf("unable to enable TPM: %s", err)
 				}
 			} else {
-				return diag.Errorf("TPM can't be disabled: %s", err)
+				return diag.Errorf("TPM can't be disabled")
 			}
 		}
 

--- a/pkg/resources/instance/resource.go
+++ b/pkg/resources/instance/resource.go
@@ -857,7 +857,7 @@ func rUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag
 			if d.Get(AttrEnableTPM).(bool) {
 				op, err := client.EnableTpm(ctx, instance.ID)
 				if err != nil {
-					return diag.Errorf("unable to enable TPM: %s", err)
+					return diag.Errorf("failed to enable TPM: %s", err)
 				}
 				if _, err = client.Wait(ctx, op, v3.OperationStateSuccess); err != nil {
 					return diag.Errorf("failed to enable TPM: %s", err)

--- a/pkg/resources/instance/resource.go
+++ b/pkg/resources/instance/resource.go
@@ -284,6 +284,16 @@ func rCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag
 		instanceRequest.PublicIPAssignment = v3.PublicIPAssignment(t)
 	}
 
+	if enableTPM, ok := d.GetOk(AttrEnableTPM); ok {
+		tpmEnabledBool := enableTPM.(bool)
+		instanceRequest.TpmEnabled = &tpmEnabledBool
+	}
+
+	if enableSecureBoot, ok := d.GetOk(AttrEnableSecureBoot); ok {
+		secureBootEnabledBool := enableSecureBoot.(bool)
+		instanceRequest.SecurebootEnabled = &secureBootEnabledBool
+	}
+
 	if l, ok := d.GetOk(AttrLabels); ok {
 		labels := make(map[string]string)
 		for k, v := range l.(map[string]interface{}) {

--- a/pkg/resources/instance/resource.go
+++ b/pkg/resources/instance/resource.go
@@ -57,6 +57,18 @@ func Resource() *schema.Resource {
 			Set:         schema.HashString,
 			Elem:        &schema.Schema{Type: schema.TypeString},
 		},
+		AttrEnableSecureBoot: {
+			Description: "Enable secure boot on the instancs (boolean; default: `false`).",
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     false,
+		},
+		AttrEnableTPM: {
+			Description: "Enable TPM on the instance (boolean; default: `false`).",
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     false,
+		},
 		AttrIPv6: {
 			Description: "Enable IPv6 on the instance (boolean; default: `false`).",
 			Type:        schema.TypeBool,

--- a/pkg/resources/instance/resource.go
+++ b/pkg/resources/instance/resource.go
@@ -860,7 +860,7 @@ func rUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag
 					return diag.Errorf("unable to enable TPM: %s", err)
 				}
 				if _, err = client.Wait(ctx, op, v3.OperationStateSuccess); err != nil {
-					return diag.Errorf("unable to enable TPM: %s", err)
+					return diag.Errorf("failed to enable TPM: %s", err)
 				}
 			} else {
 				return diag.Errorf("TPM can't be disabled")

--- a/pkg/resources/instance/resource_test.go
+++ b/pkg/resources/instance/resource_test.go
@@ -83,6 +83,8 @@ resource "exoscale_compute_instance" "test" {
   disk_size               = %d
   template_id             = data.exoscale_template.ubuntu.id
   ipv6                    = true
+  enable_tpm			  = true
+  enable_secure_boot	  = true
   anti_affinity_group_ids = [exoscale_anti_affinity_group.test.id]
   security_group_ids      = [
     data.exoscale_security_group.default.id,
@@ -165,6 +167,8 @@ resource "exoscale_compute_instance" "test" {
   disk_size               = %d
   template_id             = data.exoscale_template.ubuntu.id
   ipv6                    = true
+  enable_tpm			  = true
+  enable_secure_boot	  = true
   anti_affinity_group_ids = [exoscale_anti_affinity_group.test.id]
   security_group_ids      = [data.exoscale_security_group.default.id]
   elastic_ip_ids          = []
@@ -240,6 +244,8 @@ resource "exoscale_compute_instance" "test" {
   disk_size               = %d
   template_id             = data.exoscale_template.ubuntu.id
   ipv6                    = true
+  enable_tpm			  = true
+  enable_secure_boot	  = true
   anti_affinity_group_ids = [exoscale_anti_affinity_group.test.id]
   security_group_ids      = [data.exoscale_security_group.default.id]
   elastic_ip_ids          = []
@@ -314,6 +320,8 @@ resource "exoscale_compute_instance" "test" {
   disk_size               = %d
   template_id             = data.exoscale_template.ubuntu.id
   ipv6                    = true
+  enable_tpm			  = true
+  enable_secure_boot	  = true
   anti_affinity_group_ids = [exoscale_anti_affinity_group.test.id]
   security_group_ids      = [data.exoscale_security_group.default.id]
   elastic_ip_ids          = []
@@ -516,6 +524,8 @@ func testResource(t *testing.T) {
 						instance.AttrElasticIPIDs + ".#":         testutils.ValidateString("1"),
 						instance.AttrIPv6:                        testutils.ValidateString("true"),
 						instance.AttrIPv6Address:                 validation.ToDiagFunc(validation.IsIPv6Address),
+						instance.AttrEnableTPM:                   testutils.ValidateString("true"),
+						instance.AttrEnableSecureBoot:            testutils.ValidateString("true"),
 						instance.AttrLabels + ".test":            testutils.ValidateString(rLabelValue),
 						instance.AttrName:                        testutils.ValidateString(rName),
 						instance.AttrMACAddress:                  validation.ToDiagFunc(validation.NoZeroValues),


### PR DESCRIPTION
# Description
Support for [TPM](https://openapi-v2.exoscale.com/operation/operation-create-instance#operation-create-instance-body-application-json-tpm-enabled) and [SecureBoot](https://openapi-v2.exoscale.com/operation/operation-create-instance#operation-create-instance-body-application-json-secureboot-enabled) flags for compute_instance

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Acceptance tests OK
* [x] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing


```
# Providers
# -> providers.tf

# Customizable parameters
locals {
  my_zone = "ch-gva-2"
}

data "exoscale_template" "my_template" {
  zone = "ch-gva-2"
  name = "Linux Ubuntu 22.04 LTS 64-bit"
}

resource "exoscale_compute_instance" "my_instance" {
  zone = "ch-gva-2"
  name = "my-instance-ho"
  enable_tpm = true
  enable_secure_boot = true

  template_id = data.exoscale_template.my_template.id
  type        = "standard.medium"
  disk_size   = 10
}
```

**CREATING**

```
terraform apply

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # exoscale_compute_instance.my_instance will be created
  + resource "exoscale_compute_instance" "my_instance" {
      + created_at          = (known after apply)
      + disk_size           = 10
      + enable_secure_boot  = true
      + enable_tpm          = true
      + id                  = (known after apply)
      + ipv6                = false
      + ipv6_address        = (known after apply)
      + mac_address         = (known after apply)
      + name                = "my-instance-ho"
      + private             = false
      + private_network_ids = (known after apply)
      + public_ip_address   = (known after apply)
      + state               = (known after apply)
      + template_id         = "f9950b1f-8c1b-4957-8be5-22061a0a3a0b"
      + type                = "standard.medium"
      + zone                = "ch-gva-2"
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

exoscale_compute_instance.my_instance: Creating...
exoscale_compute_instance.my_instance: Still creating... [10s elapsed]
exoscale_compute_instance.my_instance: Creation complete after 13s [id=240e7f09-5d1b-415a-b230-afe7a37bf693]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

<img width="1498" height="817" alt="Screenshot 2025-07-21 at 14 45 46" src="https://github.com/user-attachments/assets/bb0e87bc-a81d-44ab-bb7a-4704ccafbdd0" />

**ENABLING TPM**
```
 exoscale/terraform  terraform apply

data.exoscale_template.my_template: Reading...
data.exoscale_template.my_template: Read complete after 1s [id=f9950b1f-8c1b-4957-8be5-22061a0a3a0b]
exoscale_compute_instance.my_instance: Refreshing state... [id=a53f01f2-597b-417d-8196-174cda068b23]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # exoscale_compute_instance.my_instance will be updated in-place
  ~ resource "exoscale_compute_instance" "my_instance" {
      ~ enable_tpm          = false -> true
        id                  = "a53f01f2-597b-417d-8196-174cda068b23"
        name                = "my-instance"
      ~ security_group_ids  = [
          - "757ee92c-d1a5-4161-bb7c-4adebe3d388d",
        ]
        # (16 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

exoscale_compute_instance.my_instance: Modifying... [id=a53f01f2-597b-417d-8196-174cda068b23]
exoscale_compute_instance.my_instance: Still modifying... [id=a53f01f2-597b-417d-8196-174cda068b23, 10s elapsed]
exoscale_compute_instance.my_instance: Still modifying... [id=a53f01f2-597b-417d-8196-174cda068b23, 20s elapsed]
exoscale_compute_instance.my_instance: Modifications complete after 26s [id=a53f01f2-597b-417d-8196-174cda068b23]
```

**DISABLING TPM**

```
exoscale/terraform  terraform apply

data.exoscale_template.my_template: Reading...
data.exoscale_template.my_template: Read complete after 1s [id=f9950b1f-8c1b-4957-8be5-22061a0a3a0b]
exoscale_compute_instance.my_instance: Refreshing state... [id=43e251de-0da7-4022-a0ec-ee2e99bb9cba]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # exoscale_compute_instance.my_instance will be updated in-place
  ~ resource "exoscale_compute_instance" "my_instance" {
      ~ enable_tpm          = true -> false
        id                  = "43e251de-0da7-4022-a0ec-ee2e99bb9cba"
        name                = "my-instance"
        # (17 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

exoscale_compute_instance.my_instance: Modifying... [id=43e251de-0da7-4022-a0ec-ee2e99bb9cba]
╷
│ Error: TPM can't be disabled
│
│   with exoscale_compute_instance.my_instance,
│   on main.tf line 14, in resource "exoscale_compute_instance" "my_instance":
│   14: resource "exoscale_compute_instance" "my_instance" {
│
╵
```

**ENABLING_SECURE_BOOT**

```
exoscale/terraform  terraform apply
data.exoscale_template.my_template: Reading...
data.exoscale_template.my_template: Read complete after 1s [id=f9950b1f-8c1b-4957-8be5-22061a0a3a0b]
exoscale_compute_instance.my_instance: Refreshing state... [id=43e251de-0da7-4022-a0ec-ee2e99bb9cba]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
-/+ destroy and then create replacement

Terraform will perform the following actions:

  # exoscale_compute_instance.my_instance must be replaced
-/+ resource "exoscale_compute_instance" "my_instance" {
      ~ created_at          = "2025-08-12 11:24:52 +0000 UTC" -> (known after apply)
      ~ enable_secure_boot  = false -> true # forces replacement
      ~ enable_tpm          = true -> false
      ~ id                  = "43e251de-0da7-4022-a0ec-ee2e99bb9cba" -> (known after apply)
      + ipv6_address        = (known after apply)
      - labels              = {} -> null
      ~ mac_address         = "06:f1:d6:00:00:6b" -> (known after apply)
        name                = "my-instance"
      ~ private_network_ids = [] -> (known after apply)
      ~ public_ip_address   = "159.100.241.212" -> (known after apply)
      - security_group_ids  = [] -> null
      - ssh_keys            = [] -> null
      ~ state               = "running" -> (known after apply)
        # (8 unchanged attributes hidden)
    }

Plan: 1 to add, 0 to change, 1 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

exoscale_compute_instance.my_instance: Destroying... [id=43e251de-0da7-4022-a0ec-ee2e99bb9cba]
exoscale_compute_instance.my_instance: Destruction complete after 4s
exoscale_compute_instance.my_instance: Creating...
exoscale_compute_instance.my_instance: Still creating... [10s elapsed]
exoscale_compute_instance.my_instance: Creation complete after 10s [id=b7b5a18e-9c79-4f4e-b7da-6691daa5222c]

Apply complete! Resources: 1 added, 0 changed, 1 destroyed.
```

**DISABLING SECURE_BOOT**

```
exoscale/terraform  terraform apply
data.exoscale_template.my_template: Reading...
data.exoscale_template.my_template: Read complete after 1s [id=f9950b1f-8c1b-4957-8be5-22061a0a3a0b]
exoscale_compute_instance.my_instance: Refreshing state... [id=b7b5a18e-9c79-4f4e-b7da-6691daa5222c]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
-/+ destroy and then create replacement

Terraform will perform the following actions:

  # exoscale_compute_instance.my_instance must be replaced
-/+ resource "exoscale_compute_instance" "my_instance" {
      ~ created_at          = "2025-08-12 11:45:46 +0000 UTC" -> (known after apply)
      ~ enable_secure_boot  = true -> false # forces replacement
      ~ id                  = "b7b5a18e-9c79-4f4e-b7da-6691daa5222c" -> (known after apply)
      + ipv6_address        = (known after apply)
      - labels              = {} -> null
      ~ mac_address         = "06:86:2e:00:00:6b" -> (known after apply)
        name                = "my-instance"
      ~ private_network_ids = [] -> (known after apply)
      ~ public_ip_address   = "159.100.241.212" -> (known after apply)
      - security_group_ids  = [
          - "757ee92c-d1a5-4161-bb7c-4adebe3d388d",
        ] -> null
      - ssh_keys            = [] -> null
      ~ state               = "running" -> (known after apply)
        # (9 unchanged attributes hidden)
    }

Plan: 1 to add, 0 to change, 1 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

exoscale_compute_instance.my_instance: Destroying... [id=b7b5a18e-9c79-4f4e-b7da-6691daa5222c]
exoscale_compute_instance.my_instance: Destruction complete after 6s
exoscale_compute_instance.my_instance: Creating...
exoscale_compute_instance.my_instance: Still creating... [10s elapsed]
exoscale_compute_instance.my_instance: Creation complete after 10s [id=16c98b85-960c-4eb8-8924-fcf8d64e0697]

Apply complete! Resources: 1 added, 0 changed, 1 destroyed.
```