### PR TITLE
Make instance.ssh_key(s) force resource replace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ IMPROVEMENTS:
 BUG FIXES:
 
 - Update the database opensearch test to use latest major version #462
+- Make instance.ssh_key(s) force resource replace #461
 
 ## 0.65.1
 

--- a/pkg/resources/instance/resource.go
+++ b/pkg/resources/instance/resource.go
@@ -159,6 +159,7 @@ func Resource() *schema.Resource {
 			Optional:      true,
 			Deprecated:    "Use ssh_keys instead",
 			ConflictsWith: []string{AttrSSHKeys},
+			ForceNew:      true,
 		},
 		AttrSSHKeys: {
 			Description: "The list of [exoscale_ssh_key](./ssh_key.md) (name) to authorize in the instance (may only be set at creation time).",
@@ -166,6 +167,7 @@ func Resource() *schema.Resource {
 			Optional:    true,
 			Set:         schema.HashString,
 			Elem:        &schema.Schema{Type: schema.TypeString},
+			ForceNew:    true,
 		},
 		AttrSecurityGroupIDs: {
 			Description: "A list of [exoscale_security_group](./security_group.md) (IDs) to attach to the instance.",


### PR DESCRIPTION
# Description

As we only support setting SSH key(s) on instance create, this PR marks the corresponding attribute with `ForceNew` to force resource replacement.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [ ] Acceptance tests OK
* [ ] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing

<!--
Describe the tests you did
-->
