### PR TITLE
detach instance before dropping a resource.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ BUG FIXES:
 - Update the database opensearch test to use latest major version #462
 - Make instance.ssh_key(s) force resource replace #461
 - Fix bug in SKS: `enable_kube_proxy` is always `true` #457
+- Fix bug with resouce detachment prior to deletion #460
 
 ## 0.65.1
 

--- a/exoscale/util.go
+++ b/exoscale/util.go
@@ -204,24 +204,27 @@ func detachMatchingResource(
 			return diag.FromErr(err)
 		}
 
-		if match(inst, resourceID) {
-			tflog.Debug(ctx,
-				fmt.Sprintf("Found instance with matching %s, detaching...", resourceType),
-				map[string]interface{}{
-					"instance_id": inst.ID,
-					"resource_id": resourceID,
-				},
-			)
+		if !match(inst, resourceID) {
+			continue
+		}
 
-			op, err := detach(ctx, client, resourceID, inst)
-			if err != nil {
-				return diag.FromErr(err)
-			}
+		tflog.Debug(ctx,
+			fmt.Sprintf("Found instance with matching %s, detaching...", resourceType),
+			map[string]interface{}{
+				"instance_id": inst.ID,
+				"resource_id": resourceID,
+			},
+		)
 
-			if _, err = client.Wait(ctx, op, v3.OperationStateSuccess); err != nil {
-				return diag.FromErr(err)
-			}
+		op, err := detach(ctx, client, resourceID, inst)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		if _, err = client.Wait(ctx, op, v3.OperationStateSuccess); err != nil {
+			return diag.FromErr(err)
 		}
 	}
+
 	return nil
 }

--- a/exoscale/util.go
+++ b/exoscale/util.go
@@ -1,14 +1,18 @@
 package exoscale
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"regexp"
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	egoscale "github.com/exoscale/egoscale/v2"
+	v3 "github.com/exoscale/egoscale/v3"
 )
 
 // in returns true if v is found in list.
@@ -175,6 +179,49 @@ func validateDNSLabel(label string) error {
 	if strings.HasPrefix(label, "-") || strings.HasSuffix(label, "-") {
 		return fmt.Errorf("DNS label cannot start or end with hyphen")
 	}
+	return nil
+}
 
+// This is an auxiliary function, aimed to extract a similar logic of detaching an instance
+// before dropping a resource
+func detachMatchingResource(
+	ctx context.Context,
+	client *v3.Client,
+	resourceType string,
+	resourceID v3.UUID,
+	match func(*v3.Instance, v3.UUID) bool,
+	detach func(ctx context.Context, client *v3.Client, id v3.UUID, instance *v3.Instance) (*v3.Operation, error),
+) diag.Diagnostics {
+
+	listInstancesResponse, err := client.ListInstances(ctx)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	for _, listInst := range listInstancesResponse.Instances {
+		inst, err := client.GetInstance(ctx, listInst.ID)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		if match(inst, resourceID) {
+			tflog.Debug(ctx,
+				fmt.Sprintf("Found instance with matching %s, detaching...", resourceType),
+				map[string]interface{}{
+					"instance_id": inst.ID,
+					"resource_id": resourceID,
+				},
+			)
+
+			op, err := detach(ctx, client, resourceID, inst)
+			if err != nil {
+				return diag.FromErr(err)
+			}
+
+			if _, err = client.Wait(ctx, op, v3.OperationStateSuccess); err != nil {
+				return diag.FromErr(err)
+			}
+		}
+	}
 	return nil
 }

--- a/pkg/resources/instance/resource.go
+++ b/pkg/resources/instance/resource.go
@@ -699,12 +699,27 @@ func rUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag
 				op, err := client.DetachInstanceFromElasticIP(
 					ctx,
 					v3.UUID(id.(string)),
-					v3.DetachInstanceFromElasticIPRequest{Instance: &v3.InstanceTarget{ID: instance.ID}},
+					v3.DetachInstanceFromElasticIPRequest{
+						Instance: &v3.InstanceTarget{ID: instance.ID},
+					},
 				)
 				if err != nil {
+					if errors.Is(err, v3.ErrNotFound) {
+						tflog.Debug(ctx, "ElasticIP already detached, ignoring", map[string]interface{}{
+							"id": id.(string),
+						})
+						continue
+					}
 					return diag.FromErr(err)
 				}
+
 				if _, err = client.Wait(ctx, op, v3.OperationStateSuccess); err != nil {
+					if errors.Is(err, v3.ErrNotFound) {
+						tflog.Debug(ctx, "ElasticIP detach operation already gone, ignoring", map[string]interface{}{
+							"id": id.(string),
+						})
+						continue
+					}
 					return diag.FromErr(err)
 				}
 			}
@@ -729,9 +744,22 @@ func rUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag
 					v3.DetachInstanceFromPrivateNetworkRequest{Instance: &v3.Instance{ID: instance.ID}},
 				)
 				if err != nil {
+					if errors.Is(err, v3.ErrNotFound) {
+						tflog.Debug(ctx, "Private Network already detached, ignoring", map[string]interface{}{
+							"id": nif.NetworkID,
+						})
+						continue
+					}
 					return diag.FromErr(err)
 				}
