### PR TITLE
fix a bug with "enable-kube-proxy" flag in SKS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ IMPROVEMENTS:
 BUG FIXES:
 
 - Fix regression in instance_pool ds when matching by name #455
+- Fix bug in SKS: `enable_kube_proxy` is always `true` #457
 
 ## 0.65.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ BUG FIXES:
 
 - Update the database opensearch test to use latest major version #462
 - Make instance.ssh_key(s) force resource replace #461
+- Fix bug in SKS: `enable_kube_proxy` is always `true` #457
 
 ## 0.65.1
 
@@ -22,7 +23,6 @@ IMPROVEMENTS:
 BUG FIXES:
 
 - Fix regression in instance_pool ds when matching by name #455
-- Fix bug in SKS: `enable_kube_proxy` is always `true` #457
 
 ## 0.65.0
 

--- a/exoscale/resource_exoscale_sks_cluster.go
+++ b/exoscale/resource_exoscale_sks_cluster.go
@@ -340,8 +340,8 @@ func resourceSKSClusterCreate(ctx context.Context, d *schema.ResourceData, meta 
 		createReq.AutoUpgrade = &autoUpgrade
 	}
 
-	if enableKubeProxy, isSet := d.GetOk(resSKSClusterAttrEnableKubeProxy); isSet {
-		v := enableKubeProxy.(bool)
+	if !d.GetRawConfig().GetAttr("enable_kube_proxy").IsNull() {
+		v := d.Get(resSKSClusterAttrEnableKubeProxy).(bool)
 		createReq.EnableKubeProxy = &v
 	}
 

--- a/exoscale/resource_exoscale_sks_cluster.go
+++ b/exoscale/resource_exoscale_sks_cluster.go
@@ -340,7 +340,7 @@ func resourceSKSClusterCreate(ctx context.Context, d *schema.ResourceData, meta 
 		createReq.AutoUpgrade = &autoUpgrade
 	}
 
-	if !d.GetRawConfig().GetAttr("enable_kube_proxy").IsNull() {
+	if !d.GetRawConfig().GetAttr(resSKSClusterAttrEnableKubeProxy).IsNull() {
 		v := d.Get(resSKSClusterAttrEnableKubeProxy).(bool)
 		createReq.EnableKubeProxy = &v
 	}


### PR DESCRIPTION
# Description

`enable_kube_proxy` flag always set to true on SKS cluster creation.

...

seems like `d.GetOk()` for boolean fields treats false as "not set"

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Acceptance tests OK
* [ ] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing

main.tf
```
# Providers
# -> providers.tf

# Customizable parameters
locals {
  my_zone = "ch-gva-2"
}

data "exoscale_template" "my_template" {
  zone = "ch-gva-2"
  name = "Linux Ubuntu 22.04 LTS 64-bit"
}

resource "exoscale_sks_cluster" "kube-proxyless" {
  zone              = "ch-gva-2"
  name              = "kube-proxyless"
  version           = ""
  cni               = "calico"
  service_level     = "pro"
  auto_upgrade      = true
  exoscale_csi      = true
  exoscale_ccm      = true
  metrics_server    = true
  enable_kube_proxy = false
}
```

```
terraform apply

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # exoscale_sks_cluster.kube-proxyless will be created
  + resource "exoscale_sks_cluster" "kube-proxyless" {
      + addons            = (known after apply)
      + aggregation_ca    = (known after apply)
      + auto_upgrade      = true
      + cni               = "calico"
      + control_plane_ca  = (known after apply)
      + created_at        = (known after apply)
      + enable_kube_proxy = false
      ...

      + oidc (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```
========>>
```
restish root-api-preprod sks-get d85df96f-46d5-413e-8b94-050dfdecfeaf

{
  addons: [
    "exoscale-cloud-controller"
    "exoscale-container-storage-interface"
    "metrics-server"
  ]
  auto-upgrade: true
  cluster-cidr: "192.168.0.0/16"
  cni: "calico"
  created-at: "2025-08-28T07:01:21Z"
  default-security-group-id: null
  enable-kube-proxy: false
  ...
  ```

ENABLING:

maint.tf
```
resource "exoscale_sks_cluster" "kube-proxyless" {
  zone              = "ch-gva-2"
  name              = "kube-proxy"
  version           = ""
  cni               = "calico"
  service_level     = "pro"
  auto_upgrade      = true
  exoscale_csi      = true
  exoscale_ccm      = true
  metrics_server    = true
  enable_kube_proxy = true 
}
```

```
terraform apply

data.exoscale_template.my_template: Reading...
exoscale_sks_cluster.kube-proxyless: Refreshing state... [id=d85df96f-46d5-413e-8b94-050dfdecfeaf]
data.exoscale_template.my_template: Read complete after 1s [id=17d57a55-c3e4-418a-b518-df67c9399225]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
-/+ destroy and then create replacement

Terraform will perform the following actions:

  # exoscale_sks_cluster.kube-proxyless must be replaced
-/+ resource "exoscale_sks_cluster" "kube-proxyless" {
      ...
            -----BEGIN CERTIFICATE-----
            MIIGBjCCA+6gAwIBAgIUEdmFSYyTsi2kbwCanuNLUrZoth4wDQYJKoZIhvcNAQEL
            PFmO4OktXyE03N4E7B8/osmVdGVTODsX/SbzhHa7IpAKIdfClY5La+v4zaitF2Di
            9YvRvSh7/zK1nw==
            -----END CERTIFICATE-----
        EOT -> (known after apply)
      ~ created_at        = "2025-08-28 07:01:21 +0000 UTC" -> (known after apply)
      ~ enable_kube_proxy = false -> true # forces replacement
      ~ endpoint          = "d85df96f-46d5-413e-8b94-050dfdecfeaf.ppsks-ch-gva-2.exo.io" -> (known after apply)
      - feature_gates     = [] -> null
      ~ id                = "d85df96f-46d5-413e-8b94-050dfdecfeaf" -> (known after apply)
      ...
    }

Plan: 1 to add, 0 to change, 1 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes
  ```
  
========>>
  
  ```
  restish root-api-preprod sks-get 7dac036f-19b5-41c3-bdd4-428a212e3635

{
  addons: [
    "exoscale-cloud-controller"
    "exoscale-container-storage-interface"
    "metrics-server"
  ]
  auto-upgrade: true
  cluster-cidr: "192.168.0.0/16"
  cni: "calico"
  created-at: "2025-08-28T07:43:59Z"
  default-security-group-id: null
  enable-kube-proxy: true
  enable-operators-ca: true
  endpoint: "7dac036f-19b5-41c3-bdd4-428a212e3635.ppsks-ch-gva-2.exo.io"
  exoscale.entity/zone: {
 ...
}
```

Default value:

main.tf

```
# Providers
# -> providers.tf

# Customizable parameters
locals {
  my_zone = "ch-gva-2"
}

data "exoscale_template" "my_template" {
  zone = "ch-gva-2"
  name = "Linux Ubuntu 22.04 LTS 64-bit"
}

resource "exoscale_sks_cluster" "kube-proxyless" {
  zone              = "ch-gva-2"
  name              = "kube-proxy"
  version           = ""
  cni               = "calico"
  service_level     = "pro"
  auto_upgrade      = true
  exoscale_csi      = true
  exoscale_ccm      = true
  metrics_server    = true
}
```

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # exoscale_sks_cluster.kube-proxyless will be created
  + resource "exoscale_sks_cluster" "kube-proxyless" {
      + addons            = (known after apply)
      + aggregation_ca    = (known after apply)
      + auto_upgrade      = true
      + cni               = "calico"
      + control_plane_ca  = (known after apply)
      + created_at        = (known after apply)
      + enable_kube_proxy = (known after apply)
      + endpoint          = (known after apply)
...

      + oidc (known after apply)
    }
```

========>>

```
restish root-api-preprod sks-get 2bbe1b85-6658-4714-aac1-3320cde82fd6

{
  addons: [
    "exoscale-cloud-controller"
    "exoscale-container-storage-interface"
    "metrics-server"
  ]
  auto-upgrade: true
  cluster-cidr: "192.168.0.0/16"
  cni: "calico"
  created-at: "2025-08-28T10:09:24Z"
  default-security-group-id: null
  enable-kube-proxy: true
  enable-operators-ca: true
  endpoint: "2bbe1b85-6658-4714-aac1-3320cde82fd6.ppsks-ch-gva-2.exo.io"
 ...
}
```
