### PR TITLE
Fix the database opensearch test to use latest major version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ IMPROVEMENTS:
 
 - Add example rules for sks cilium CNI
 
+BUG FIXES:
+
+- Update the database opensearch test to use latest major version #462
+
 ## 0.65.1
 
 IMPROVEMENTS:

--- a/pkg/resources/database/resource_service_opensearch_test.go
+++ b/pkg/resources/database/resource_service_opensearch_test.go
@@ -89,7 +89,7 @@ func testResourceOpensearch(t *testing.T) {
 		Plan:                  "hobbyist-2",
 		Zone:                  testutils.TestZoneName,
 		TerminationProtection: false,
-		Version:               "1",
+		Version:               "2",
 	}
 
 	userFullResourceName := "exoscale_dbaas_opensearch_user.test_user"
@@ -337,7 +337,7 @@ func CheckExistsOpensearch(name string, data *TemplateModelOpensearch) error {
 		}
 	}
 
-	if data.Version != *service.Version {
+	if !strings.HasPrefix(*service.Version, data.Version+".") { // we only choose major version, so we only check prefix
 		return fmt.Errorf("opensearch.version: expected %q, got %q", data.Version, *service.Version)
 	}
 


### PR DESCRIPTION
# Description

API has been flaky around opensearch versions, this PR bumps the major version we use for testing which seems to fix the issue.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [ ] Acceptance tests OK
* [ ] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing
```bash
$ TF_ACC=1 go test ./... -run TestDatabase/ResourceOpensearch 
?       github.com/exoscale/terraform-provider-exoscale [no test files]
ok      github.com/exoscale/terraform-provider-exoscale/exoscale        0.035s [no tests to run]
?       github.com/exoscale/terraform-provider-exoscale/pkg/config      [no test files]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/filter      0.010s [no tests to run]
?       github.com/exoscale/terraform-provider-exoscale/pkg/general     [no test files]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/list        0.026s [no tests to run]
?       github.com/exoscale/terraform-provider-exoscale/pkg/provider    [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/provider/config     [no test files]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/anti_affinity_group       0.021s [no tests to run]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/block_storage     0.049s [no tests to run]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/database  23.833s
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/iam       0.030s [no tests to run]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/instance  0.032s [no tests to run]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/instance_pool     0.024s [no tests to run]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/nlb_service       0.024s [no tests to run]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/sos_bucket_policy 0.014s [no tests to run]
?       github.com/exoscale/terraform-provider-exoscale/pkg/resources/zones     [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/sos [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/testutils   [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/utils       [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/validators  [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/version     [no test files]
?       github.com/exoscale/terraform-provider-exoscale/version [no test files]
```