+
 				if _, err = client.Wait(ctx, op, v3.OperationStateSuccess); err != nil {
+					if errors.Is(err, v3.ErrNotFound) {
+						tflog.Debug(ctx, "Private Network detach operation already gone, ignoring", map[string]interface{}{
+							"id": nif.NetworkID,
+						})
+						continue
+					}
 					return diag.FromErr(err)
 				}
 			}
@@ -791,9 +819,22 @@ func rUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag
 					v3.DetachInstanceFromSecurityGroupRequest{Instance: &v3.Instance{ID: instance.ID}},
 				)
 				if err != nil {
+					if errors.Is(err, v3.ErrNotFound) {
+						tflog.Debug(ctx, "Security Group already detached, ignoring", map[string]interface{}{
+							"id": id.(string),
+						})
+						continue
+					}
 					return diag.FromErr(err)
 				}
+
 				if _, err = client.Wait(ctx, op, v3.OperationStateSuccess); err != nil {
+					if errors.Is(err, v3.ErrNotFound) {
+						tflog.Debug(ctx, "Security Group detach operation already gone, ignoring", map[string]interface{}{
+							"id": id.(string),
+						})
+						continue
+					}
 					return diag.FromErr(err)
 				}
 			}


### PR DESCRIPTION
# Description

Attempt to drop an attached resource results in error:

```
data.exoscale_template.my_template: Reading...
exoscale_security_group.my_security_group: Refreshing state... [id=be94748a-c115-4a2b-9780-382c572eb26e]
exoscale_private_network.my_managed_private_network: Refreshing state... [id=bc933c98-5eac-48b6-acbe-793927a432a2]
exoscale_elastic_ip.my_elastic_ip: Refreshing state... [id=5a30ca7d-b1e7-430a-a46a-c6ecefec4305]
exoscale_security_group_rule.my_security_group_rule: Refreshing state... [id=b2622040-e413-49ba-9143-65b8e0265f77]
data.exoscale_template.my_template: Read complete after 0s [id=b2d42d57-3ed3-40b9-ad7d-2eb9a2e72745]
exoscale_compute_instance.this: Refreshing state... [id=e2e09c60-426f-43c4-8f8c-93cfb28b28e4]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place
  - destroy
-/+ destroy and then create replacement

Terraform will perform the following actions:

  # exoscale_compute_instance.this will be updated in-place
  ~ resource "exoscale_compute_instance" "this" {
      ~ elastic_ip_ids      = [
          - "5a30ca7d-b1e7-430a-a46a-c6ecefec4305",
        ]
        id                  = "e2e09c60-426f-43c4-8f8c-93cfb28b28e4"
        name                = "bug-instance"
      ~ security_group_ids  = [
          - "be94748a-c115-4a2b-9780-382c572eb26e",
        ] -> (known after apply)
        # (15 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }

  # exoscale_elastic_ip.my_elastic_ip will be destroyed
  # (because exoscale_elastic_ip.my_elastic_ip is not in configuration)
  - resource "exoscale_elastic_ip" "my_elastic_ip" {
      - address_family = "inet4" -> null
      - cidr           = "194.182.169.25/32" -> null
      - id             = "5a30ca7d-b1e7-430a-a46a-c6ecefec4305" -> null
      - ip_address     = "194.182.169.25" -> null
      - labels         = {} -> null
      - zone           = "de-fra-1" -> null
        # (2 unchanged attributes hidden)
    }

  # exoscale_security_group.my_security_group must be replaced
-/+ resource "exoscale_security_group" "my_security_group" {
      ~ id          = "be94748a-c115-4a2b-9780-382c572eb26e" -> (known after apply)
      ~ name        = "bug-security-group" -> "bug-change-security-group" # forces replacement
        # (1 unchanged attribute hidden)
    }

  # exoscale_security_group_rule.my_security_group_rule must be replaced
-/+ resource "exoscale_security_group_rule" "my_security_group_rule" {
      ~ id                    = "b2622040-e413-49ba-9143-65b8e0265f77" -> (known after apply)
      + public_security_group = (known after apply)
      ~ security_group        = "bug-security-group" -> (known after apply)
      ~ security_group_id     = "be94748a-c115-4a2b-9780-382c572eb26e" -> (known after apply) # forces replacement
      + user_security_group   = (known after apply)
        # (6 unchanged attributes hidden)
    }

Plan: 2 to add, 1 to change, 3 to destroy.
exoscale_elastic_ip.my_elastic_ip: Destroying... [id=5a30ca7d-b1e7-430a-a46a-c6ecefec4305]
exoscale_security_group_rule.my_security_group_rule: Destroying... [id=b2622040-e413-49ba-9143-65b8e0265f77]
exoscale_security_group_rule.my_security_group_rule: Destruction complete after 3s
exoscale_security_group.my_security_group: Destroying... [id=be94748a-c115-4a2b-9780-382c572eb26e]
╷
│ Error: Delete "https://api-de-fra-1.exoscale.com/v2/elastic-ip/5a30ca7d-b1e7-430a-a46a-c6ecefec4305": invalid request: Allocated IP address can't be deleted
│ 
│ 
╵
╷
│ Error: Delete "https://api-ch-gva-2.exoscale.com/v2/security-group/be94748a-c115-4a2b-9780-382c572eb26e": invalid request: Cannot delete group when it's in use by virtual machines
│ 
│ 
╵
```

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Acceptance tests OK
* [ ] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place
  - destroy

