### PR TITLE
Bump go.mk

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,5 @@
+version: 2
+
 builds:
   - env:
       - CGO_ENABLED=0
@@ -23,7 +25,7 @@ builds:
         goarch: '386'
 
 archives:
-  - format: zip
+  - formats: [ 'zip' ]
     name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
 
 checksum:
@@ -41,4 +43,4 @@ release:
     name: terraform-provider-exoscale
 
 changelog:
-  skip: true
+  disable: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ IMPROVEMENTS:
 
 - Add example rules for sks cilium CNI
 - Bump egoscale and fix breaking change #465
+- Bump go.mk #464
 
 BUG FIXES:
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-GO_MK_REF := v2.0.3
+GO_MK_REF := v2.0.4
 
 # make go.mk a dependency for all targets
 .EXTRA_PREREQS = go.mk


### PR DESCRIPTION
# Description

- Bumps go.mk to 2.0.4 to pull new version on goreleaser;
- Updates .goreleaser.yml (replace deprecated fields).

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [ ] Acceptance tests OK
* [ ] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing

<!--
Describe the tests you did
-->
