### PR TITLE
fix: add cilium security group rules to sks example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+IMPROVEMENTS:
+
+- Add example rules for sks cilium CNI
+
 ## 0.65.1
 
 IMPROVEMENTS:

--- a/examples/sks/main.tf
+++ b/examples/sks/main.tf
@@ -40,6 +40,7 @@ resource "exoscale_security_group_rule" "kubelet" {
   user_security_group_id = exoscale_security_group.my_sks_security_group.id
 }
 
+# mandatory rules for Calico CNI (default)
 resource "exoscale_security_group_rule" "calico_vxlan" {
   security_group_id = exoscale_security_group.my_sks_security_group.id
   description       = "VXLAN (Calico)"
@@ -50,6 +51,40 @@ resource "exoscale_security_group_rule" "calico_vxlan" {
   # (beetwen worker nodes only)
   user_security_group_id = exoscale_security_group.my_sks_security_group.id
 }
+
+# mandatory rules for Cilium CNI (default)
+# resource "exoscale_security_group_rule" "cilium_icmp_health" {
+#   security_group_id = exoscale_security_group.my_sks_security_group.id
+#   description       = "Cilium ICMP healthcheck"
+#   type              = "INGRESS"
+#   protocol          = "ICMP"
+#   icmp_type         = 8
+#   icmp_code         = 0
+#   # (beetwen worker nodes only)
+#   user_security_group_id = exoscale_security_group.my_sks_security_group.id
+# }
+
+# resource "exoscale_security_group_rule" "cilium_vxlan" {
+#   security_group_id = exoscale_security_group.my_sks_security_group.id
+#   description       = "VXLan (Cilium)"
+#   type              = "INGRESS"
+#   protocol          = "UDP"
+#   start_port        = 8472
+#   end_port          = 8472
+#   # (beetwen worker nodes only)
+#   user_security_group_id = exoscale_security_group.my_sks_security_group.id
+# }
+
+# resource "exoscale_security_group_rule" "cilium_udp_health" {
+#   security_group_id = exoscale_security_group.my_sks_security_group.id
+#   description       = "Cilium UDP healthcheck"
+#   type              = "INGRESS"
+#   protocol          = "UDP"
+#   start_port        = 4240
+#   end_port          = 4240
+#   # (beetwen worker nodes only)
+#   user_security_group_id = exoscale_security_group.my_sks_security_group.id
+# }
 
 resource "exoscale_security_group_rule" "nodeport_tcp" {
   security_group_id = exoscale_security_group.my_sks_security_group.id

--- a/examples/sks/main.tf
+++ b/examples/sks/main.tf
@@ -17,6 +17,9 @@ resource "exoscale_sks_cluster" "my_sks_cluster" {
   name         = "my-sks-cluster"
   auto_upgrade = true
   exoscale_csi = true
+  # The default cni is "calico", use the Cilium security group rules provided below if
+  # you change the cni to "cilium"
+  # cni = "cilium"
 }
 
 # (ad-hoc anti-affinity group)


### PR DESCRIPTION
# Description

Adding the Cilium CNI basic/mandatory rules in the SKS examples

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Acceptance tests OK (irrelevant here)
* [ ] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing

(it's only comments in an example)