Terraform will perform the following actions:

  # exoscale_compute_instance.this will be updated in-place
  ~ resource "exoscale_compute_instance" "this" {
      ~ elastic_ip_ids          = [
          - "82dc1591-d59e-4d33-ae96-8bdca924f50a",
        ]
        id                      = "2562e751-0a80-4159-9b3c-f8c988929bad"
        name                    = "bug-instance"
      ~ security_group_ids      = [
          - "71665399-b418-43a6-b504-c213ccb9b545",
        ]
        # (18 unchanged attributes hidden)

      - network_interface {
          - ip_address  = "10.0.0.21" -> null
          - mac_address = "0a:cd:68:1d:d4:74" -> null
          - network_id  = "e07f9cda-7339-494b-8a79-e2a66fe51308" -> null
        }
    }

  # exoscale_elastic_ip.my_elastic_ip will be destroyed
  # (because exoscale_elastic_ip.my_elastic_ip is not in configuration)
  - resource "exoscale_elastic_ip" "my_elastic_ip" {
      - address_family = "inet4" -> null
      - cidr           = "85.217.161.223/32" -> null
      - id             = "82dc1591-d59e-4d33-ae96-8bdca924f50a" -> null
      - ip_address     = "85.217.161.223" -> null
      - zone           = "ch-gva-2" -> null
        # (2 unchanged attributes hidden)
    }

  # exoscale_private_network.my_managed_private_network will be destroyed
  # (because exoscale_private_network.my_managed_private_network is not in configuration)
  - resource "exoscale_private_network" "my_managed_private_network" {
      - end_ip      = "10.0.0.253" -> null
      - id          = "e07f9cda-7339-494b-8a79-e2a66fe51308" -> null
      - labels      = {} -> null
      - name        = "my-managed-private-network" -> null
      - netmask     = "255.255.255.0" -> null
      - start_ip    = "10.0.0.20" -> null
      - zone        = "ch-gva-2" -> null
        # (1 unchanged attribute hidden)
    }

  # exoscale_security_group.my_security_group will be destroyed
  # (because exoscale_security_group.my_security_group is not in configuration)
  - resource "exoscale_security_group" "my_security_group" {
      - id          = "71665399-b418-43a6-b504-c213ccb9b545" -> null
      - name        = "bug-security-group" -> null
        # (1 unchanged attribute hidden)
    }

  # exoscale_security_group_rule.my_security_group_rule will be destroyed
  # (because exoscale_security_group_rule.my_security_group_rule is not in configuration)
  - resource "exoscale_security_group_rule" "my_security_group_rule" {
      - cidr              = "0.0.0.0/0" -> null
      - end_port          = 80 -> null
      - id                = "c483ac4f-4597-4e80-bd49-18771fee0b07" -> null
      - protocol          = "TCP" -> null
      - security_group    = "bug-security-group" -> null
      - security_group_id = "71665399-b418-43a6-b504-c213ccb9b545" -> null
      - start_port        = 80 -> null
      - type              = "INGRESS" -> null
        # (1 unchanged attribute hidden)
    }

Plan: 0 to add, 1 to change, 4 to destroy.

...

cale/projects/terraform-provider-exoscale/pkg/resources/instance/resource.go:507 @module=exoscale tf_req_id=05405596-d4e4-72d1-afe4-06ccf0c05093 tf_resource_type=exoscale_compute_instance tf_rpc=ApplyResourceChange timestamp="2025-10-04T12:13:18.479+0200"
exoscale_compute_instance.this: Modifications complete after 1s [id=2562e751-0a80-4159-9b3c-f8c988929bad]
2025-10-04T12:13:18.704+0200 [DEBUG] State storage *statemgr.Filesystem declined to persist a state snapshot
2025-10-04T12:13:18.707+0200 [DEBUG] provider.stdio: received EOF, stopping recv loop: err="rpc error: code = Unavailable desc = error reading from server: EOF"
2025-10-04T12:13:18.709+0200 [INFO]  provider: plugin process exited: plugin="/Volumes/Macintosh HD/Users/arthuraliiev/Documents/artsoft/work/exoscale/projects/terraform-provider-exoscale/terraform-provider-exoscale" id=39000
2025-10-04T12:13:18.709+0200 [DEBUG] provider: plugin exited

Apply complete! Resources: 0 added, 1 changed, 4 destroyed.
```
