### PR TITLE
Fix regression in instance_pool ds when matching by name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ IMPROVEMENTS:
 
 - Bump egoscale 3.1.25 (retryable HTTP client for v3) #454
 
+BUG FIXES:
+
+- Fix regression in instance_pool ds when matching by name #455
+
 ## 0.65.0
 
 BREAKING CHANGES:

--- a/exoscale/provider_test.go
+++ b/exoscale/provider_test.go
@@ -20,7 +20,7 @@ const (
 	testPrefix                     = "test-terraform-exoscale"
 	testDescription                = "Created by the terraform-exoscale provider"
 	testZoneName                   = "bg-sof-1"
-	testInstanceTemplateName       = "Linux Ubuntu 20.04 LTS 64-bit"
+	testInstanceTemplateName       = "Linux Ubuntu 22.04 LTS 64-bit"
 	testInstanceTemplateUsername   = "ubuntu"
 	testInstanceTemplateFilter     = "featured"
 	testInstanceTemplateVisibility = "public"

--- a/pkg/resources/instance/datasource_list_test.go
+++ b/pkg/resources/instance/datasource_list_test.go
@@ -29,7 +29,7 @@ locals {
 }
 data "exoscale_template" "ubuntu" {
   zone = local.zone
-  name = "Linux Ubuntu 20.04 LTS 64-bit"
+  name = "Linux Ubuntu 22.04 LTS 64-bit"
 }
 resource "exoscale_security_group" "test" {
   name = "%s"

--- a/pkg/resources/instance/datasource_test.go
+++ b/pkg/resources/instance/datasource_test.go
@@ -34,7 +34,7 @@ locals {
 
 data "exoscale_template" "ubuntu" {
   zone = local.zone
-  name = "Linux Ubuntu 20.04 LTS 64-bit"
+  name = "Linux Ubuntu 22.04 LTS 64-bit"
 }
 
 resource "exoscale_security_group" "test" {

--- a/pkg/resources/instance/resource_test.go
+++ b/pkg/resources/instance/resource_test.go
@@ -46,7 +46,7 @@ locals {
 
 data "exoscale_template" "ubuntu" {
   zone = local.zone
-  name = "Linux Ubuntu 20.04 LTS 64-bit"
+  name = "Linux Ubuntu 22.04 LTS 64-bit"
 }
 
 data "exoscale_security_group" "default" {
@@ -128,7 +128,7 @@ locals {
 
 data "exoscale_template" "ubuntu" {
   zone = local.zone
-  name = "Linux Ubuntu 20.04 LTS 64-bit"
+  name = "Linux Ubuntu 22.04 LTS 64-bit"
 }
 
 data "exoscale_security_group" "default" {
@@ -203,7 +203,7 @@ locals {
 
 data "exoscale_template" "ubuntu" {
   zone = local.zone
-  name = "Linux Ubuntu 20.04 LTS 64-bit"
+  name = "Linux Ubuntu 22.04 LTS 64-bit"
 }
 
 data "exoscale_security_group" "default" {
@@ -277,7 +277,7 @@ locals {
 
 data "exoscale_template" "ubuntu" {
   zone = local.zone
-  name = "Linux Ubuntu 20.04 LTS 64-bit"
+  name = "Linux Ubuntu 22.04 LTS 64-bit"
 }
 
 data "exoscale_security_group" "default" {
@@ -350,7 +350,7 @@ locals {
 
 data "exoscale_template" "ubuntu" {
   zone = local.zone
-  name = "Linux Ubuntu 20.04 LTS 64-bit"
+  name = "Linux Ubuntu 22.04 LTS 64-bit"
 }
 
 data "exoscale_security_group" "default" {
@@ -396,7 +396,7 @@ locals {
 
 data "exoscale_template" "ubuntu" {
   zone = local.zone
-  name = "Linux Ubuntu 20.04 LTS 64-bit"
+  name = "Linux Ubuntu 22.04 LTS 64-bit"
 }
 
 data "exoscale_security_group" "default" {

--- a/pkg/resources/instance_pool/datasource.go
+++ b/pkg/resources/instance_pool/datasource.go
@@ -222,21 +222,20 @@ func dsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.
 			ctx,
 			v3.UUID(id.(string)),
 		)
+		if err != nil {
+			return diag.FromErr(err)
+		}
 	} else {
 		rep, err := client.ListInstancePools(ctx)
-		if err == nil {
+		if err != nil {
 			return diag.FromErr(err)
 		}
 
 		p, err := rep.FindInstancePool(name.(string))
-		if err == nil {
+		if err != nil {
 			return diag.FromErr(err)
 		}
 		pool = &p
-	}
-
-	if err != nil {
-		return diag.FromErr(err)
 	}
 
 	d.SetId(pool.ID.String())
@@ -277,7 +276,7 @@ func dsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.
 			}
 
 			instancesData[k] = map[string]interface{}{
-				AttrInstanceID:              id,
+				AttrInstanceID:              i.ID,
 				AttrInstanceIPv6Address:     ipv6,
 				AttrInstanceName:            instance.Name,
 				AttrInstancePublicIPAddress: publicIp,

--- a/pkg/resources/instance_pool/datasource_list_test.go
+++ b/pkg/resources/instance_pool/datasource_list_test.go
@@ -29,7 +29,7 @@ locals {
 }
 data "exoscale_template" "ubuntu" {
   zone = local.zone
-  name = "Linux Ubuntu 20.04 LTS 64-bit"
+  name = "Linux Ubuntu 22.04 LTS 64-bit"
 }
 resource "exoscale_instance_pool" "test1" {
   zone = local.zone

--- a/pkg/resources/instance_pool/datasource_test.go
+++ b/pkg/resources/instance_pool/datasource_test.go
@@ -87,6 +87,11 @@ resource "exoscale_instance_pool" "test" {
 data "exoscale_instance_pool" "by-id" {
   zone = exoscale_instance_pool.test.zone
   id   = exoscale_instance_pool.test.id
+}
+
+data "exoscale_instance_pool" "by-name" {
+  zone = exoscale_instance_pool.test.zone
+  name   = exoscale_instance_pool.test.name
 }`,
 					testutils.TestZoneName,
 					dsTemplateName,
@@ -104,6 +109,28 @@ data "exoscale_instance_pool" "by-id" {
 				),
 				Check: resource.ComposeTestCheckFunc(
 					dsCheckAttrs("data.exoscale_instance_pool.by-id", testutils.TestAttrs{
+						"anti_affinity_group_ids.#": testutils.ValidateString("1"),
+						"anti_affinity_group_ids.0": validation.ToDiagFunc(validation.IsUUID),
+						"description":               testutils.ValidateString(dsDescription),
+						"disk_size":                 testutils.ValidateString(dsDiskSize),
+						"instance_type":             utils.ValidateComputeInstanceType,
+						"instance_prefix":           testutils.ValidateString(dsInstancePrefix),
+						"key_pair":                  testutils.ValidateString(dsKeyPair),
+						"labels.test":               testutils.ValidateString(dsLabelValue),
+						"id":                        validation.ToDiagFunc(validation.IsUUID),
+						"name":                      testutils.ValidateString(dsName),
+						"network_ids.#":             testutils.ValidateString("1"),
+						"network_ids.0":             validation.ToDiagFunc(validation.IsUUID),
+						"size":                      testutils.ValidateString(dsSize),
+						// NOTE: state is unreliable atm, improvement suggested in 54808
+						// "state":                testutils.ValidateString("running"),
+						"template_id":    validation.ToDiagFunc(validation.IsUUID),
+						"user_data":      testutils.ValidateString(dsUserData),
+						"instances.#":    testutils.ValidateString("2"),
+						"instances.0.id": validation.ToDiagFunc(validation.IsUUID),
+						"instances.1.id": validation.ToDiagFunc(validation.IsUUID),
+					}),
+					dsCheckAttrs("data.exoscale_instance_pool.by-name", testutils.TestAttrs{
 						"anti_affinity_group_ids.#": testutils.ValidateString("1"),
 						"anti_affinity_group_ids.0": validation.ToDiagFunc(validation.IsUUID),
 						"description":               testutils.ValidateString(dsDescription),

--- a/pkg/resources/instance_pool/resource_test.go
+++ b/pkg/resources/instance_pool/resource_test.go
@@ -46,7 +46,7 @@ locals {
 
 data "exoscale_template" "ubuntu" {
   zone = local.zone
-  name = "Linux Ubuntu 20.04 LTS 64-bit"
+  name = "Linux Ubuntu 22.04 LTS 64-bit"
 }
 
 data "exoscale_security_group" "default" {

--- a/pkg/testutils/testutils.go
+++ b/pkg/testutils/testutils.go
@@ -28,7 +28,7 @@ const (
 	TestUsername                   = "test-exo-username"
 	TestDescription                = "Created by the terraform-exoscale provider"
 	TestZoneName                   = "bg-sof-1"
-	TestInstanceTemplateName       = "Linux Ubuntu 20.04 LTS 64-bit"
+	TestInstanceTemplateName       = "Linux Ubuntu 22.04 LTS 64-bit"
 	TestInstanceTemplateUsername   = "ubuntu"
 	TestInstanceTemplateFilter     = "featured"
 	TestInstanceTemplateVisibility = "public"


### PR DESCRIPTION
# Description

* Fixes error handling on matching by name in ipool ds;
* Fixes instance ID in ipool ds `instances` list;
* Bumps Ubuntu template used by testing (20.04 -> 22.04).

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [ ] Acceptance tests OK
* [x] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing

```bash
$ TF_ACC=1 go test ./... -run 'TestInstancePool/DataSource$'
?       github.com/exoscale/terraform-provider-exoscale [no test files]
ok      github.com/exoscale/terraform-provider-exoscale/exoscale        0.061s [no tests to run]
?       github.com/exoscale/terraform-provider-exoscale/pkg/config      [no test files]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/filter      0.015s [no tests to run]
?       github.com/exoscale/terraform-provider-exoscale/pkg/general     [no test files]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/list        0.041s [no tests to run]
?       github.com/exoscale/terraform-provider-exoscale/pkg/provider    [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/provider/config     [no test files]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/anti_affinity_group       0.036s [no tests to run]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/block_storage     0.068s [no tests to run]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/database  0.024s [no tests to run]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/iam       0.023s [no tests to run]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/instance  0.018s [no tests to run]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/instance_pool     69.207s
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/nlb_service       0.015s [no tests to run]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/sos_bucket_policy 0.019s [no tests to run]
?       github.com/exoscale/terraform-provider-exoscale/pkg/resources/zones     [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/sos [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/testutils   [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/utils       [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/validators  [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/version     [no test files]
?       github.com/exoscale/terraform-provider-exoscale/version [no test files]
```