### PR TITLE
fix(sks): code & tests are now working properly

### DIFF
--- a/exoscale/resource_exoscale_sks_cluster_test.go
+++ b/exoscale/resource_exoscale_sks_cluster_test.go
@@ -166,7 +166,7 @@ locals {
   zone = "%s"
 }
 
-resource "exoscale_sks_cluster" "test" {
+resource "exoscale_sks_cluster" "test-with-audit" {
   zone = local.zone
   name = "%s"
   description = "%s"
@@ -182,7 +182,7 @@ resource "exoscale_sks_cluster" "test" {
     endpoint = "%s"
 	initial_backoff = "%s"
 	bearer_token = "%s"
-}
+  }
 
   timeouts {
     create = "10m"
@@ -203,7 +203,7 @@ locals {
   zone = "%s"
 }
 
-resource "exoscale_sks_cluster" "test" {
+resource "exoscale_sks_cluster" "test-with-audit" {
   zone = local.zone
   name = "%s"
   description = "%s"
@@ -234,7 +234,7 @@ locals {
   zone = "%s"
 }
 
-resource "exoscale_sks_cluster" "test" {
+resource "exoscale_sks_cluster" "test-with-audit" {
   zone = local.zone
   name = "%s"
   description = "%s"
@@ -481,7 +481,9 @@ func TestAccResourceSKSClusterSKSClusterWithAudit(t *testing.T) {
 						// Verify audit is enabled in the API response
 						assert.NotNil(t, sksCluster.Audit)
 						if sksCluster.Audit != nil {
-							a.True(*sksCluster.Audit.Enabled)
+							if a.NotNil(sksCluster.Audit.Enabled) {
+								a.True(*sksCluster.Audit.Enabled)
+							}
 							a.Equal(testAccResourceSKSClusterAuditRemoteURL, string(sksCluster.Audit.Endpoint))
 							a.Equal(testAccResourceSKSClusterAuditInitBackoff, string(sksCluster.Audit.InitialBackoff))
 						} else {
@@ -516,8 +518,7 @@ func TestAccResourceSKSClusterSKSClusterWithAudit(t *testing.T) {
 						a.Equal(testAccResourceSKSClusterName, sksCluster.Name)
 
 						// Verify audit is disabled in the API response
-						assert.NotNil(t, sksCluster.Audit)
-						if sksCluster.Audit != nil {
+						if assert.NotNil(t, sksCluster.Audit) {
 							a.False(*sksCluster.Audit.Enabled)
 						}
 


### PR DESCRIPTION
# Description
<!--
* Prefix: the title with the component name being changed. Add a short and self describing sentence to ease the review
* Please add a few lines providing context and describing the change
* Please self comment changes whenever applicable to help with the review process
* Please keep the checklist as part of the PR. Tick what applies to this change.
-->

An errored version was published recently. This fixes all code and tests around SKS clusters

## Checklist
(For exoscale contributors)

* [ ] Changelog updated (under *Unreleased* block)
* [x] Acceptance tests OK
* [ ] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing

<!--
Describe the tests you did
-->

```
❯ TF_ACC=1 go test ./... -run 'TestAccResourceSKSClusterSKSClusterWithAudit$'
?   	github.com/exoscale/terraform-provider-exoscale	[no test files]
ok  	github.com/exoscale/terraform-provider-exoscale/exoscale	157.246s
?   	github.com/exoscale/terraform-provider-exoscale/pkg/config	[no test files]
ok  	github.com/exoscale/terraform-provider-exoscale/pkg/filter	(cached) [no tests to run]
?   	github.com/exoscale/terraform-provider-exoscale/pkg/general	[no test files]
ok  	github.com/exoscale/terraform-provider-exoscale/pkg/list	0.031s [no tests to run]
?   	github.com/exoscale/terraform-provider-exoscale/pkg/provider	[no test files]
?   	github.com/exoscale/terraform-provider-exoscale/pkg/provider/config	[no test files]
ok  	github.com/exoscale/terraform-provider-exoscale/pkg/resources/anti_affinity_group	0.031s [no tests to run]
ok  	github.com/exoscale/terraform-provider-exoscale/pkg/resources/block_storage	0.031s [no tests to run]
ok  	github.com/exoscale/terraform-provider-exoscale/pkg/resources/database	0.030s [no tests to run]
ok  	github.com/exoscale/terraform-provider-exoscale/pkg/resources/iam	0.030s [no tests to run]
ok  	github.com/exoscale/terraform-provider-exoscale/pkg/resources/instance	0.028s [no tests to run]
ok  	github.com/exoscale/terraform-provider-exoscale/pkg/resources/instance_pool	0.031s [no tests to run]
ok  	github.com/exoscale/terraform-provider-exoscale/pkg/resources/nlb_service	0.027s [no tests to run]
ok  	github.com/exoscale/terraform-provider-exoscale/pkg/resources/sos_bucket_policy	0.028s [no tests to run]
?   	github.com/exoscale/terraform-provider-exoscale/pkg/resources/zones	[no test files]
?   	github.com/exoscale/terraform-provider-exoscale/pkg/sos	[no test files]
?   	github.com/exoscale/terraform-provider-exoscale/pkg/testutils	[no test files]
?   	github.com/exoscale/terraform-provider-exoscale/pkg/utils	[no test files]
?   	github.com/exoscale/terraform-provider-exoscale/pkg/validators	[no test files]
?   	github.com/exoscale/terraform-provider-exoscale/pkg/version	[no test files]
?   	github.com/exoscale/terraform-provider-exoscale/version	[no test files]
```
