### PR TITLE
Bump egoscale & fix breaking change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+IMPROVEMENTS:
+
+- Bump egoscale & fix breaking change #468
+
 ## 0.67.1
 
 IMPROVEMENTS:

--- a/exoscale/resource_exoscale_sks_cluster.go
+++ b/exoscale/resource_exoscale_sks_cluster.go
@@ -646,11 +646,6 @@ func resourceSKSClusterUpdate(ctx context.Context, d *schema.ResourceData, meta 
 		} else if !enableKarpenter && addons.Contains(sksClusterAddonKarpenter) {
 			addonStrings := removeAddonFromSet(addons, sksClusterAddonKarpenter)
 			updateReq.Addons = addonStrings
-			for _, v := range addons.List() {
-				addonStrings = append(addonStrings, v.(string))
-			}
-			addonStrings = append(addonStrings, sksClusterAddonExoscaleCSI)
-			updateReq.Addons = addonStrings
 			updated = true
 		}
 	}

--- a/exoscale/resource_exoscale_sks_cluster.go
+++ b/exoscale/resource_exoscale_sks_cluster.go
@@ -324,7 +324,7 @@ func resourceSKSClusterCreate(ctx context.Context, d *schema.ResourceData, meta 
 
 	createReq := v3.CreateSKSClusterRequest{}
 
-	addOns := v3.SKSClusterAddons{}
+	addOns := []string{}
 	if addonsSet, ok := d.Get(resSKSClusterAttrAddons).(*schema.Set); ok && addonsSet.Len() > 0 {
 		addOns = make([]string, addonsSet.Len())
 		for i, a := range addonsSet.List() {
@@ -344,7 +344,7 @@ func resourceSKSClusterCreate(ctx context.Context, d *schema.ResourceData, meta 
 		addOns = append(addOns, sksClusterAddonKarpenter)
 	}
 	if len(addOns) > 0 {
-		createReq.Addons = &addOns
+		createReq.Addons = addOns
 	}
 
 	if autoUpgrade := d.Get(resSKSClusterAttrAutoUpgrade).(bool); autoUpgrade {
@@ -631,7 +631,7 @@ func resourceSKSClusterUpdate(ctx context.Context, d *schema.ResourceData, meta 
 		addons := d.Get(resSKSClusterAttrAddons).(*schema.Set)
 		if enableCSI && !addons.Contains(sksClusterAddonExoscaleCSI) {
 			addonStrings := appendAddonToSet(addons, sksClusterAddonExoscaleCSI)
-			updateReq.Addons = &addonStrings
+			updateReq.Addons = addonStrings
 			updated = true
 		}
 	}
@@ -641,11 +641,16 @@ func resourceSKSClusterUpdate(ctx context.Context, d *schema.ResourceData, meta 
 		addons := d.Get(resSKSClusterAttrAddons).(*schema.Set)
 		if enableKarpenter && !addons.Contains(sksClusterAddonKarpenter) {
 			addonStrings := appendAddonToSet(addons, sksClusterAddonKarpenter)
-			updateReq.Addons = &addonStrings
+			updateReq.Addons = addonStrings
 			updated = true
 		} else if !enableKarpenter && addons.Contains(sksClusterAddonKarpenter) {
 			addonStrings := removeAddonFromSet(addons, sksClusterAddonKarpenter)
-			updateReq.Addons = &addonStrings
+			updateReq.Addons = addonStrings
+			for _, v := range addons.List() {
+				addonStrings = append(addonStrings, v.(string))
+			}
+			addonStrings = append(addonStrings, sksClusterAddonExoscaleCSI)
+			updateReq.Addons = addonStrings
 			updated = true
 		}
 	}
@@ -741,20 +746,20 @@ func resourceSKSClusterDelete(ctx context.Context, d *schema.ResourceData, meta 
 }
 
 func resourceSKSClusterApply(_ context.Context, d *schema.ResourceData, sksCluster *v3.SKSCluster, certificates *SKSClusterCertificates) error {
-	if sksCluster.Addons != nil && len(*sksCluster.Addons) > 0 {
+	if len(sksCluster.Addons) > 0 {
 		if err := d.Set(resSKSClusterAttrAddons, sksCluster.Addons); err != nil {
 			return err
 		}
 
-		if err := d.Set(resSKSClusterAttrExoscaleCCM, in(*sksCluster.Addons, sksClusterAddonExoscaleCCM)); err != nil {
+		if err := d.Set(resSKSClusterAttrExoscaleCCM, in(sksCluster.Addons, sksClusterAddonExoscaleCCM)); err != nil {
 			return err
 		}
 
-		if err := d.Set(resSKSClusterAttrMetricsServer, in(*sksCluster.Addons, sksClusterAddonMS)); err != nil {
+		if err := d.Set(resSKSClusterAttrMetricsServer, in(sksCluster.Addons, sksClusterAddonMS)); err != nil {
 			return err
 		}
 
-		if err := d.Set(resSKSClusterAttrExoscaleCSI, in(*sksCluster.Addons, sksClusterAddonExoscaleCSI)); err != nil {
+		if err := d.Set(resSKSClusterAttrExoscaleCSI, in(sksCluster.Addons, sksClusterAddonExoscaleCSI)); err != nil {
 			return err
 		}
 	}
@@ -840,8 +845,8 @@ func resSKSClusterAttrAudit(a string) string {
 }
 
 // addonsSetToSlice converts a schema.Set of addons to v3.SKSClusterAddons
-func addonsSetToSlice(addons *schema.Set) v3.SKSClusterAddons {
-	addonStrings := make(v3.SKSClusterAddons, 0, addons.Len())
+func addonsSetToSlice(addons *schema.Set) []string {
+	addonStrings := make([]string, 0, addons.Len())
 	for _, v := range addons.List() {
 		addonStrings = append(addonStrings, v.(string))
 	}
@@ -849,15 +854,15 @@ func addonsSetToSlice(addons *schema.Set) v3.SKSClusterAddons {
 }
 
 // appendAddonToSet returns a new SKSClusterAddons slice with the specified addon added
-func appendAddonToSet(addons *schema.Set, addon string) v3.SKSClusterAddons {
+func appendAddonToSet(addons *schema.Set, addon string) []string {
 	addonStrings := addonsSetToSlice(addons)
 	addonStrings = append(addonStrings, addon)
 	return addonStrings
 }
 
 // removeAddonFromSet returns a new SKSClusterAddons slice with the specified addon removed
-func removeAddonFromSet(addons *schema.Set, addon string) v3.SKSClusterAddons {
-	addonStrings := make(v3.SKSClusterAddons, 0, addons.Len())
+func removeAddonFromSet(addons *schema.Set, addon string) []string {
+	addonStrings := make([]string, 0, addons.Len())
 	for _, v := range addons.List() {
 		if v.(string) != addon {
 			addonStrings = append(addonStrings, v.(string))

--- a/exoscale/resource_exoscale_sks_cluster_test.go
+++ b/exoscale/resource_exoscale_sks_cluster_test.go
@@ -376,7 +376,7 @@ func TestAccResourceSKSCluster(t *testing.T) {
 
 						latestVersion := versions[0]
 
-						a.Equal(&egoscale.SKSClusterAddons{sksClusterAddonExoscaleCCM}, sksCluster.Addons)
+						a.Equal([]string{sksClusterAddonExoscaleCCM}, sksCluster.Addons)
 						a.True(defaultBool(sksCluster.AutoUpgrade, false))
 						a.Equal(defaultSKSClusterCNI, string(sksCluster.Cni))
 						a.Equal(testAccResourceSKSClusterDescription, sksCluster.Description)

--- a/exoscale/resource_exoscale_sks_cluster_test.go
+++ b/exoscale/resource_exoscale_sks_cluster_test.go
@@ -694,7 +694,7 @@ func TestAccResourceSKSClusterWithKarpenter(t *testing.T) {
 						assert.NotNil(t, sksCluster.Addons)
 						if sksCluster.Addons != nil {
 							found := false
-							for _, addon := range *sksCluster.Addons {
+							for _, addon := range sksCluster.Addons {
 								if addon == sksClusterAddonKarpenter {
 									found = true
 									break
@@ -732,7 +732,7 @@ func TestAccResourceSKSClusterWithKarpenter(t *testing.T) {
 						// Verify Karpenter addon is not present in the API response
 						if assert.NotNil(t, sksCluster.Addons) {
 							found := false
-							for _, addon := range *sksCluster.Addons {
+							for _, addon := range sksCluster.Addons {
 								if addon == sksClusterAddonKarpenter {
 									found = true
 									break
@@ -769,7 +769,7 @@ func TestAccResourceSKSClusterWithKarpenter(t *testing.T) {
 						assert.NotNil(t, sksCluster.Addons)
 						if sksCluster.Addons != nil {
 							found := false
-							for _, addon := range *sksCluster.Addons {
+							for _, addon := range sksCluster.Addons {
 								if addon == sksClusterAddonKarpenter {
 									found = true
 									break

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.42
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.66.2
 	github.com/exoscale/egoscale v0.102.4
-	github.com/exoscale/egoscale/v3 v3.1.28
+	github.com/exoscale/egoscale/v3 v3.1.31
 	github.com/google/go-cmp v0.7.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.42
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.66.2
 	github.com/exoscale/egoscale v0.102.4
-	github.com/exoscale/egoscale/v3 v3.1.27
+	github.com/exoscale/egoscale/v3 v3.1.28
 	github.com/google/go-cmp v0.7.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320

--- a/go.sum
+++ b/go.sum
@@ -104,8 +104,8 @@ github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
 github.com/exoscale/egoscale v0.102.4 h1:GBKsZMIOzwBfSu+4ZmWka3Ejf2JLiaBDHp4CQUgvp2E=
 github.com/exoscale/egoscale v0.102.4/go.mod h1:ROSmPtle0wvf91iLZb09++N/9BH2Jo9XxIpAEumvocA=
-github.com/exoscale/egoscale/v3 v3.1.28 h1:m4sPeZSXc1P3D/6ZZFzqqgA8y+jQXTit/zDEY0Kts8U=
-github.com/exoscale/egoscale/v3 v3.1.28/go.mod h1:0iY8OxgHJCS5TKqDNhwOW95JBKCnBZl3YGU4Yt+NqkU=
+github.com/exoscale/egoscale/v3 v3.1.31 h1:/dySEUSAxU+hlAS/eLxAoY8ZYmtOtaoL1P+lDwH7ojY=
+github.com/exoscale/egoscale/v3 v3.1.31/go.mod h1:0iY8OxgHJCS5TKqDNhwOW95JBKCnBZl3YGU4Yt+NqkU=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=

--- a/go.sum
+++ b/go.sum
@@ -104,8 +104,8 @@ github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
 github.com/exoscale/egoscale v0.102.4 h1:GBKsZMIOzwBfSu+4ZmWka3Ejf2JLiaBDHp4CQUgvp2E=
 github.com/exoscale/egoscale v0.102.4/go.mod h1:ROSmPtle0wvf91iLZb09++N/9BH2Jo9XxIpAEumvocA=
-github.com/exoscale/egoscale/v3 v3.1.27 h1:vKdWZG8QFDc7rY7lCfcuudO+ovyp5psYjFwKVqmkhCE=
-github.com/exoscale/egoscale/v3 v3.1.27/go.mod h1:0iY8OxgHJCS5TKqDNhwOW95JBKCnBZl3YGU4Yt+NqkU=
+github.com/exoscale/egoscale/v3 v3.1.28 h1:m4sPeZSXc1P3D/6ZZFzqqgA8y+jQXTit/zDEY0Kts8U=
+github.com/exoscale/egoscale/v3 v3.1.28/go.mod h1:0iY8OxgHJCS5TKqDNhwOW95JBKCnBZl3YGU4Yt+NqkU=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=

--- a/pkg/resources/sos_bucket_policy/main_test.go
+++ b/pkg/resources/sos_bucket_policy/main_test.go
@@ -38,7 +38,8 @@ func TestSOSBucketPolicy(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ExternalProviders: map[string]resource.ExternalProvider{
 			"aws": resource.ExternalProvider{
-				Source: "hashicorp/aws",
+				Source:            "hashicorp/aws",
+				VersionConstraint: "6.22.0",
 			},
 		},
 		PreCheck:                 func() { testutils.AccPreCheck(t) },

--- a/vendor/github.com/exoscale/egoscale/v3/operations.go
+++ b/vendor/github.com/exoscale/egoscale/v3/operations.go
@@ -12,6 +12,551 @@ import (
 	"time"
 )
 
+// FindListDeploymentsResponseEntry attempts to find an ListDeploymentsResponseEntry by nameOrID.
+func (l ListDeploymentsResponse) FindListDeploymentsResponseEntry(nameOrID string) (ListDeploymentsResponseEntry, error) {
+	var result []ListDeploymentsResponseEntry
+	for i, elem := range l.Deployments {
+		if string(elem.Name) == nameOrID || string(elem.ID) == nameOrID {
+			result = append(result, l.Deployments[i])
+		}
+	}
+	if len(result) == 1 {
+		return result[0], nil
+	}
+
+	if len(result) > 1 {
+		return ListDeploymentsResponseEntry{}, fmt.Errorf("%q too many found in ListDeploymentsResponse: %w", nameOrID, ErrConflict)
+	}
+
+	return ListDeploymentsResponseEntry{}, fmt.Errorf("%q not found in ListDeploymentsResponse: %w", nameOrID, ErrNotFound)
+}
+
+// [BETA] List Deployments
+func (c Client) ListDeployments(ctx context.Context) (*ListDeploymentsResponse, error) {
+	path := "/ai/deployment"
+
+	request, err := http.NewRequestWithContext(ctx, "GET", c.serverEndpoint+path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("ListDeployments: new request: %w", err)
+	}
+
+	request.Header.Add("User-Agent", c.getUserAgent())
+
+	if err := c.executeRequestInterceptors(ctx, request); err != nil {
+		return nil, fmt.Errorf("ListDeployments: execute request editors: %w", err)
+	}
+
+	if err := c.signRequest(request); err != nil {
+		return nil, fmt.Errorf("ListDeployments: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "list-deployments")
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("ListDeployments: http client do: %w", err)
+	}
+
+	if c.trace {
+		dumpResponse(response)
+	}
+
+	if err := handleHTTPErrorResp(response); err != nil {
+		return nil, fmt.Errorf("ListDeployments: http response: %w", err)
+	}
+
+	bodyresp := new(ListDeploymentsResponse)
+	if err := prepareJSONResponse(response, bodyresp); err != nil {
+		return nil, fmt.Errorf("ListDeployments: prepare Json response: %w", err)
+	}
+
+	return bodyresp, nil
+}
+
+// Deploy a model on an inference server
+func (c Client) CreateDeployment(ctx context.Context, req CreateDeploymentRequest) (*Operation, error) {
+	path := "/ai/deployment"
+
+	body, err := prepareJSONBody(req)
+	if err != nil {
+		return nil, fmt.Errorf("CreateDeployment: prepare Json body: %w", err)
+	}
+
+	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
+	if err != nil {
+		return nil, fmt.Errorf("CreateDeployment: new request: %w", err)
+	}
+
+	request.Header.Add("User-Agent", c.getUserAgent())
+
+	request.Header.Add("Content-Type", "application/json")
+
+	if err := c.executeRequestInterceptors(ctx, request); err != nil {
+		return nil, fmt.Errorf("CreateDeployment: execute request editors: %w", err)
+	}
+
+	if err := c.signRequest(request); err != nil {
+		return nil, fmt.Errorf("CreateDeployment: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "create-deployment")
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("CreateDeployment: http client do: %w", err)
+	}
+
+	if c.trace {
+		dumpResponse(response)
+	}
+
+	if err := handleHTTPErrorResp(response); err != nil {
+		return nil, fmt.Errorf("CreateDeployment: http response: %w", err)
+	}
+
+	bodyresp := new(Operation)
+	if err := prepareJSONResponse(response, bodyresp); err != nil {
+		return nil, fmt.Errorf("CreateDeployment: prepare Json response: %w", err)
+	}
+
+	return bodyresp, nil
+}
+
+// [BETA] Delete Deployment
+func (c Client) DeleteDeployment(ctx context.Context, id UUID) (*Operation, error) {
+	path := fmt.Sprintf("/ai/deployment/%v", id)
+
+	request, err := http.NewRequestWithContext(ctx, "DELETE", c.serverEndpoint+path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("DeleteDeployment: new request: %w", err)
+	}
+
+	request.Header.Add("User-Agent", c.getUserAgent())
+
+	if err := c.executeRequestInterceptors(ctx, request); err != nil {
+		return nil, fmt.Errorf("DeleteDeployment: execute request editors: %w", err)
+	}
+
+	if err := c.signRequest(request); err != nil {
+		return nil, fmt.Errorf("DeleteDeployment: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "delete-deployment")
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("DeleteDeployment: http client do: %w", err)
+	}
+
+	if c.trace {
+		dumpResponse(response)
+	}
+
+	if err := handleHTTPErrorResp(response); err != nil {
+		return nil, fmt.Errorf("DeleteDeployment: http response: %w", err)
+	}
+
+	bodyresp := new(Operation)
+	if err := prepareJSONResponse(response, bodyresp); err != nil {
+		return nil, fmt.Errorf("DeleteDeployment: prepare Json response: %w", err)
+	}
+
+	return bodyresp, nil
+}
+
+// [BETA] Get Deployment
+func (c Client) GetDeployment(ctx context.Context, id UUID) (*GetDeploymentResponse, error) {
+	path := fmt.Sprintf("/ai/deployment/%v", id)
+
+	request, err := http.NewRequestWithContext(ctx, "GET", c.serverEndpoint+path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("GetDeployment: new request: %w", err)
+	}
+
+	request.Header.Add("User-Agent", c.getUserAgent())
+
+	if err := c.executeRequestInterceptors(ctx, request); err != nil {
+		return nil, fmt.Errorf("GetDeployment: execute request editors: %w", err)
+	}
+
+	if err := c.signRequest(request); err != nil {
+		return nil, fmt.Errorf("GetDeployment: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "get-deployment")
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("GetDeployment: http client do: %w", err)
+	}
+
+	if c.trace {
+		dumpResponse(response)
+	}
+
+	if err := handleHTTPErrorResp(response); err != nil {
+		return nil, fmt.Errorf("GetDeployment: http response: %w", err)
+	}
+
+	bodyresp := new(GetDeploymentResponse)
+	if err := prepareJSONResponse(response, bodyresp); err != nil {
+		return nil, fmt.Errorf("GetDeployment: prepare Json response: %w", err)
+	}
+
+	return bodyresp, nil
+}
+
+// [BETA] Reveal Deployment API Key
+func (c Client) RevealDeploymentAPIKey(ctx context.Context, id UUID) (*RevealDeploymentAPIKeyResponse, error) {
+	path := fmt.Sprintf("/ai/deployment/%v/api-key", id)
+
+	request, err := http.NewRequestWithContext(ctx, "GET", c.serverEndpoint+path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("RevealDeploymentAPIKey: new request: %w", err)
+	}
+
+	request.Header.Add("User-Agent", c.getUserAgent())
+
+	if err := c.executeRequestInterceptors(ctx, request); err != nil {
+		return nil, fmt.Errorf("RevealDeploymentAPIKey: execute request editors: %w", err)
+	}
+
+	if err := c.signRequest(request); err != nil {
+		return nil, fmt.Errorf("RevealDeploymentAPIKey: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "reveal-deployment-api-key")
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("RevealDeploymentAPIKey: http client do: %w", err)
+	}
+
+	if c.trace {
+		dumpResponse(response)
+	}
+
+	if err := handleHTTPErrorResp(response); err != nil {
+		return nil, fmt.Errorf("RevealDeploymentAPIKey: http response: %w", err)
+	}
+
+	bodyresp := new(RevealDeploymentAPIKeyResponse)
+	if err := prepareJSONResponse(response, bodyresp); err != nil {
+		return nil, fmt.Errorf("RevealDeploymentAPIKey: prepare Json response: %w", err)
+	}
+
+	return bodyresp, nil
+}
+
+// Return logs for the vLLM deployment (deploy/<release-name>--deployment-vllm). Optional ?stream=true to request streaming (may not be supported).
+func (c Client) GetDeploymentLogs(ctx context.Context, id UUID) (*GetDeploymentLogsResponse, error) {
+	path := fmt.Sprintf("/ai/deployment/%v/logs", id)
+
+	request, err := http.NewRequestWithContext(ctx, "GET", c.serverEndpoint+path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("GetDeploymentLogs: new request: %w", err)
+	}
+
+	request.Header.Add("User-Agent", c.getUserAgent())
+
+	if err := c.executeRequestInterceptors(ctx, request); err != nil {
+		return nil, fmt.Errorf("GetDeploymentLogs: execute request editors: %w", err)
+	}
+
+	if err := c.signRequest(request); err != nil {
+		return nil, fmt.Errorf("GetDeploymentLogs: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "get-deployment-logs")
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("GetDeploymentLogs: http client do: %w", err)
+	}
+
+	if c.trace {
+		dumpResponse(response)
+	}
+
+	if err := handleHTTPErrorResp(response); err != nil {
+		return nil, fmt.Errorf("GetDeploymentLogs: http response: %w", err)
+	}
+
+	bodyresp := new(GetDeploymentLogsResponse)
+	if err := prepareJSONResponse(response, bodyresp); err != nil {
+		return nil, fmt.Errorf("GetDeploymentLogs: prepare Json response: %w", err)
+	}
+
+	return bodyresp, nil
+}
+
+// [BETA] Scale Deployment
+func (c Client) ScaleDeployment(ctx context.Context, id UUID, req ScaleDeploymentRequest) (*Operation, error) {
+	path := fmt.Sprintf("/ai/deployment/%v/scale", id)
+
+	body, err := prepareJSONBody(req)
+	if err != nil {
+		return nil, fmt.Errorf("ScaleDeployment: prepare Json body: %w", err)
+	}
+
+	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
+	if err != nil {
+		return nil, fmt.Errorf("ScaleDeployment: new request: %w", err)
+	}
+
+	request.Header.Add("User-Agent", c.getUserAgent())
+
+	request.Header.Add("Content-Type", "application/json")
+
+	if err := c.executeRequestInterceptors(ctx, request); err != nil {
+		return nil, fmt.Errorf("ScaleDeployment: execute request editors: %w", err)
+	}
+
+	if err := c.signRequest(request); err != nil {
+		return nil, fmt.Errorf("ScaleDeployment: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "scale-deployment")
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("ScaleDeployment: http client do: %w", err)
+	}
+
+	if c.trace {
+		dumpResponse(response)
+	}
+
+	if err := handleHTTPErrorResp(response); err != nil {
+		return nil, fmt.Errorf("ScaleDeployment: http response: %w", err)
+	}
+
+	bodyresp := new(Operation)
+	if err := prepareJSONResponse(response, bodyresp); err != nil {
+		return nil, fmt.Errorf("ScaleDeployment: prepare Json response: %w", err)
+	}
+
+	return bodyresp, nil
+}
+
+// FindListModelsResponseEntry attempts to find an ListModelsResponseEntry by nameOrID.
+func (l ListModelsResponse) FindListModelsResponseEntry(nameOrID string) (ListModelsResponseEntry, error) {
+	var result []ListModelsResponseEntry
+	for i, elem := range l.Models {
+		if string(elem.Name) == nameOrID || string(elem.ID) == nameOrID {
+			result = append(result, l.Models[i])
+		}
+	}
+	if len(result) == 1 {
+		return result[0], nil
+	}
+
+	if len(result) > 1 {
+		return ListModelsResponseEntry{}, fmt.Errorf("%q too many found in ListModelsResponse: %w", nameOrID, ErrConflict)
+	}
+
+	return ListModelsResponseEntry{}, fmt.Errorf("%q not found in ListModelsResponse: %w", nameOrID, ErrNotFound)
+}
+
+// [BETA] List Models
+func (c Client) ListModels(ctx context.Context) (*ListModelsResponse, error) {
+	path := "/ai/model"
+
+	request, err := http.NewRequestWithContext(ctx, "GET", c.serverEndpoint+path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("ListModels: new request: %w", err)
+	}
+
+	request.Header.Add("User-Agent", c.getUserAgent())
+
+	if err := c.executeRequestInterceptors(ctx, request); err != nil {
+		return nil, fmt.Errorf("ListModels: execute request editors: %w", err)
+	}
+
+	if err := c.signRequest(request); err != nil {
+		return nil, fmt.Errorf("ListModels: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "list-models")
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("ListModels: http client do: %w", err)
+	}
+
+	if c.trace {
+		dumpResponse(response)
+	}
+
+	if err := handleHTTPErrorResp(response); err != nil {
+		return nil, fmt.Errorf("ListModels: http response: %w", err)
+	}
+
+	bodyresp := new(ListModelsResponse)
+	if err := prepareJSONResponse(response, bodyresp); err != nil {
+		return nil, fmt.Errorf("ListModels: prepare Json response: %w", err)
+	}
+
+	return bodyresp, nil
+}
+
+// Model files will be downloaded from Huggingface.
+// If the model is under a license then you must provide a Huggingface access token for an account that signed the license agreement
+// If the model is under a license then you must provide a Huggingface access token for an account that signed the license agreement
+func (c Client) CreateModel(ctx context.Context, req CreateModelRequest) (*Operation, error) {
+	path := "/ai/model"
+
+	body, err := prepareJSONBody(req)
+	if err != nil {
+		return nil, fmt.Errorf("CreateModel: prepare Json body: %w", err)
+	}
+
+	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
+	if err != nil {
+		return nil, fmt.Errorf("CreateModel: new request: %w", err)
+	}
+
+	request.Header.Add("User-Agent", c.getUserAgent())
+
+	request.Header.Add("Content-Type", "application/json")
+
+	if err := c.executeRequestInterceptors(ctx, request); err != nil {
+		return nil, fmt.Errorf("CreateModel: execute request editors: %w", err)
+	}
+
+	if err := c.signRequest(request); err != nil {
+		return nil, fmt.Errorf("CreateModel: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "create-model")
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("CreateModel: http client do: %w", err)
+	}
+
+	if c.trace {
+		dumpResponse(response)
+	}
+
+	if err := handleHTTPErrorResp(response); err != nil {
+		return nil, fmt.Errorf("CreateModel: http response: %w", err)
+	}
+
+	bodyresp := new(Operation)
+	if err := prepareJSONResponse(response, bodyresp); err != nil {
+		return nil, fmt.Errorf("CreateModel: prepare Json response: %w", err)
+	}
+
+	return bodyresp, nil
+}
+
+// [BETA] Delete Model
+func (c Client) DeleteModel(ctx context.Context, id UUID) (*Operation, error) {
+	path := fmt.Sprintf("/ai/model/%v", id)
+
+	request, err := http.NewRequestWithContext(ctx, "DELETE", c.serverEndpoint+path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("DeleteModel: new request: %w", err)
+	}
+
+	request.Header.Add("User-Agent", c.getUserAgent())
+
+	if err := c.executeRequestInterceptors(ctx, request); err != nil {
+		return nil, fmt.Errorf("DeleteModel: execute request editors: %w", err)
+	}
+
+	if err := c.signRequest(request); err != nil {
+		return nil, fmt.Errorf("DeleteModel: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "delete-model")
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("DeleteModel: http client do: %w", err)
+	}
+
+	if c.trace {
+		dumpResponse(response)
+	}
+
+	if err := handleHTTPErrorResp(response); err != nil {
+		return nil, fmt.Errorf("DeleteModel: http response: %w", err)
+	}
+
+	bodyresp := new(Operation)
+	if err := prepareJSONResponse(response, bodyresp); err != nil {
+		return nil, fmt.Errorf("DeleteModel: prepare Json response: %w", err)
+	}
+
+	return bodyresp, nil
+}
+
+// [BETA] Get Model
+func (c Client) GetModel(ctx context.Context, id UUID) (*GetModelResponse, error) {
+	path := fmt.Sprintf("/ai/model/%v", id)
+
+	request, err := http.NewRequestWithContext(ctx, "GET", c.serverEndpoint+path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("GetModel: new request: %w", err)
+	}
+
+	request.Header.Add("User-Agent", c.getUserAgent())
+
+	if err := c.executeRequestInterceptors(ctx, request); err != nil {
+		return nil, fmt.Errorf("GetModel: execute request editors: %w", err)
+	}
+
+	if err := c.signRequest(request); err != nil {
+		return nil, fmt.Errorf("GetModel: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "get-model")
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("GetModel: http client do: %w", err)
+	}
+
+	if c.trace {
+		dumpResponse(response)
+	}
+
+	if err := handleHTTPErrorResp(response); err != nil {
+		return nil, fmt.Errorf("GetModel: http response: %w", err)
+	}
+
+	bodyresp := new(GetModelResponse)
+	if err := prepareJSONResponse(response, bodyresp); err != nil {
+		return nil, fmt.Errorf("GetModel: prepare Json response: %w", err)
+	}
+
+	return bodyresp, nil
+}
+
 type ListAntiAffinityGroupsResponse struct {
 	AntiAffinityGroups []AntiAffinityGroup `json:"anti-affinity-groups,omitempty"`
 }
@@ -71,7 +616,7 @@ func (c Client) ListAntiAffinityGroups(ctx context.Context) (*ListAntiAffinityGr
 		return nil, fmt.Errorf("ListAntiAffinityGroups: http response: %w", err)
 	}
 
-	bodyresp := &ListAntiAffinityGroupsResponse{}
+	bodyresp := new(ListAntiAffinityGroupsResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("ListAntiAffinityGroups: prepare Json response: %w", err)
 	}
@@ -129,7 +674,7 @@ func (c Client) CreateAntiAffinityGroup(ctx context.Context, req CreateAntiAffin
 		return nil, fmt.Errorf("CreateAntiAffinityGroup: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("CreateAntiAffinityGroup: prepare Json response: %w", err)
 	}
@@ -173,7 +718,7 @@ func (c Client) DeleteAntiAffinityGroup(ctx context.Context, id UUID) (*Operatio
 		return nil, fmt.Errorf("DeleteAntiAffinityGroup: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("DeleteAntiAffinityGroup: prepare Json response: %w", err)
 	}
@@ -217,7 +762,7 @@ func (c Client) GetAntiAffinityGroup(ctx context.Context, id UUID) (*AntiAffinit
 		return nil, fmt.Errorf("GetAntiAffinityGroup: http response: %w", err)
 	}
 
-	bodyresp := &AntiAffinityGroup{}
+	bodyresp := new(AntiAffinityGroup)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("GetAntiAffinityGroup: prepare Json response: %w", err)
 	}
@@ -284,7 +829,7 @@ func (c Client) ListAPIKeys(ctx context.Context) (*ListAPIKeysResponse, error) {
 		return nil, fmt.Errorf("ListAPIKeys: http response: %w", err)
 	}
 
-	bodyresp := &ListAPIKeysResponse{}
+	bodyresp := new(ListAPIKeysResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("ListAPIKeys: prepare Json response: %w", err)
 	}
@@ -342,7 +887,7 @@ func (c Client) CreateAPIKey(ctx context.Context, req CreateAPIKeyRequest) (*IAM
 		return nil, fmt.Errorf("CreateAPIKey: http response: %w", err)
 	}
 
-	bodyresp := &IAMAPIKeyCreated{}
+	bodyresp := new(IAMAPIKeyCreated)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("CreateAPIKey: prepare Json response: %w", err)
 	}
@@ -386,7 +931,7 @@ func (c Client) DeleteAPIKey(ctx context.Context, id string) (*Operation, error)
 		return nil, fmt.Errorf("DeleteAPIKey: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("DeleteAPIKey: prepare Json response: %w", err)
 	}
@@ -430,7 +975,7 @@ func (c Client) GetAPIKey(ctx context.Context, id string) (*IAMAPIKey, error) {
 		return nil, fmt.Errorf("GetAPIKey: http response: %w", err)
 	}
 
-	bodyresp := &IAMAPIKey{}
+	bodyresp := new(IAMAPIKey)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("GetAPIKey: prepare Json response: %w", err)
 	}
@@ -513,7 +1058,7 @@ func (c Client) ListBlockStorageVolumes(ctx context.Context, opts ...ListBlockSt
 		return nil, fmt.Errorf("ListBlockStorageVolumes: http response: %w", err)
 	}
 
-	bodyresp := &ListBlockStorageVolumesResponse{}
+	bodyresp := new(ListBlockStorageVolumesResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("ListBlockStorageVolumes: prepare Json response: %w", err)
 	}
@@ -575,7 +1120,7 @@ func (c Client) CreateBlockStorageVolume(ctx context.Context, req CreateBlockSto
 		return nil, fmt.Errorf("CreateBlockStorageVolume: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("CreateBlockStorageVolume: prepare Json response: %w", err)
 	}
@@ -642,7 +1187,7 @@ func (c Client) ListBlockStorageSnapshots(ctx context.Context) (*ListBlockStorag
 		return nil, fmt.Errorf("ListBlockStorageSnapshots: http response: %w", err)
 	}
 
-	bodyresp := &ListBlockStorageSnapshotsResponse{}
+	bodyresp := new(ListBlockStorageSnapshotsResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("ListBlockStorageSnapshots: prepare Json response: %w", err)
 	}
@@ -686,7 +1231,7 @@ func (c Client) DeleteBlockStorageSnapshot(ctx context.Context, id UUID) (*Opera
 		return nil, fmt.Errorf("DeleteBlockStorageSnapshot: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("DeleteBlockStorageSnapshot: prepare Json response: %w", err)
 	}
@@ -730,7 +1275,7 @@ func (c Client) GetBlockStorageSnapshot(ctx context.Context, id UUID) (*BlockSto
 		return nil, fmt.Errorf("GetBlockStorageSnapshot: http response: %w", err)
 	}
 
-	bodyresp := &BlockStorageSnapshot{}
+	bodyresp := new(BlockStorageSnapshot)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("GetBlockStorageSnapshot: prepare Json response: %w", err)
 	}
@@ -787,7 +1332,7 @@ func (c Client) UpdateBlockStorageSnapshot(ctx context.Context, id UUID, req Upd
 		return nil, fmt.Errorf("UpdateBlockStorageSnapshot: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("UpdateBlockStorageSnapshot: prepare Json response: %w", err)
 	}
@@ -831,7 +1376,7 @@ func (c Client) DeleteBlockStorageVolume(ctx context.Context, id UUID) (*Operati
 		return nil, fmt.Errorf("DeleteBlockStorageVolume: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("DeleteBlockStorageVolume: prepare Json response: %w", err)
 	}
@@ -875,7 +1420,7 @@ func (c Client) GetBlockStorageVolume(ctx context.Context, id UUID) (*BlockStora
 		return nil, fmt.Errorf("GetBlockStorageVolume: http response: %w", err)
 	}
 
-	bodyresp := &BlockStorageVolume{}
+	bodyresp := new(BlockStorageVolume)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("GetBlockStorageVolume: prepare Json response: %w", err)
 	}
@@ -932,7 +1477,7 @@ func (c Client) UpdateBlockStorageVolume(ctx context.Context, id UUID, req Updat
 		return nil, fmt.Errorf("UpdateBlockStorageVolume: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("UpdateBlockStorageVolume: prepare Json response: %w", err)
 	}
@@ -988,7 +1533,7 @@ func (c Client) AttachBlockStorageVolumeToInstance(ctx context.Context, id UUID,
 		return nil, fmt.Errorf("AttachBlockStorageVolumeToInstance: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("AttachBlockStorageVolumeToInstance: prepare Json response: %w", err)
 	}
@@ -1045,7 +1590,7 @@ func (c Client) CreateBlockStorageSnapshot(ctx context.Context, id UUID, req Cre
 		return nil, fmt.Errorf("CreateBlockStorageSnapshot: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("CreateBlockStorageSnapshot: prepare Json response: %w", err)
 	}
@@ -1089,7 +1634,7 @@ func (c Client) DetachBlockStorageVolume(ctx context.Context, id UUID) (*Operati
 		return nil, fmt.Errorf("DetachBlockStorageVolume: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("DetachBlockStorageVolume: prepare Json response: %w", err)
 	}
@@ -1145,7 +1690,7 @@ func (c Client) ResizeBlockStorageVolume(ctx context.Context, id UUID, req Resiz
 		return nil, fmt.Errorf("ResizeBlockStorageVolume: http response: %w", err)
 	}
 
-	bodyresp := &BlockStorageVolume{}
+	bodyresp := new(BlockStorageVolume)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("ResizeBlockStorageVolume: prepare Json response: %w", err)
 	}
@@ -1195,7 +1740,7 @@ func (c Client) GetConsoleProxyURL(ctx context.Context, id UUID) (*GetConsolePro
 		return nil, fmt.Errorf("GetConsoleProxyURL: http response: %w", err)
 	}
 
-	bodyresp := &GetConsoleProxyURLResponse{}
+	bodyresp := new(GetConsoleProxyURLResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("GetConsoleProxyURL: prepare Json response: %w", err)
 	}
@@ -1243,7 +1788,7 @@ func (c Client) GetDBAASCACertificate(ctx context.Context) (*GetDBAASCACertifica
 		return nil, fmt.Errorf("GetDBAASCACertificate: http response: %w", err)
 	}
 
-	bodyresp := &GetDBAASCACertificateResponse{}
+	bodyresp := new(GetDBAASCACertificateResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("GetDBAASCACertificate: prepare Json response: %w", err)
 	}
@@ -1287,7 +1832,7 @@ func (c Client) DeleteDBAASExternalEndpointDatadog(ctx context.Context, endpoint
 		return nil, fmt.Errorf("DeleteDBAASExternalEndpointDatadog: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("DeleteDBAASExternalEndpointDatadog: prepare Json response: %w", err)
 	}
@@ -1331,7 +1876,7 @@ func (c Client) GetDBAASExternalEndpointDatadog(ctx context.Context, endpointID 
 		return nil, fmt.Errorf("GetDBAASExternalEndpointDatadog: http response: %w", err)
 	}
 
-	bodyresp := &DBAASExternalEndpointDatadogOutput{}
+	bodyresp := new(DBAASExternalEndpointDatadogOutput)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("GetDBAASExternalEndpointDatadog: prepare Json response: %w", err)
 	}
@@ -1382,7 +1927,7 @@ func (c Client) UpdateDBAASExternalEndpointDatadog(ctx context.Context, endpoint
 		return nil, fmt.Errorf("UpdateDBAASExternalEndpointDatadog: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("UpdateDBAASExternalEndpointDatadog: prepare Json response: %w", err)
 	}
@@ -1433,7 +1978,7 @@ func (c Client) CreateDBAASExternalEndpointDatadog(ctx context.Context, name str
 		return nil, fmt.Errorf("CreateDBAASExternalEndpointDatadog: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("CreateDBAASExternalEndpointDatadog: prepare Json response: %w", err)
 	}
@@ -1477,7 +2022,7 @@ func (c Client) DeleteDBAASExternalEndpointElasticsearch(ctx context.Context, en
 		return nil, fmt.Errorf("DeleteDBAASExternalEndpointElasticsearch: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("DeleteDBAASExternalEndpointElasticsearch: prepare Json response: %w", err)
 	}
@@ -1521,7 +2066,7 @@ func (c Client) GetDBAASExternalEndpointElasticsearch(ctx context.Context, endpo
 		return nil, fmt.Errorf("GetDBAASExternalEndpointElasticsearch: http response: %w", err)
 	}
 
-	bodyresp := &DBAASEndpointElasticsearchOutput{}
+	bodyresp := new(DBAASEndpointElasticsearchOutput)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("GetDBAASExternalEndpointElasticsearch: prepare Json response: %w", err)
 	}
@@ -1572,7 +2117,7 @@ func (c Client) UpdateDBAASExternalEndpointElasticsearch(ctx context.Context, en
 		return nil, fmt.Errorf("UpdateDBAASExternalEndpointElasticsearch: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("UpdateDBAASExternalEndpointElasticsearch: prepare Json response: %w", err)
 	}
@@ -1623,7 +2168,7 @@ func (c Client) CreateDBAASExternalEndpointElasticsearch(ctx context.Context, na
 		return nil, fmt.Errorf("CreateDBAASExternalEndpointElasticsearch: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("CreateDBAASExternalEndpointElasticsearch: prepare Json response: %w", err)
 	}
@@ -1667,7 +2212,7 @@ func (c Client) DeleteDBAASExternalEndpointOpensearch(ctx context.Context, endpo
 		return nil, fmt.Errorf("DeleteDBAASExternalEndpointOpensearch: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("DeleteDBAASExternalEndpointOpensearch: prepare Json response: %w", err)
 	}
@@ -1711,7 +2256,7 @@ func (c Client) GetDBAASExternalEndpointOpensearch(ctx context.Context, endpoint
 		return nil, fmt.Errorf("GetDBAASExternalEndpointOpensearch: http response: %w", err)
 	}
 
-	bodyresp := &DBAASEndpointOpensearchOutput{}
+	bodyresp := new(DBAASEndpointOpensearchOutput)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("GetDBAASExternalEndpointOpensearch: prepare Json response: %w", err)
 	}
@@ -1762,7 +2307,7 @@ func (c Client) UpdateDBAASExternalEndpointOpensearch(ctx context.Context, endpo
 		return nil, fmt.Errorf("UpdateDBAASExternalEndpointOpensearch: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("UpdateDBAASExternalEndpointOpensearch: prepare Json response: %w", err)
 	}
@@ -1813,7 +2358,7 @@ func (c Client) CreateDBAASExternalEndpointOpensearch(ctx context.Context, name 
 		return nil, fmt.Errorf("CreateDBAASExternalEndpointOpensearch: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("CreateDBAASExternalEndpointOpensearch: prepare Json response: %w", err)
 	}
@@ -1857,7 +2402,7 @@ func (c Client) DeleteDBAASExternalEndpointPrometheus(ctx context.Context, endpo
 		return nil, fmt.Errorf("DeleteDBAASExternalEndpointPrometheus: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("DeleteDBAASExternalEndpointPrometheus: prepare Json response: %w", err)
 	}
@@ -1901,7 +2446,7 @@ func (c Client) GetDBAASExternalEndpointPrometheus(ctx context.Context, endpoint
 		return nil, fmt.Errorf("GetDBAASExternalEndpointPrometheus: http response: %w", err)
 	}
 
-	bodyresp := &DBAASEndpointExternalPrometheusOutput{}
+	bodyresp := new(DBAASEndpointExternalPrometheusOutput)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("GetDBAASExternalEndpointPrometheus: prepare Json response: %w", err)
 	}
@@ -1952,7 +2497,7 @@ func (c Client) UpdateDBAASExternalEndpointPrometheus(ctx context.Context, endpo
 		return nil, fmt.Errorf("UpdateDBAASExternalEndpointPrometheus: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("UpdateDBAASExternalEndpointPrometheus: prepare Json response: %w", err)
 	}
@@ -2003,7 +2548,7 @@ func (c Client) CreateDBAASExternalEndpointPrometheus(ctx context.Context, name 
 		return nil, fmt.Errorf("CreateDBAASExternalEndpointPrometheus: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("CreateDBAASExternalEndpointPrometheus: prepare Json response: %w", err)
 	}
@@ -2047,7 +2592,7 @@ func (c Client) DeleteDBAASExternalEndpointRsyslog(ctx context.Context, endpoint
 		return nil, fmt.Errorf("DeleteDBAASExternalEndpointRsyslog: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("DeleteDBAASExternalEndpointRsyslog: prepare Json response: %w", err)
 	}
@@ -2091,7 +2636,7 @@ func (c Client) GetDBAASExternalEndpointRsyslog(ctx context.Context, endpointID 
 		return nil, fmt.Errorf("GetDBAASExternalEndpointRsyslog: http response: %w", err)
 	}
 
-	bodyresp := &DBAASExternalEndpointRsyslogOutput{}
+	bodyresp := new(DBAASExternalEndpointRsyslogOutput)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("GetDBAASExternalEndpointRsyslog: prepare Json response: %w", err)
 	}
@@ -2142,7 +2687,7 @@ func (c Client) UpdateDBAASExternalEndpointRsyslog(ctx context.Context, endpoint
 		return nil, fmt.Errorf("UpdateDBAASExternalEndpointRsyslog: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("UpdateDBAASExternalEndpointRsyslog: prepare Json response: %w", err)
 	}
@@ -2193,7 +2738,7 @@ func (c Client) CreateDBAASExternalEndpointRsyslog(ctx context.Context, name str
 		return nil, fmt.Errorf("CreateDBAASExternalEndpointRsyslog: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("CreateDBAASExternalEndpointRsyslog: prepare Json response: %w", err)
 	}
@@ -2247,7 +2792,7 @@ func (c Client) ListDBAASExternalEndpointTypes(ctx context.Context) (*ListDBAASE
 		return nil, fmt.Errorf("ListDBAASExternalEndpointTypes: http response: %w", err)
 	}
 
-	bodyresp := &ListDBAASExternalEndpointTypesResponse{}
+	bodyresp := new(ListDBAASExternalEndpointTypesResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("ListDBAASExternalEndpointTypes: prepare Json response: %w", err)
 	}
@@ -2304,7 +2849,7 @@ func (c Client) AttachDBAASServiceToEndpoint(ctx context.Context, sourceServiceN
 		return nil, fmt.Errorf("AttachDBAASServiceToEndpoint: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("AttachDBAASServiceToEndpoint: prepare Json response: %w", err)
 	}
@@ -2360,7 +2905,7 @@ func (c Client) DetachDBAASServiceFromEndpoint(ctx context.Context, sourceServic
 		return nil, fmt.Errorf("DetachDBAASServiceFromEndpoint: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("DetachDBAASServiceFromEndpoint: prepare Json response: %w", err)
 	}
@@ -2427,7 +2972,7 @@ func (c Client) ListDBAASExternalEndpoints(ctx context.Context) (*ListDBAASExter
 		return nil, fmt.Errorf("ListDBAASExternalEndpoints: http response: %w", err)
 	}
 
-	bodyresp := &ListDBAASExternalEndpointsResponse{}
+	bodyresp := new(ListDBAASExternalEndpointsResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("ListDBAASExternalEndpoints: prepare Json response: %w", err)
 	}
@@ -2475,7 +3020,7 @@ func (c Client) GetDBAASExternalIntegrationSettingsDatadog(ctx context.Context, 
 		return nil, fmt.Errorf("GetDBAASExternalIntegrationSettingsDatadog: http response: %w", err)
 	}
 
-	bodyresp := &GetDBAASExternalIntegrationSettingsDatadogResponse{}
+	bodyresp := new(GetDBAASExternalIntegrationSettingsDatadogResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("GetDBAASExternalIntegrationSettingsDatadog: prepare Json response: %w", err)
 	}
@@ -2530,7 +3075,7 @@ func (c Client) UpdateDBAASExternalIntegrationSettingsDatadog(ctx context.Contex
 		return nil, fmt.Errorf("UpdateDBAASExternalIntegrationSettingsDatadog: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("UpdateDBAASExternalIntegrationSettingsDatadog: prepare Json response: %w", err)
 	}
@@ -2574,7 +3119,7 @@ func (c Client) GetDBAASExternalIntegration(ctx context.Context, integrationID U
 		return nil, fmt.Errorf("GetDBAASExternalIntegration: http response: %w", err)
 	}
 
-	bodyresp := &DBAASExternalIntegration{}
+	bodyresp := new(DBAASExternalIntegration)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("GetDBAASExternalIntegration: prepare Json response: %w", err)
 	}
@@ -2622,7 +3167,7 @@ func (c Client) ListDBAASExternalIntegrations(ctx context.Context, serviceName s
 		return nil, fmt.Errorf("ListDBAASExternalIntegrations: http response: %w", err)
 	}
 
-	bodyresp := &ListDBAASExternalIntegrationsResponse{}
+	bodyresp := new(ListDBAASExternalIntegrationsResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("ListDBAASExternalIntegrations: prepare Json response: %w", err)
 	}
@@ -2666,7 +3211,7 @@ func (c Client) DeleteDBAASServiceGrafana(ctx context.Context, name string) (*Op
 		return nil, fmt.Errorf("DeleteDBAASServiceGrafana: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("DeleteDBAASServiceGrafana: prepare Json response: %w", err)
 	}
@@ -2710,7 +3255,7 @@ func (c Client) GetDBAASServiceGrafana(ctx context.Context, name string) (*DBAAS
 		return nil, fmt.Errorf("GetDBAASServiceGrafana: http response: %w", err)
 	}
 
-	bodyresp := &DBAASServiceGrafana{}
+	bodyresp := new(DBAASServiceGrafana)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("GetDBAASServiceGrafana: prepare Json response: %w", err)
 	}
@@ -2796,7 +3341,7 @@ func (c Client) CreateDBAASServiceGrafana(ctx context.Context, name string, req 
 		return nil, fmt.Errorf("CreateDBAASServiceGrafana: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("CreateDBAASServiceGrafana: prepare Json response: %w", err)
 	}
@@ -2881,7 +3426,7 @@ func (c Client) UpdateDBAASServiceGrafana(ctx context.Context, name string, req 
 		return nil, fmt.Errorf("UpdateDBAASServiceGrafana: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("UpdateDBAASServiceGrafana: prepare Json response: %w", err)
 	}
@@ -2925,7 +3470,7 @@ func (c Client) StartDBAASGrafanaMaintenance(ctx context.Context, name string) (
 		return nil, fmt.Errorf("StartDBAASGrafanaMaintenance: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("StartDBAASGrafanaMaintenance: prepare Json response: %w", err)
 	}
@@ -2980,7 +3525,7 @@ func (c Client) ResetDBAASGrafanaUserPassword(ctx context.Context, serviceName s
 		return nil, fmt.Errorf("ResetDBAASGrafanaUserPassword: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("ResetDBAASGrafanaUserPassword: prepare Json response: %w", err)
 	}
@@ -3024,7 +3569,7 @@ func (c Client) RevealDBAASGrafanaUserPassword(ctx context.Context, serviceName 
 		return nil, fmt.Errorf("RevealDBAASGrafanaUserPassword: http response: %w", err)
 	}
 
-	bodyresp := &DBAASUserGrafanaSecrets{}
+	bodyresp := new(DBAASUserGrafanaSecrets)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("RevealDBAASGrafanaUserPassword: prepare Json response: %w", err)
 	}
@@ -3083,7 +3628,7 @@ func (c Client) CreateDBAASIntegration(ctx context.Context, req CreateDBAASInteg
 		return nil, fmt.Errorf("CreateDBAASIntegration: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("CreateDBAASIntegration: prepare Json response: %w", err)
 	}
@@ -3140,7 +3685,7 @@ func (c Client) ListDBAASIntegrationSettings(ctx context.Context, integrationTyp
 		return nil, fmt.Errorf("ListDBAASIntegrationSettings: http response: %w", err)
 	}
 
-	bodyresp := &ListDBAASIntegrationSettingsResponse{}
+	bodyresp := new(ListDBAASIntegrationSettingsResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("ListDBAASIntegrationSettings: prepare Json response: %w", err)
 	}
@@ -3188,7 +3733,7 @@ func (c Client) ListDBAASIntegrationTypes(ctx context.Context) (*ListDBAASIntegr
 		return nil, fmt.Errorf("ListDBAASIntegrationTypes: http response: %w", err)
 	}
 
-	bodyresp := &ListDBAASIntegrationTypesResponse{}
+	bodyresp := new(ListDBAASIntegrationTypesResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("ListDBAASIntegrationTypes: prepare Json response: %w", err)
 	}
@@ -3232,7 +3777,7 @@ func (c Client) DeleteDBAASIntegration(ctx context.Context, id UUID) (*Operation
 		return nil, fmt.Errorf("DeleteDBAASIntegration: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("DeleteDBAASIntegration: prepare Json response: %w", err)
 	}
@@ -3276,7 +3821,7 @@ func (c Client) GetDBAASIntegration(ctx context.Context, id UUID) (*DBAASIntegra
 		return nil, fmt.Errorf("GetDBAASIntegration: http response: %w", err)
 	}
 
-	bodyresp := &DBAASIntegration{}
+	bodyresp := new(DBAASIntegration)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("GetDBAASIntegration: prepare Json response: %w", err)
 	}
@@ -3332,7 +3877,7 @@ func (c Client) UpdateDBAASIntegration(ctx context.Context, id UUID, req UpdateD
 		return nil, fmt.Errorf("UpdateDBAASIntegration: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("UpdateDBAASIntegration: prepare Json response: %w", err)
 	}
@@ -3376,7 +3921,7 @@ func (c Client) DeleteDBAASServiceKafka(ctx context.Context, name string) (*Oper
 		return nil, fmt.Errorf("DeleteDBAASServiceKafka: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("DeleteDBAASServiceKafka: prepare Json response: %w", err)
 	}
@@ -3420,7 +3965,7 @@ func (c Client) GetDBAASServiceKafka(ctx context.Context, name string) (*DBAASSe
 		return nil, fmt.Errorf("GetDBAASServiceKafka: http response: %w", err)
 	}
 
-	bodyresp := &DBAASServiceKafka{}
+	bodyresp := new(DBAASServiceKafka)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("GetDBAASServiceKafka: prepare Json response: %w", err)
 	}
@@ -3529,7 +4074,7 @@ func (c Client) CreateDBAASServiceKafka(ctx context.Context, name string, req Cr
 		return nil, fmt.Errorf("CreateDBAASServiceKafka: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("CreateDBAASServiceKafka: prepare Json response: %w", err)
 	}
@@ -3638,7 +4183,7 @@ func (c Client) UpdateDBAASServiceKafka(ctx context.Context, name string, req Up
 		return nil, fmt.Errorf("UpdateDBAASServiceKafka: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("UpdateDBAASServiceKafka: prepare Json response: %w", err)
 	}
@@ -3682,7 +4227,7 @@ func (c Client) GetDBAASKafkaAclConfig(ctx context.Context, name string) (*DBAAS
 		return nil, fmt.Errorf("GetDBAASKafkaAclConfig: http response: %w", err)
 	}
 
-	bodyresp := &DBAASKafkaAcls{}
+	bodyresp := new(DBAASKafkaAcls)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("GetDBAASKafkaAclConfig: prepare Json response: %w", err)
 	}
@@ -3726,7 +4271,7 @@ func (c Client) StartDBAASKafkaMaintenance(ctx context.Context, name string) (*O
 		return nil, fmt.Errorf("StartDBAASKafkaMaintenance: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("StartDBAASKafkaMaintenance: prepare Json response: %w", err)
 	}
@@ -3777,7 +4322,7 @@ func (c Client) CreateDBAASKafkaSchemaRegistryAclConfig(ctx context.Context, nam
 		return nil, fmt.Errorf("CreateDBAASKafkaSchemaRegistryAclConfig: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("CreateDBAASKafkaSchemaRegistryAclConfig: prepare Json response: %w", err)
 	}
@@ -3821,7 +4366,7 @@ func (c Client) DeleteDBAASKafkaSchemaRegistryAclConfig(ctx context.Context, nam
 		return nil, fmt.Errorf("DeleteDBAASKafkaSchemaRegistryAclConfig: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("DeleteDBAASKafkaSchemaRegistryAclConfig: prepare Json response: %w", err)
 	}
@@ -3872,7 +4417,7 @@ func (c Client) CreateDBAASKafkaTopicAclConfig(ctx context.Context, name string,
 		return nil, fmt.Errorf("CreateDBAASKafkaTopicAclConfig: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("CreateDBAASKafkaTopicAclConfig: prepare Json response: %w", err)
 	}
@@ -3916,7 +4461,7 @@ func (c Client) DeleteDBAASKafkaTopicAclConfig(ctx context.Context, name string,
 		return nil, fmt.Errorf("DeleteDBAASKafkaTopicAclConfig: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("DeleteDBAASKafkaTopicAclConfig: prepare Json response: %w", err)
 	}
@@ -3960,7 +4505,7 @@ func (c Client) RevealDBAASKafkaConnectPassword(ctx context.Context, serviceName
 		return nil, fmt.Errorf("RevealDBAASKafkaConnectPassword: http response: %w", err)
 	}
 
-	bodyresp := &DBAASUserKafkaConnectSecrets{}
+	bodyresp := new(DBAASUserKafkaConnectSecrets)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("RevealDBAASKafkaConnectPassword: prepare Json response: %w", err)
 	}
@@ -4015,7 +4560,7 @@ func (c Client) CreateDBAASKafkaUser(ctx context.Context, serviceName string, re
 		return nil, fmt.Errorf("CreateDBAASKafkaUser: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("CreateDBAASKafkaUser: prepare Json response: %w", err)
 	}
@@ -4059,7 +4604,7 @@ func (c Client) DeleteDBAASKafkaUser(ctx context.Context, serviceName string, us
 		return nil, fmt.Errorf("DeleteDBAASKafkaUser: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("DeleteDBAASKafkaUser: prepare Json response: %w", err)
 	}
@@ -4114,7 +4659,7 @@ func (c Client) ResetDBAASKafkaUserPassword(ctx context.Context, serviceName str
 		return nil, fmt.Errorf("ResetDBAASKafkaUserPassword: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("ResetDBAASKafkaUserPassword: prepare Json response: %w", err)
 	}
@@ -4158,7 +4703,7 @@ func (c Client) RevealDBAASKafkaUserPassword(ctx context.Context, serviceName st
 		return nil, fmt.Errorf("RevealDBAASKafkaUserPassword: http response: %w", err)
 	}
 
-	bodyresp := &DBAASUserKafkaSecrets{}
+	bodyresp := new(DBAASUserKafkaSecrets)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("RevealDBAASKafkaUserPassword: prepare Json response: %w", err)
 	}
@@ -4202,7 +4747,7 @@ func (c Client) GetDBAASMigrationStatus(ctx context.Context, name string) (*DBAA
 		return nil, fmt.Errorf("GetDBAASMigrationStatus: http response: %w", err)
 	}
 
-	bodyresp := &DBAASMigrationStatus{}
+	bodyresp := new(DBAASMigrationStatus)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("GetDBAASMigrationStatus: prepare Json response: %w", err)
 	}
@@ -4246,7 +4791,7 @@ func (c Client) DeleteDBAASServiceMysql(ctx context.Context, name string) (*Oper
 		return nil, fmt.Errorf("DeleteDBAASServiceMysql: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("DeleteDBAASServiceMysql: prepare Json response: %w", err)
 	}
@@ -4290,7 +4835,7 @@ func (c Client) GetDBAASServiceMysql(ctx context.Context, name string) (*DBAASSe
 		return nil, fmt.Errorf("GetDBAASServiceMysql: http response: %w", err)
 	}
 
-	bodyresp := &DBAASServiceMysql{}
+	bodyresp := new(DBAASServiceMysql)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("GetDBAASServiceMysql: prepare Json response: %w", err)
 	}
@@ -4432,7 +4977,7 @@ func (c Client) CreateDBAASServiceMysql(ctx context.Context, name string, req Cr
 		return nil, fmt.Errorf("CreateDBAASServiceMysql: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("CreateDBAASServiceMysql: prepare Json response: %w", err)
 	}
@@ -4548,7 +5093,7 @@ func (c Client) UpdateDBAASServiceMysql(ctx context.Context, name string, req Up
 		return nil, fmt.Errorf("UpdateDBAASServiceMysql: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("UpdateDBAASServiceMysql: prepare Json response: %w", err)
 	}
@@ -4592,7 +5137,7 @@ func (c Client) EnableDBAASMysqlWrites(ctx context.Context, name string) (*Opera
 		return nil, fmt.Errorf("EnableDBAASMysqlWrites: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("EnableDBAASMysqlWrites: prepare Json response: %w", err)
 	}
@@ -4636,7 +5181,7 @@ func (c Client) StartDBAASMysqlMaintenance(ctx context.Context, name string) (*O
 		return nil, fmt.Errorf("StartDBAASMysqlMaintenance: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("StartDBAASMysqlMaintenance: prepare Json response: %w", err)
 	}
@@ -4680,7 +5225,7 @@ func (c Client) StopDBAASMysqlMigration(ctx context.Context, name string) (*Oper
 		return nil, fmt.Errorf("StopDBAASMysqlMigration: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("StopDBAASMysqlMigration: prepare Json response: %w", err)
 	}
@@ -4735,7 +5280,7 @@ func (c Client) CreateDBAASMysqlDatabase(ctx context.Context, serviceName string
 		return nil, fmt.Errorf("CreateDBAASMysqlDatabase: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("CreateDBAASMysqlDatabase: prepare Json response: %w", err)
 	}
@@ -4779,7 +5324,7 @@ func (c Client) DeleteDBAASMysqlDatabase(ctx context.Context, serviceName string
 		return nil, fmt.Errorf("DeleteDBAASMysqlDatabase: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("DeleteDBAASMysqlDatabase: prepare Json response: %w", err)
 	}
@@ -4835,7 +5380,7 @@ func (c Client) CreateDBAASMysqlUser(ctx context.Context, serviceName string, re
 		return nil, fmt.Errorf("CreateDBAASMysqlUser: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("CreateDBAASMysqlUser: prepare Json response: %w", err)
 	}
@@ -4879,7 +5424,7 @@ func (c Client) DeleteDBAASMysqlUser(ctx context.Context, serviceName string, us
 		return nil, fmt.Errorf("DeleteDBAASMysqlUser: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("DeleteDBAASMysqlUser: prepare Json response: %w", err)
 	}
@@ -4935,7 +5480,7 @@ func (c Client) ResetDBAASMysqlUserPassword(ctx context.Context, serviceName str
 		return nil, fmt.Errorf("ResetDBAASMysqlUserPassword: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("ResetDBAASMysqlUserPassword: prepare Json response: %w", err)
 	}
@@ -4979,7 +5524,7 @@ func (c Client) RevealDBAASMysqlUserPassword(ctx context.Context, serviceName st
 		return nil, fmt.Errorf("RevealDBAASMysqlUserPassword: http response: %w", err)
 	}
 
-	bodyresp := &DBAASUserMysqlSecrets{}
+	bodyresp := new(DBAASUserMysqlSecrets)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("RevealDBAASMysqlUserPassword: prepare Json response: %w", err)
 	}
@@ -5023,7 +5568,7 @@ func (c Client) DeleteDBAASServiceOpensearch(ctx context.Context, name string) (
 		return nil, fmt.Errorf("DeleteDBAASServiceOpensearch: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("DeleteDBAASServiceOpensearch: prepare Json response: %w", err)
 	}
@@ -5067,7 +5612,7 @@ func (c Client) GetDBAASServiceOpensearch(ctx context.Context, name string) (*DB
 		return nil, fmt.Errorf("GetDBAASServiceOpensearch: http response: %w", err)
 	}
 
-	bodyresp := &DBAASServiceOpensearch{}
+	bodyresp := new(DBAASServiceOpensearch)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("GetDBAASServiceOpensearch: prepare Json response: %w", err)
 	}
@@ -5203,7 +5748,7 @@ func (c Client) CreateDBAASServiceOpensearch(ctx context.Context, name string, r
 		return nil, fmt.Errorf("CreateDBAASServiceOpensearch: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("CreateDBAASServiceOpensearch: prepare Json response: %w", err)
 	}
@@ -5336,7 +5881,7 @@ func (c Client) UpdateDBAASServiceOpensearch(ctx context.Context, name string, r
 		return nil, fmt.Errorf("UpdateDBAASServiceOpensearch: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("UpdateDBAASServiceOpensearch: prepare Json response: %w", err)
 	}
@@ -5380,7 +5925,7 @@ func (c Client) GetDBAASOpensearchAclConfig(ctx context.Context, name string) (*
 		return nil, fmt.Errorf("GetDBAASOpensearchAclConfig: http response: %w", err)
 	}
 
-	bodyresp := &DBAASOpensearchAclConfig{}
+	bodyresp := new(DBAASOpensearchAclConfig)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("GetDBAASOpensearchAclConfig: prepare Json response: %w", err)
 	}
@@ -5431,7 +5976,7 @@ func (c Client) UpdateDBAASOpensearchAclConfig(ctx context.Context, name string,
 		return nil, fmt.Errorf("UpdateDBAASOpensearchAclConfig: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("UpdateDBAASOpensearchAclConfig: prepare Json response: %w", err)
 	}
@@ -5475,7 +6020,7 @@ func (c Client) StartDBAASOpensearchMaintenance(ctx context.Context, name string
 		return nil, fmt.Errorf("StartDBAASOpensearchMaintenance: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("StartDBAASOpensearchMaintenance: prepare Json response: %w", err)
 	}
@@ -5530,7 +6075,7 @@ func (c Client) CreateDBAASOpensearchUser(ctx context.Context, serviceName strin
 		return nil, fmt.Errorf("CreateDBAASOpensearchUser: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("CreateDBAASOpensearchUser: prepare Json response: %w", err)
 	}
@@ -5574,7 +6119,7 @@ func (c Client) DeleteDBAASOpensearchUser(ctx context.Context, serviceName strin
 		return nil, fmt.Errorf("DeleteDBAASOpensearchUser: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("DeleteDBAASOpensearchUser: prepare Json response: %w", err)
 	}
@@ -5629,7 +6174,7 @@ func (c Client) ResetDBAASOpensearchUserPassword(ctx context.Context, serviceNam
 		return nil, fmt.Errorf("ResetDBAASOpensearchUserPassword: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("ResetDBAASOpensearchUserPassword: prepare Json response: %w", err)
 	}
@@ -5673,7 +6218,7 @@ func (c Client) RevealDBAASOpensearchUserPassword(ctx context.Context, serviceNa
 		return nil, fmt.Errorf("RevealDBAASOpensearchUserPassword: http response: %w", err)
 	}
 
-	bodyresp := &DBAASUserOpensearchSecrets{}
+	bodyresp := new(DBAASUserOpensearchSecrets)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("RevealDBAASOpensearchUserPassword: prepare Json response: %w", err)
 	}
@@ -5717,7 +6262,7 @@ func (c Client) DeleteDBAASServicePG(ctx context.Context, name string) (*Operati
 		return nil, fmt.Errorf("DeleteDBAASServicePG: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("DeleteDBAASServicePG: prepare Json response: %w", err)
 	}
@@ -5761,7 +6306,7 @@ func (c Client) GetDBAASServicePG(ctx context.Context, name string) (*DBAASServi
 		return nil, fmt.Errorf("GetDBAASServicePG: http response: %w", err)
 	}
 
-	bodyresp := &DBAASServicePG{}
+	bodyresp := new(DBAASServicePG)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("GetDBAASServicePG: prepare Json response: %w", err)
 	}
@@ -5912,7 +6457,7 @@ func (c Client) CreateDBAASServicePG(ctx context.Context, name string, req Creat
 		return nil, fmt.Errorf("CreateDBAASServicePG: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("CreateDBAASServicePG: prepare Json response: %w", err)
 	}
@@ -6040,7 +6585,7 @@ func (c Client) UpdateDBAASServicePG(ctx context.Context, name string, req Updat
 		return nil, fmt.Errorf("UpdateDBAASServicePG: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("UpdateDBAASServicePG: prepare Json response: %w", err)
 	}
@@ -6084,7 +6629,7 @@ func (c Client) StartDBAASPGMaintenance(ctx context.Context, name string) (*Oper
 		return nil, fmt.Errorf("StartDBAASPGMaintenance: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("StartDBAASPGMaintenance: prepare Json response: %w", err)
 	}
@@ -6128,7 +6673,7 @@ func (c Client) StopDBAASPGMigration(ctx context.Context, name string) (*Operati
 		return nil, fmt.Errorf("StopDBAASPGMigration: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("StopDBAASPGMigration: prepare Json response: %w", err)
 	}
@@ -6187,7 +6732,7 @@ func (c Client) CreateDBAASPGConnectionPool(ctx context.Context, serviceName str
 		return nil, fmt.Errorf("CreateDBAASPGConnectionPool: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("CreateDBAASPGConnectionPool: prepare Json response: %w", err)
 	}
@@ -6231,7 +6776,7 @@ func (c Client) DeleteDBAASPGConnectionPool(ctx context.Context, serviceName str
 		return nil, fmt.Errorf("DeleteDBAASPGConnectionPool: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("DeleteDBAASPGConnectionPool: prepare Json response: %w", err)
 	}
@@ -6289,7 +6834,7 @@ func (c Client) UpdateDBAASPGConnectionPool(ctx context.Context, serviceName str
 		return nil, fmt.Errorf("UpdateDBAASPGConnectionPool: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("UpdateDBAASPGConnectionPool: prepare Json response: %w", err)
 	}
@@ -6348,7 +6893,7 @@ func (c Client) CreateDBAASPGDatabase(ctx context.Context, serviceName string, r
 		return nil, fmt.Errorf("CreateDBAASPGDatabase: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("CreateDBAASPGDatabase: prepare Json response: %w", err)
 	}
@@ -6392,7 +6937,7 @@ func (c Client) DeleteDBAASPGDatabase(ctx context.Context, serviceName string, d
 		return nil, fmt.Errorf("DeleteDBAASPGDatabase: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("DeleteDBAASPGDatabase: prepare Json response: %w", err)
 	}
@@ -6448,7 +6993,7 @@ func (c Client) CreateDBAASPostgresUser(ctx context.Context, serviceName string,
 		return nil, fmt.Errorf("CreateDBAASPostgresUser: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("CreateDBAASPostgresUser: prepare Json response: %w", err)
 	}
@@ -6492,7 +7037,7 @@ func (c Client) DeleteDBAASPostgresUser(ctx context.Context, serviceName string,
 		return nil, fmt.Errorf("DeleteDBAASPostgresUser: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("DeleteDBAASPostgresUser: prepare Json response: %w", err)
 	}
@@ -6547,7 +7092,7 @@ func (c Client) UpdateDBAASPostgresAllowReplication(ctx context.Context, service
 		return nil, fmt.Errorf("UpdateDBAASPostgresAllowReplication: http response: %w", err)
 	}
 
-	bodyresp := &DBAASPostgresUsers{}
+	bodyresp := new(DBAASPostgresUsers)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("UpdateDBAASPostgresAllowReplication: prepare Json response: %w", err)
 	}
@@ -6602,7 +7147,7 @@ func (c Client) ResetDBAASPostgresUserPassword(ctx context.Context, serviceName 
 		return nil, fmt.Errorf("ResetDBAASPostgresUserPassword: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("ResetDBAASPostgresUserPassword: prepare Json response: %w", err)
 	}
@@ -6646,7 +7191,7 @@ func (c Client) RevealDBAASPostgresUserPassword(ctx context.Context, serviceName
 		return nil, fmt.Errorf("RevealDBAASPostgresUserPassword: http response: %w", err)
 	}
 
-	bodyresp := &DBAASUserPostgresSecrets{}
+	bodyresp := new(DBAASUserPostgresSecrets)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("RevealDBAASPostgresUserPassword: prepare Json response: %w", err)
 	}
@@ -6701,7 +7246,7 @@ func (c Client) CreateDBAASPGUpgradeCheck(ctx context.Context, service string, r
 		return nil, fmt.Errorf("CreateDBAASPGUpgradeCheck: http response: %w", err)
 	}
 
-	bodyresp := &DBAASTask{}
+	bodyresp := new(DBAASTask)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("CreateDBAASPGUpgradeCheck: prepare Json response: %w", err)
 	}
@@ -6768,7 +7313,7 @@ func (c Client) ListDBAASServices(ctx context.Context) (*ListDBAASServicesRespon
 		return nil, fmt.Errorf("ListDBAASServices: http response: %w", err)
 	}
 
-	bodyresp := &ListDBAASServicesResponse{}
+	bodyresp := new(ListDBAASServicesResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("ListDBAASServices: prepare Json response: %w", err)
 	}
@@ -6827,7 +7372,7 @@ func (c Client) GetDBAASServiceLogs(ctx context.Context, serviceName string, req
 		return nil, fmt.Errorf("GetDBAASServiceLogs: http response: %w", err)
 	}
 
-	bodyresp := &DBAASServiceLogs{}
+	bodyresp := new(DBAASServiceLogs)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("GetDBAASServiceLogs: prepare Json response: %w", err)
 	}
@@ -6897,7 +7442,7 @@ func (c Client) GetDBAASServiceMetrics(ctx context.Context, serviceName string, 
 		return nil, fmt.Errorf("GetDBAASServiceMetrics: http response: %w", err)
 	}
 
-	bodyresp := &GetDBAASServiceMetricsResponse{}
+	bodyresp := new(GetDBAASServiceMetricsResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("GetDBAASServiceMetrics: prepare Json response: %w", err)
 	}
@@ -6964,7 +7509,7 @@ func (c Client) ListDBAASServiceTypes(ctx context.Context) (*ListDBAASServiceTyp
 		return nil, fmt.Errorf("ListDBAASServiceTypes: http response: %w", err)
 	}
 
-	bodyresp := &ListDBAASServiceTypesResponse{}
+	bodyresp := new(ListDBAASServiceTypesResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("ListDBAASServiceTypes: prepare Json response: %w", err)
 	}
@@ -7008,7 +7553,7 @@ func (c Client) GetDBAASServiceType(ctx context.Context, serviceTypeName string)
 		return nil, fmt.Errorf("GetDBAASServiceType: http response: %w", err)
 	}
 
-	bodyresp := &DBAASServiceType{}
+	bodyresp := new(DBAASServiceType)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("GetDBAASServiceType: prepare Json response: %w", err)
 	}
@@ -7052,7 +7597,7 @@ func (c Client) DeleteDBAASService(ctx context.Context, name string) (*Operation
 		return nil, fmt.Errorf("DeleteDBAASService: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("DeleteDBAASService: prepare Json response: %w", err)
 	}
@@ -7113,7 +7658,7 @@ func (c Client) GetDBAASSettingsGrafana(ctx context.Context) (*GetDBAASSettingsG
 		return nil, fmt.Errorf("GetDBAASSettingsGrafana: http response: %w", err)
 	}
 
-	bodyresp := &GetDBAASSettingsGrafanaResponse{}
+	bodyresp := new(GetDBAASSettingsGrafanaResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("GetDBAASSettingsGrafana: prepare Json response: %w", err)
 	}
@@ -7204,7 +7749,7 @@ func (c Client) GetDBAASSettingsKafka(ctx context.Context) (*GetDBAASSettingsKaf
 		return nil, fmt.Errorf("GetDBAASSettingsKafka: http response: %w", err)
 	}
 
-	bodyresp := &GetDBAASSettingsKafkaResponse{}
+	bodyresp := new(GetDBAASSettingsKafkaResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("GetDBAASSettingsKafka: prepare Json response: %w", err)
 	}
@@ -7265,7 +7810,7 @@ func (c Client) GetDBAASSettingsMysql(ctx context.Context) (*GetDBAASSettingsMys
 		return nil, fmt.Errorf("GetDBAASSettingsMysql: http response: %w", err)
 	}
 
-	bodyresp := &GetDBAASSettingsMysqlResponse{}
+	bodyresp := new(GetDBAASSettingsMysqlResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("GetDBAASSettingsMysql: prepare Json response: %w", err)
 	}
@@ -7326,7 +7871,7 @@ func (c Client) GetDBAASSettingsOpensearch(ctx context.Context) (*GetDBAASSettin
 		return nil, fmt.Errorf("GetDBAASSettingsOpensearch: http response: %w", err)
 	}
 
-	bodyresp := &GetDBAASSettingsOpensearchResponse{}
+	bodyresp := new(GetDBAASSettingsOpensearchResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("GetDBAASSettingsOpensearch: prepare Json response: %w", err)
 	}
@@ -7417,7 +7962,7 @@ func (c Client) GetDBAASSettingsPG(ctx context.Context) (*GetDBAASSettingsPGResp
 		return nil, fmt.Errorf("GetDBAASSettingsPG: http response: %w", err)
 	}
 
-	bodyresp := &GetDBAASSettingsPGResponse{}
+	bodyresp := new(GetDBAASSettingsPGResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("GetDBAASSettingsPG: prepare Json response: %w", err)
 	}
@@ -7478,7 +8023,7 @@ func (c Client) GetDBAASSettingsValkey(ctx context.Context) (*GetDBAASSettingsVa
 		return nil, fmt.Errorf("GetDBAASSettingsValkey: http response: %w", err)
 	}
 
-	bodyresp := &GetDBAASSettingsValkeyResponse{}
+	bodyresp := new(GetDBAASSettingsValkeyResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("GetDBAASSettingsValkey: prepare Json response: %w", err)
 	}
@@ -7537,7 +8082,7 @@ func (c Client) CreateDBAASTaskMigrationCheck(ctx context.Context, service strin
 		return nil, fmt.Errorf("CreateDBAASTaskMigrationCheck: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("CreateDBAASTaskMigrationCheck: prepare Json response: %w", err)
 	}
@@ -7581,7 +8126,7 @@ func (c Client) GetDBAASTask(ctx context.Context, service string, id UUID) (*DBA
 		return nil, fmt.Errorf("GetDBAASTask: http response: %w", err)
 	}
 
-	bodyresp := &DBAASTask{}
+	bodyresp := new(DBAASTask)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("GetDBAASTask: prepare Json response: %w", err)
 	}
@@ -7625,7 +8170,7 @@ func (c Client) DeleteDBAASServiceValkey(ctx context.Context, name string) (*Ope
 		return nil, fmt.Errorf("DeleteDBAASServiceValkey: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("DeleteDBAASServiceValkey: prepare Json response: %w", err)
 	}
@@ -7669,7 +8214,7 @@ func (c Client) GetDBAASServiceValkey(ctx context.Context, name string) (*DBAASS
 		return nil, fmt.Errorf("GetDBAASServiceValkey: http response: %w", err)
 	}
 
-	bodyresp := &DBAASServiceValkey{}
+	bodyresp := new(DBAASServiceValkey)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("GetDBAASServiceValkey: prepare Json response: %w", err)
 	}
@@ -7778,7 +8323,7 @@ func (c Client) CreateDBAASServiceValkey(ctx context.Context, name string, req C
 		return nil, fmt.Errorf("CreateDBAASServiceValkey: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("CreateDBAASServiceValkey: prepare Json response: %w", err)
 	}
@@ -7884,7 +8429,7 @@ func (c Client) UpdateDBAASServiceValkey(ctx context.Context, name string, req U
 		return nil, fmt.Errorf("UpdateDBAASServiceValkey: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("UpdateDBAASServiceValkey: prepare Json response: %w", err)
 	}
@@ -7928,7 +8473,7 @@ func (c Client) StartDBAASValkeyMaintenance(ctx context.Context, name string) (*
 		return nil, fmt.Errorf("StartDBAASValkeyMaintenance: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("StartDBAASValkeyMaintenance: prepare Json response: %w", err)
 	}
@@ -7972,7 +8517,7 @@ func (c Client) StopDBAASValkeyMigration(ctx context.Context, name string) (*Ope
 		return nil, fmt.Errorf("StopDBAASValkeyMigration: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("StopDBAASValkeyMigration: prepare Json response: %w", err)
 	}
@@ -8027,7 +8572,7 @@ func (c Client) CreateDBAASValkeyUser(ctx context.Context, serviceName string, r
 		return nil, fmt.Errorf("CreateDBAASValkeyUser: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("CreateDBAASValkeyUser: prepare Json response: %w", err)
 	}
@@ -8071,7 +8616,7 @@ func (c Client) DeleteDBAASValkeyUser(ctx context.Context, serviceName string, u
 		return nil, fmt.Errorf("DeleteDBAASValkeyUser: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("DeleteDBAASValkeyUser: prepare Json response: %w", err)
 	}
@@ -8126,7 +8671,7 @@ func (c Client) ResetDBAASValkeyUserPassword(ctx context.Context, serviceName st
 		return nil, fmt.Errorf("ResetDBAASValkeyUserPassword: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("ResetDBAASValkeyUserPassword: prepare Json response: %w", err)
 	}
@@ -8170,7 +8715,7 @@ func (c Client) RevealDBAASValkeyUserPassword(ctx context.Context, serviceName s
 		return nil, fmt.Errorf("RevealDBAASValkeyUserPassword: http response: %w", err)
 	}
 
-	bodyresp := &DBAASUserValkeySecrets{}
+	bodyresp := new(DBAASUserValkeySecrets)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("RevealDBAASValkeyUserPassword: prepare Json response: %w", err)
 	}
@@ -8237,7 +8782,7 @@ func (c Client) ListDeployTargets(ctx context.Context) (*ListDeployTargetsRespon
 		return nil, fmt.Errorf("ListDeployTargets: http response: %w", err)
 	}
 
-	bodyresp := &ListDeployTargetsResponse{}
+	bodyresp := new(ListDeployTargetsResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("ListDeployTargets: prepare Json response: %w", err)
 	}
@@ -8281,7 +8826,7 @@ func (c Client) GetDeployTarget(ctx context.Context, id UUID) (*DeployTarget, er
 		return nil, fmt.Errorf("GetDeployTarget: http response: %w", err)
 	}
 
-	bodyresp := &DeployTarget{}
+	bodyresp := new(DeployTarget)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("GetDeployTarget: prepare Json response: %w", err)
 	}
@@ -8348,7 +8893,7 @@ func (c Client) ListDNSDomains(ctx context.Context) (*ListDNSDomainsResponse, er
 		return nil, fmt.Errorf("ListDNSDomains: http response: %w", err)
 	}
 
-	bodyresp := &ListDNSDomainsResponse{}
+	bodyresp := new(ListDNSDomainsResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("ListDNSDomains: prepare Json response: %w", err)
 	}
@@ -8405,7 +8950,7 @@ func (c Client) CreateDNSDomain(ctx context.Context, req CreateDNSDomainRequest)
 		return nil, fmt.Errorf("CreateDNSDomain: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("CreateDNSDomain: prepare Json response: %w", err)
 	}
@@ -8472,7 +9017,7 @@ func (c Client) ListDNSDomainRecords(ctx context.Context, domainID UUID) (*ListD
 		return nil, fmt.Errorf("ListDNSDomainRecords: http response: %w", err)
 	}
 
-	bodyresp := &ListDNSDomainRecordsResponse{}
+	bodyresp := new(ListDNSDomainRecordsResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("ListDNSDomainRecords: prepare Json response: %w", err)
 	}
@@ -8555,7 +9100,7 @@ func (c Client) CreateDNSDomainRecord(ctx context.Context, domainID UUID, req Cr
 		return nil, fmt.Errorf("CreateDNSDomainRecord: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("CreateDNSDomainRecord: prepare Json response: %w", err)
 	}
@@ -8599,7 +9144,7 @@ func (c Client) DeleteDNSDomainRecord(ctx context.Context, domainID UUID, record
 		return nil, fmt.Errorf("DeleteDNSDomainRecord: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("DeleteDNSDomainRecord: prepare Json response: %w", err)
 	}
@@ -8643,7 +9188,7 @@ func (c Client) GetDNSDomainRecord(ctx context.Context, domainID UUID, recordID 
 		return nil, fmt.Errorf("GetDNSDomainRecord: http response: %w", err)
 	}
 
-	bodyresp := &DNSDomainRecord{}
+	bodyresp := new(DNSDomainRecord)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("GetDNSDomainRecord: prepare Json response: %w", err)
 	}
@@ -8705,7 +9250,7 @@ func (c Client) UpdateDNSDomainRecord(ctx context.Context, domainID UUID, record
 		return nil, fmt.Errorf("UpdateDNSDomainRecord: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("UpdateDNSDomainRecord: prepare Json response: %w", err)
 	}
@@ -8749,7 +9294,7 @@ func (c Client) DeleteDNSDomain(ctx context.Context, id UUID) (*Operation, error
 		return nil, fmt.Errorf("DeleteDNSDomain: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("DeleteDNSDomain: prepare Json response: %w", err)
 	}
@@ -8793,7 +9338,7 @@ func (c Client) GetDNSDomain(ctx context.Context, id UUID) (*DNSDomain, error) {
 		return nil, fmt.Errorf("GetDNSDomain: http response: %w", err)
 	}
 
-	bodyresp := &DNSDomain{}
+	bodyresp := new(DNSDomain)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("GetDNSDomain: prepare Json response: %w", err)
 	}
@@ -8841,7 +9386,7 @@ func (c Client) GetDNSDomainZoneFile(ctx context.Context, id UUID) (*GetDNSDomai
 		return nil, fmt.Errorf("GetDNSDomainZoneFile: http response: %w", err)
 	}
 
-	bodyresp := &GetDNSDomainZoneFileResponse{}
+	bodyresp := new(GetDNSDomainZoneFileResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("GetDNSDomainZoneFile: prepare Json response: %w", err)
 	}
@@ -8908,7 +9453,7 @@ func (c Client) ListElasticIPS(ctx context.Context) (*ListElasticIPSResponse, er
 		return nil, fmt.Errorf("ListElasticIPS: http response: %w", err)
 	}
 
-	bodyresp := &ListElasticIPSResponse{}
+	bodyresp := new(ListElasticIPSResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("ListElasticIPS: prepare Json response: %w", err)
 	}
@@ -8976,7 +9521,7 @@ func (c Client) CreateElasticIP(ctx context.Context, req CreateElasticIPRequest)
 		return nil, fmt.Errorf("CreateElasticIP: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("CreateElasticIP: prepare Json response: %w", err)
 	}
@@ -9020,7 +9565,7 @@ func (c Client) DeleteElasticIP(ctx context.Context, id UUID) (*Operation, error
 		return nil, fmt.Errorf("DeleteElasticIP: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("DeleteElasticIP: prepare Json response: %w", err)
 	}
@@ -9064,7 +9609,7 @@ func (c Client) GetElasticIP(ctx context.Context, id UUID) (*ElasticIP, error) {
 		return nil, fmt.Errorf("GetElasticIP: http response: %w", err)
 	}
 
-	bodyresp := &ElasticIP{}
+	bodyresp := new(ElasticIP)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("GetElasticIP: prepare Json response: %w", err)
 	}
@@ -9123,7 +9668,7 @@ func (c Client) UpdateElasticIP(ctx context.Context, id UUID, req UpdateElasticI
 		return nil, fmt.Errorf("UpdateElasticIP: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("UpdateElasticIP: prepare Json response: %w", err)
 	}
@@ -9173,7 +9718,7 @@ func (c Client) ResetElasticIPField(ctx context.Context, id UUID, field ResetEla
 		return nil, fmt.Errorf("ResetElasticIPField: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("ResetElasticIPField: prepare Json response: %w", err)
 	}
@@ -9229,7 +9774,7 @@ func (c Client) AttachInstanceToElasticIP(ctx context.Context, id UUID, req Atta
 		return nil, fmt.Errorf("AttachInstanceToElasticIP: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("AttachInstanceToElasticIP: prepare Json response: %w", err)
 	}
@@ -9285,7 +9830,7 @@ func (c Client) DetachInstanceFromElasticIP(ctx context.Context, id UUID, req De
 		return nil, fmt.Errorf("DetachInstanceFromElasticIP: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("DetachInstanceFromElasticIP: prepare Json response: %w", err)
 	}
@@ -9329,7 +9874,7 @@ func (c Client) GetEnvImpact(ctx context.Context, period string) (*EnvImpactRepo
 		return nil, fmt.Errorf("GetEnvImpact: http response: %w", err)
 	}
 
-	bodyresp := &EnvImpactReport{}
+	bodyresp := new(EnvImpactReport)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("GetEnvImpact: prepare Json response: %w", err)
 	}
@@ -9441,7 +9986,7 @@ func (c Client) GetIAMOrganizationPolicy(ctx context.Context) (*IAMPolicy, error
 		return nil, fmt.Errorf("GetIAMOrganizationPolicy: http response: %w", err)
 	}
 
-	bodyresp := &IAMPolicy{}
+	bodyresp := new(IAMPolicy)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("GetIAMOrganizationPolicy: prepare Json response: %w", err)
 	}
@@ -9492,7 +10037,7 @@ func (c Client) UpdateIAMOrganizationPolicy(ctx context.Context, req IAMPolicy) 
 		return nil, fmt.Errorf("UpdateIAMOrganizationPolicy: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("UpdateIAMOrganizationPolicy: prepare Json response: %w", err)
 	}
@@ -9536,7 +10081,7 @@ func (c Client) ResetIAMOrganizationPolicy(ctx context.Context) (*Operation, err
 		return nil, fmt.Errorf("ResetIAMOrganizationPolicy: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("ResetIAMOrganizationPolicy: prepare Json response: %w", err)
 	}
@@ -9603,7 +10148,7 @@ func (c Client) ListIAMRoles(ctx context.Context) (*ListIAMRolesResponse, error)
 		return nil, fmt.Errorf("ListIAMRoles: http response: %w", err)
 	}
 
-	bodyresp := &ListIAMRolesResponse{}
+	bodyresp := new(ListIAMRolesResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("ListIAMRoles: prepare Json response: %w", err)
 	}
@@ -9668,7 +10213,7 @@ func (c Client) CreateIAMRole(ctx context.Context, req CreateIAMRoleRequest) (*O
 		return nil, fmt.Errorf("CreateIAMRole: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("CreateIAMRole: prepare Json response: %w", err)
 	}
@@ -9712,7 +10257,7 @@ func (c Client) DeleteIAMRole(ctx context.Context, id UUID) (*Operation, error) 
 		return nil, fmt.Errorf("DeleteIAMRole: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("DeleteIAMRole: prepare Json response: %w", err)
 	}
@@ -9756,7 +10301,7 @@ func (c Client) GetIAMRole(ctx context.Context, id UUID) (*IAMRole, error) {
 		return nil, fmt.Errorf("GetIAMRole: http response: %w", err)
 	}
 
-	bodyresp := &IAMRole{}
+	bodyresp := new(IAMRole)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("GetIAMRole: prepare Json response: %w", err)
 	}
@@ -9815,7 +10360,7 @@ func (c Client) UpdateIAMRole(ctx context.Context, id UUID, req UpdateIAMRoleReq
 		return nil, fmt.Errorf("UpdateIAMRole: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("UpdateIAMRole: prepare Json response: %w", err)
 	}
@@ -9866,7 +10411,7 @@ func (c Client) UpdateIAMRolePolicy(ctx context.Context, id UUID, req IAMPolicy)
 		return nil, fmt.Errorf("UpdateIAMRolePolicy: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("UpdateIAMRolePolicy: prepare Json response: %w", err)
 	}
@@ -10008,7 +10553,7 @@ func (c Client) ListInstances(ctx context.Context, opts ...ListInstancesOpt) (*L
 		return nil, fmt.Errorf("ListInstances: http response: %w", err)
 	}
 
-	bodyresp := &ListInstancesResponse{}
+	bodyresp := new(ListInstancesResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("ListInstances: prepare Json response: %w", err)
 	}
@@ -10019,6 +10564,8 @@ func (c Client) ListInstances(ctx context.Context, opts ...ListInstancesOpt) (*L
 type CreateInstanceRequest struct {
 	// Instance Anti-affinity Groups
 	AntiAffinityGroups []AntiAffinityGroup `json:"anti-affinity-groups,omitempty"`
+	// Enable application-consistent snapshot for the instance
+	ApplicationConsistentSnapshotEnabled *bool `json:"application-consistent-snapshot-enabled,omitempty"`
 	// Start Instance on creation (default: true)
 	AutoStart *bool `json:"auto-start,omitempty"`
 	// Deploy target
@@ -10092,7 +10639,7 @@ func (c Client) CreateInstance(ctx context.Context, req CreateInstanceRequest) (
 		return nil, fmt.Errorf("CreateInstance: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("CreateInstance: prepare Json response: %w", err)
 	}
@@ -10159,7 +10706,7 @@ func (c Client) ListInstancePools(ctx context.Context) (*ListInstancePoolsRespon
 		return nil, fmt.Errorf("ListInstancePools: http response: %w", err)
 	}
 
-	bodyresp := &ListInstancePoolsResponse{}
+	bodyresp := new(ListInstancePoolsResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("ListInstancePools: prepare Json response: %w", err)
 	}
@@ -10258,7 +10805,7 @@ func (c Client) CreateInstancePool(ctx context.Context, req CreateInstancePoolRe
 		return nil, fmt.Errorf("CreateInstancePool: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("CreateInstancePool: prepare Json response: %w", err)
 	}
@@ -10302,7 +10849,7 @@ func (c Client) DeleteInstancePool(ctx context.Context, id UUID) (*Operation, er
 		return nil, fmt.Errorf("DeleteInstancePool: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("DeleteInstancePool: prepare Json response: %w", err)
 	}
@@ -10346,7 +10893,7 @@ func (c Client) GetInstancePool(ctx context.Context, id UUID) (*InstancePool, er
 		return nil, fmt.Errorf("GetInstancePool: http response: %w", err)
 	}
 
-	bodyresp := &InstancePool{}
+	bodyresp := new(InstancePool)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("GetInstancePool: prepare Json response: %w", err)
 	}
@@ -10442,7 +10989,7 @@ func (c Client) UpdateInstancePool(ctx context.Context, id UUID, req UpdateInsta
 		return nil, fmt.Errorf("UpdateInstancePool: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("UpdateInstancePool: prepare Json response: %w", err)
 	}
@@ -10501,7 +11048,7 @@ func (c Client) ResetInstancePoolField(ctx context.Context, id UUID, field Reset
 		return nil, fmt.Errorf("ResetInstancePoolField: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("ResetInstancePoolField: prepare Json response: %w", err)
 	}
@@ -10556,7 +11103,7 @@ func (c Client) EvictInstancePoolMembers(ctx context.Context, id UUID, req Evict
 		return nil, fmt.Errorf("EvictInstancePoolMembers: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("EvictInstancePoolMembers: prepare Json response: %w", err)
 	}
@@ -10612,7 +11159,7 @@ func (c Client) ScaleInstancePool(ctx context.Context, id UUID, req ScaleInstanc
 		return nil, fmt.Errorf("ScaleInstancePool: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("ScaleInstancePool: prepare Json response: %w", err)
 	}
@@ -10679,7 +11226,7 @@ func (c Client) ListInstanceTypes(ctx context.Context) (*ListInstanceTypesRespon
 		return nil, fmt.Errorf("ListInstanceTypes: http response: %w", err)
 	}
 
-	bodyresp := &ListInstanceTypesResponse{}
+	bodyresp := new(ListInstanceTypesResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("ListInstanceTypes: prepare Json response: %w", err)
 	}
@@ -10723,7 +11270,7 @@ func (c Client) GetInstanceType(ctx context.Context, id UUID) (*InstanceType, er
 		return nil, fmt.Errorf("GetInstanceType: http response: %w", err)
 	}
 
-	bodyresp := &InstanceType{}
+	bodyresp := new(InstanceType)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("GetInstanceType: prepare Json response: %w", err)
 	}
@@ -10767,7 +11314,7 @@ func (c Client) DeleteInstance(ctx context.Context, id UUID) (*Operation, error)
 		return nil, fmt.Errorf("DeleteInstance: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("DeleteInstance: prepare Json response: %w", err)
 	}
@@ -10811,7 +11358,7 @@ func (c Client) GetInstance(ctx context.Context, id UUID) (*Instance, error) {
 		return nil, fmt.Errorf("GetInstance: http response: %w", err)
 	}
 
-	bodyresp := &Instance{}
+	bodyresp := new(Instance)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("GetInstance: prepare Json response: %w", err)
 	}
@@ -10820,7 +11367,9 @@ func (c Client) GetInstance(ctx context.Context, id UUID) (*Instance, error) {
 }
 
 type UpdateInstanceRequest struct {
-	Labels Labels `json:"labels"`
+	// Enable/Disable Application Consistent Snapshot for Instance
+	ApplicationConsistentSnapshotEnabled *bool  `json:"application-consistent-snapshot-enabled,omitempty"`
+	Labels                               Labels `json:"labels"`
 	// Instance name
 	Name               string             `json:"name,omitempty" validate:"omitempty,gte=1,lte=255"`
 	PublicIPAssignment PublicIPAssignment `json:"public-ip-assignment,omitempty"`
@@ -10871,7 +11420,7 @@ func (c Client) UpdateInstance(ctx context.Context, id UUID, req UpdateInstanceR
 		return nil, fmt.Errorf("UpdateInstance: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("UpdateInstance: prepare Json response: %w", err)
 	}
@@ -10921,7 +11470,7 @@ func (c Client) ResetInstanceField(ctx context.Context, id UUID, field ResetInst
 		return nil, fmt.Errorf("ResetInstanceField: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("ResetInstanceField: prepare Json response: %w", err)
 	}
@@ -10965,7 +11514,7 @@ func (c Client) AddInstanceProtection(ctx context.Context, id UUID) (*Operation,
 		return nil, fmt.Errorf("AddInstanceProtection: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("AddInstanceProtection: prepare Json response: %w", err)
 	}
@@ -11009,7 +11558,7 @@ func (c Client) CreateSnapshot(ctx context.Context, id UUID) (*Operation, error)
 		return nil, fmt.Errorf("CreateSnapshot: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("CreateSnapshot: prepare Json response: %w", err)
 	}
@@ -11053,7 +11602,7 @@ func (c Client) EnableTpm(ctx context.Context, id UUID) (*Operation, error) {
 		return nil, fmt.Errorf("EnableTpm: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("EnableTpm: prepare Json response: %w", err)
 	}
@@ -11101,7 +11650,7 @@ func (c Client) RevealInstancePassword(ctx context.Context, id UUID) (*InstanceP
 		return nil, fmt.Errorf("RevealInstancePassword: http response: %w", err)
 	}
 
-	bodyresp := &InstancePassword{}
+	bodyresp := new(InstancePassword)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("RevealInstancePassword: prepare Json response: %w", err)
 	}
@@ -11145,7 +11694,7 @@ func (c Client) RebootInstance(ctx context.Context, id UUID) (*Operation, error)
 		return nil, fmt.Errorf("RebootInstance: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("RebootInstance: prepare Json response: %w", err)
 	}
@@ -11189,7 +11738,7 @@ func (c Client) RemoveInstanceProtection(ctx context.Context, id UUID) (*Operati
 		return nil, fmt.Errorf("RemoveInstanceProtection: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("RemoveInstanceProtection: prepare Json response: %w", err)
 	}
@@ -11247,7 +11796,7 @@ func (c Client) ResetInstance(ctx context.Context, id UUID, req ResetInstanceReq
 		return nil, fmt.Errorf("ResetInstance: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("ResetInstance: prepare Json response: %w", err)
 	}
@@ -11291,7 +11840,7 @@ func (c Client) ResetInstancePassword(ctx context.Context, id UUID) (*Operation,
 		return nil, fmt.Errorf("ResetInstancePassword: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("ResetInstancePassword: prepare Json response: %w", err)
 	}
@@ -11347,7 +11896,7 @@ func (c Client) ResizeInstanceDisk(ctx context.Context, id UUID, req ResizeInsta
 		return nil, fmt.Errorf("ResizeInstanceDisk: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("ResizeInstanceDisk: prepare Json response: %w", err)
 	}
@@ -11403,7 +11952,7 @@ func (c Client) ScaleInstance(ctx context.Context, id UUID, req ScaleInstanceReq
 		return nil, fmt.Errorf("ScaleInstance: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("ScaleInstance: prepare Json response: %w", err)
 	}
@@ -11466,7 +12015,7 @@ func (c Client) StartInstance(ctx context.Context, id UUID, req StartInstanceReq
 		return nil, fmt.Errorf("StartInstance: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("StartInstance: prepare Json response: %w", err)
 	}
@@ -11510,7 +12059,7 @@ func (c Client) StopInstance(ctx context.Context, id UUID) (*Operation, error) {
 		return nil, fmt.Errorf("StopInstance: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("StopInstance: prepare Json response: %w", err)
 	}
@@ -11567,7 +12116,7 @@ func (c Client) RevertInstanceToSnapshot(ctx context.Context, instanceID UUID, r
 		return nil, fmt.Errorf("RevertInstanceToSnapshot: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("RevertInstanceToSnapshot: prepare Json response: %w", err)
 	}
@@ -11634,7 +12183,7 @@ func (c Client) ListLoadBalancers(ctx context.Context) (*ListLoadBalancersRespon
 		return nil, fmt.Errorf("ListLoadBalancers: http response: %w", err)
 	}
 
-	bodyresp := &ListLoadBalancersResponse{}
+	bodyresp := new(ListLoadBalancersResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("ListLoadBalancers: prepare Json response: %w", err)
 	}
@@ -11693,7 +12242,7 @@ func (c Client) CreateLoadBalancer(ctx context.Context, req CreateLoadBalancerRe
 		return nil, fmt.Errorf("CreateLoadBalancer: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("CreateLoadBalancer: prepare Json response: %w", err)
 	}
@@ -11737,7 +12286,7 @@ func (c Client) DeleteLoadBalancer(ctx context.Context, id UUID) (*Operation, er
 		return nil, fmt.Errorf("DeleteLoadBalancer: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("DeleteLoadBalancer: prepare Json response: %w", err)
 	}
@@ -11781,7 +12330,7 @@ func (c Client) GetLoadBalancer(ctx context.Context, id UUID) (*LoadBalancer, er
 		return nil, fmt.Errorf("GetLoadBalancer: http response: %w", err)
 	}
 
-	bodyresp := &LoadBalancer{}
+	bodyresp := new(LoadBalancer)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("GetLoadBalancer: prepare Json response: %w", err)
 	}
@@ -11840,7 +12389,7 @@ func (c Client) UpdateLoadBalancer(ctx context.Context, id UUID, req UpdateLoadB
 		return nil, fmt.Errorf("UpdateLoadBalancer: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("UpdateLoadBalancer: prepare Json response: %w", err)
 	}
@@ -11925,7 +12474,7 @@ func (c Client) AddServiceToLoadBalancer(ctx context.Context, id UUID, req AddSe
 		return nil, fmt.Errorf("AddServiceToLoadBalancer: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("AddServiceToLoadBalancer: prepare Json response: %w", err)
 	}
@@ -11969,7 +12518,7 @@ func (c Client) DeleteLoadBalancerService(ctx context.Context, id UUID, serviceI
 		return nil, fmt.Errorf("DeleteLoadBalancerService: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("DeleteLoadBalancerService: prepare Json response: %w", err)
 	}
@@ -12013,7 +12562,7 @@ func (c Client) GetLoadBalancerService(ctx context.Context, id UUID, serviceID U
 		return nil, fmt.Errorf("GetLoadBalancerService: http response: %w", err)
 	}
 
-	bodyresp := &LoadBalancerService{}
+	bodyresp := new(LoadBalancerService)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("GetLoadBalancerService: prepare Json response: %w", err)
 	}
@@ -12096,7 +12645,7 @@ func (c Client) UpdateLoadBalancerService(ctx context.Context, id UUID, serviceI
 		return nil, fmt.Errorf("UpdateLoadBalancerService: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("UpdateLoadBalancerService: prepare Json response: %w", err)
 	}
@@ -12146,7 +12695,7 @@ func (c Client) ResetLoadBalancerServiceField(ctx context.Context, id UUID, serv
 		return nil, fmt.Errorf("ResetLoadBalancerServiceField: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("ResetLoadBalancerServiceField: prepare Json response: %w", err)
 	}
@@ -12197,7 +12746,7 @@ func (c Client) ResetLoadBalancerField(ctx context.Context, id UUID, field Reset
 		return nil, fmt.Errorf("ResetLoadBalancerField: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("ResetLoadBalancerField: prepare Json response: %w", err)
 	}
@@ -12241,7 +12790,7 @@ func (c Client) GetOperation(ctx context.Context, id UUID) (*Operation, error) {
 		return nil, fmt.Errorf("GetOperation: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("GetOperation: prepare Json response: %w", err)
 	}
@@ -12285,7 +12834,7 @@ func (c Client) GetOrganization(ctx context.Context) (*Organization, error) {
 		return nil, fmt.Errorf("GetOrganization: http response: %w", err)
 	}
 
-	bodyresp := &Organization{}
+	bodyresp := new(Organization)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("GetOrganization: prepare Json response: %w", err)
 	}
@@ -12352,7 +12901,7 @@ func (c Client) ListPrivateNetworks(ctx context.Context) (*ListPrivateNetworksRe
 		return nil, fmt.Errorf("ListPrivateNetworks: http response: %w", err)
 	}
 
-	bodyresp := &ListPrivateNetworksResponse{}
+	bodyresp := new(ListPrivateNetworksResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("ListPrivateNetworks: prepare Json response: %w", err)
 	}
@@ -12419,7 +12968,7 @@ func (c Client) CreatePrivateNetwork(ctx context.Context, req CreatePrivateNetwo
 		return nil, fmt.Errorf("CreatePrivateNetwork: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("CreatePrivateNetwork: prepare Json response: %w", err)
 	}
@@ -12463,7 +13012,7 @@ func (c Client) DeletePrivateNetwork(ctx context.Context, id UUID) (*Operation, 
 		return nil, fmt.Errorf("DeletePrivateNetwork: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("DeletePrivateNetwork: prepare Json response: %w", err)
 	}
@@ -12507,7 +13056,7 @@ func (c Client) GetPrivateNetwork(ctx context.Context, id UUID) (*PrivateNetwork
 		return nil, fmt.Errorf("GetPrivateNetwork: http response: %w", err)
 	}
 
-	bodyresp := &PrivateNetwork{}
+	bodyresp := new(PrivateNetwork)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("GetPrivateNetwork: prepare Json response: %w", err)
 	}
@@ -12574,7 +13123,7 @@ func (c Client) UpdatePrivateNetwork(ctx context.Context, id UUID, req UpdatePri
 		return nil, fmt.Errorf("UpdatePrivateNetwork: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("UpdatePrivateNetwork: prepare Json response: %w", err)
 	}
@@ -12624,7 +13173,7 @@ func (c Client) ResetPrivateNetworkField(ctx context.Context, id UUID, field Res
 		return nil, fmt.Errorf("ResetPrivateNetworkField: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("ResetPrivateNetworkField: prepare Json response: %w", err)
 	}
@@ -12688,7 +13237,7 @@ func (c Client) AttachInstanceToPrivateNetwork(ctx context.Context, id UUID, req
 		return nil, fmt.Errorf("AttachInstanceToPrivateNetwork: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("AttachInstanceToPrivateNetwork: prepare Json response: %w", err)
 	}
@@ -12744,7 +13293,7 @@ func (c Client) DetachInstanceFromPrivateNetwork(ctx context.Context, id UUID, r
 		return nil, fmt.Errorf("DetachInstanceFromPrivateNetwork: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("DetachInstanceFromPrivateNetwork: prepare Json response: %w", err)
 	}
@@ -12806,7 +13355,7 @@ func (c Client) UpdatePrivateNetworkInstanceIP(ctx context.Context, id UUID, req
 		return nil, fmt.Errorf("UpdatePrivateNetworkInstanceIP: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("UpdatePrivateNetworkInstanceIP: prepare Json response: %w", err)
 	}
@@ -12854,7 +13403,7 @@ func (c Client) ListQuotas(ctx context.Context) (*ListQuotasResponse, error) {
 		return nil, fmt.Errorf("ListQuotas: http response: %w", err)
 	}
 
-	bodyresp := &ListQuotasResponse{}
+	bodyresp := new(ListQuotasResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("ListQuotas: prepare Json response: %w", err)
 	}
@@ -12898,7 +13447,7 @@ func (c Client) GetQuota(ctx context.Context, entity string) (*Quota, error) {
 		return nil, fmt.Errorf("GetQuota: http response: %w", err)
 	}
 
-	bodyresp := &Quota{}
+	bodyresp := new(Quota)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("GetQuota: prepare Json response: %w", err)
 	}
@@ -12942,7 +13491,7 @@ func (c Client) DeleteReverseDNSElasticIP(ctx context.Context, id UUID) (*Operat
 		return nil, fmt.Errorf("DeleteReverseDNSElasticIP: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("DeleteReverseDNSElasticIP: prepare Json response: %w", err)
 	}
@@ -12986,7 +13535,7 @@ func (c Client) GetReverseDNSElasticIP(ctx context.Context, id UUID) (*ReverseDN
 		return nil, fmt.Errorf("GetReverseDNSElasticIP: http response: %w", err)
 	}
 
-	bodyresp := &ReverseDNSRecord{}
+	bodyresp := new(ReverseDNSRecord)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("GetReverseDNSElasticIP: prepare Json response: %w", err)
 	}
@@ -13041,7 +13590,7 @@ func (c Client) UpdateReverseDNSElasticIP(ctx context.Context, id UUID, req Upda
 		return nil, fmt.Errorf("UpdateReverseDNSElasticIP: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("UpdateReverseDNSElasticIP: prepare Json response: %w", err)
 	}
@@ -13085,7 +13634,7 @@ func (c Client) DeleteReverseDNSInstance(ctx context.Context, id UUID) (*Operati
 		return nil, fmt.Errorf("DeleteReverseDNSInstance: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("DeleteReverseDNSInstance: prepare Json response: %w", err)
 	}
@@ -13129,7 +13678,7 @@ func (c Client) GetReverseDNSInstance(ctx context.Context, id UUID) (*ReverseDNS
 		return nil, fmt.Errorf("GetReverseDNSInstance: http response: %w", err)
 	}
 
-	bodyresp := &ReverseDNSRecord{}
+	bodyresp := new(ReverseDNSRecord)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("GetReverseDNSInstance: prepare Json response: %w", err)
 	}
@@ -13184,7 +13733,7 @@ func (c Client) UpdateReverseDNSInstance(ctx context.Context, id UUID, req Updat
 		return nil, fmt.Errorf("UpdateReverseDNSInstance: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("UpdateReverseDNSInstance: prepare Json response: %w", err)
 	}
@@ -13277,7 +13826,7 @@ func (c Client) ListSecurityGroups(ctx context.Context, opts ...ListSecurityGrou
 		return nil, fmt.Errorf("ListSecurityGroups: http response: %w", err)
 	}
 
-	bodyresp := &ListSecurityGroupsResponse{}
+	bodyresp := new(ListSecurityGroupsResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("ListSecurityGroups: prepare Json response: %w", err)
 	}
@@ -13335,7 +13884,7 @@ func (c Client) CreateSecurityGroup(ctx context.Context, req CreateSecurityGroup
 		return nil, fmt.Errorf("CreateSecurityGroup: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("CreateSecurityGroup: prepare Json response: %w", err)
 	}
@@ -13379,7 +13928,7 @@ func (c Client) DeleteSecurityGroup(ctx context.Context, id UUID) (*Operation, e
 		return nil, fmt.Errorf("DeleteSecurityGroup: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("DeleteSecurityGroup: prepare Json response: %w", err)
 	}
@@ -13423,7 +13972,7 @@ func (c Client) GetSecurityGroup(ctx context.Context, id UUID) (*SecurityGroup, 
 		return nil, fmt.Errorf("GetSecurityGroup: http response: %w", err)
 	}
 
-	bodyresp := &SecurityGroup{}
+	bodyresp := new(SecurityGroup)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("GetSecurityGroup: prepare Json response: %w", err)
 	}
@@ -13519,7 +14068,7 @@ func (c Client) AddRuleToSecurityGroup(ctx context.Context, id UUID, req AddRule
 		return nil, fmt.Errorf("AddRuleToSecurityGroup: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("AddRuleToSecurityGroup: prepare Json response: %w", err)
 	}
@@ -13563,7 +14112,7 @@ func (c Client) DeleteRuleFromSecurityGroup(ctx context.Context, id UUID, ruleID
 		return nil, fmt.Errorf("DeleteRuleFromSecurityGroup: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("DeleteRuleFromSecurityGroup: prepare Json response: %w", err)
 	}
@@ -13619,7 +14168,7 @@ func (c Client) AddExternalSourceToSecurityGroup(ctx context.Context, id UUID, r
 		return nil, fmt.Errorf("AddExternalSourceToSecurityGroup: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("AddExternalSourceToSecurityGroup: prepare Json response: %w", err)
 	}
@@ -13675,7 +14224,7 @@ func (c Client) AttachInstanceToSecurityGroup(ctx context.Context, id UUID, req 
 		return nil, fmt.Errorf("AttachInstanceToSecurityGroup: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("AttachInstanceToSecurityGroup: prepare Json response: %w", err)
 	}
@@ -13731,7 +14280,7 @@ func (c Client) DetachInstanceFromSecurityGroup(ctx context.Context, id UUID, re
 		return nil, fmt.Errorf("DetachInstanceFromSecurityGroup: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("DetachInstanceFromSecurityGroup: prepare Json response: %w", err)
 	}
@@ -13787,7 +14336,7 @@ func (c Client) RemoveExternalSourceFromSecurityGroup(ctx context.Context, id UU
 		return nil, fmt.Errorf("RemoveExternalSourceFromSecurityGroup: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("RemoveExternalSourceFromSecurityGroup: prepare Json response: %w", err)
 	}
@@ -13854,7 +14403,7 @@ func (c Client) ListSKSClusters(ctx context.Context) (*ListSKSClustersResponse, 
 		return nil, fmt.Errorf("ListSKSClusters: http response: %w", err)
 	}
 
-	bodyresp := &ListSKSClustersResponse{}
+	bodyresp := new(ListSKSClustersResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("ListSKSClusters: prepare Json response: %w", err)
 	}
@@ -13949,7 +14498,7 @@ func (c Client) CreateSKSCluster(ctx context.Context, req CreateSKSClusterReques
 		return nil, fmt.Errorf("CreateSKSCluster: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("CreateSKSCluster: prepare Json response: %w", err)
 	}
@@ -14048,7 +14597,7 @@ func (c Client) GenerateSKSClusterKubeconfig(ctx context.Context, id UUID, req S
 		return nil, fmt.Errorf("GenerateSKSClusterKubeconfig: http response: %w", err)
 	}
 
-	bodyresp := &GenerateSKSClusterKubeconfigResponse{}
+	bodyresp := new(GenerateSKSClusterKubeconfigResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("GenerateSKSClusterKubeconfig: prepare Json response: %w", err)
 	}
@@ -14112,7 +14661,7 @@ func (c Client) ListSKSClusterVersions(ctx context.Context, opts ...ListSKSClust
 		return nil, fmt.Errorf("ListSKSClusterVersions: http response: %w", err)
 	}
 
-	bodyresp := &ListSKSClusterVersionsResponse{}
+	bodyresp := new(ListSKSClusterVersionsResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("ListSKSClusterVersions: prepare Json response: %w", err)
 	}
@@ -14156,7 +14705,7 @@ func (c Client) DeleteSKSCluster(ctx context.Context, id UUID) (*Operation, erro
 		return nil, fmt.Errorf("DeleteSKSCluster: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("DeleteSKSCluster: prepare Json response: %w", err)
 	}
@@ -14200,7 +14749,7 @@ func (c Client) GetSKSCluster(ctx context.Context, id UUID) (*SKSCluster, error)
 		return nil, fmt.Errorf("GetSKSCluster: http response: %w", err)
 	}
 
-	bodyresp := &SKSCluster{}
+	bodyresp := new(SKSCluster)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("GetSKSCluster: prepare Json response: %w", err)
 	}
@@ -14271,7 +14820,7 @@ func (c Client) UpdateSKSCluster(ctx context.Context, id UUID, req UpdateSKSClus
 		return nil, fmt.Errorf("UpdateSKSCluster: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("UpdateSKSCluster: prepare Json response: %w", err)
 	}
@@ -14327,7 +14876,7 @@ func (c Client) GetSKSClusterAuthorityCert(ctx context.Context, id UUID, authori
 		return nil, fmt.Errorf("GetSKSClusterAuthorityCert: http response: %w", err)
 	}
 
-	bodyresp := &GetSKSClusterAuthorityCertResponse{}
+	bodyresp := new(GetSKSClusterAuthorityCertResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("GetSKSClusterAuthorityCert: prepare Json response: %w", err)
 	}
@@ -14373,7 +14922,7 @@ func (c Client) GetSKSClusterInspection(ctx context.Context, id UUID) (*GetSKSCl
 		return nil, fmt.Errorf("GetSKSClusterInspection: http response: %w", err)
 	}
 
-	bodyresp := &GetSKSClusterInspectionResponse{}
+	bodyresp := new(GetSKSClusterInspectionResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("GetSKSClusterInspection: prepare Json response: %w", err)
 	}
@@ -14464,7 +15013,7 @@ func (c Client) CreateSKSNodepool(ctx context.Context, id UUID, req CreateSKSNod
 		return nil, fmt.Errorf("CreateSKSNodepool: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("CreateSKSNodepool: prepare Json response: %w", err)
 	}
@@ -14508,7 +15057,7 @@ func (c Client) DeleteSKSNodepool(ctx context.Context, id UUID, sksNodepoolID UU
 		return nil, fmt.Errorf("DeleteSKSNodepool: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("DeleteSKSNodepool: prepare Json response: %w", err)
 	}
@@ -14552,7 +15101,7 @@ func (c Client) GetSKSNodepool(ctx context.Context, id UUID, sksNodepoolID UUID)
 		return nil, fmt.Errorf("GetSKSNodepool: http response: %w", err)
 	}
 
-	bodyresp := &SKSNodepool{}
+	bodyresp := new(SKSNodepool)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("GetSKSNodepool: prepare Json response: %w", err)
 	}
@@ -14637,7 +15186,7 @@ func (c Client) UpdateSKSNodepool(ctx context.Context, id UUID, sksNodepoolID UU
 		return nil, fmt.Errorf("UpdateSKSNodepool: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("UpdateSKSNodepool: prepare Json response: %w", err)
 	}
@@ -14692,7 +15241,7 @@ func (c Client) EvictSKSNodepoolMembers(ctx context.Context, id UUID, sksNodepoo
 		return nil, fmt.Errorf("EvictSKSNodepoolMembers: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("EvictSKSNodepoolMembers: prepare Json response: %w", err)
 	}
@@ -14748,7 +15297,7 @@ func (c Client) ScaleSKSNodepool(ctx context.Context, id UUID, sksNodepoolID UUI
 		return nil, fmt.Errorf("ScaleSKSNodepool: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("ScaleSKSNodepool: prepare Json response: %w", err)
 	}
@@ -14792,7 +15341,7 @@ func (c Client) RotateSKSCcmCredentials(ctx context.Context, id UUID) (*Operatio
 		return nil, fmt.Errorf("RotateSKSCcmCredentials: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("RotateSKSCcmCredentials: prepare Json response: %w", err)
 	}
@@ -14836,7 +15385,7 @@ func (c Client) RotateSKSCsiCredentials(ctx context.Context, id UUID) (*Operatio
 		return nil, fmt.Errorf("RotateSKSCsiCredentials: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("RotateSKSCsiCredentials: prepare Json response: %w", err)
 	}
@@ -14880,7 +15429,7 @@ func (c Client) RotateSKSKarpenterCredentials(ctx context.Context, id UUID) (*Op
 		return nil, fmt.Errorf("RotateSKSKarpenterCredentials: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("RotateSKSKarpenterCredentials: prepare Json response: %w", err)
 	}
@@ -14924,7 +15473,7 @@ func (c Client) RotateSKSOperatorsCA(ctx context.Context, id UUID) (*Operation, 
 		return nil, fmt.Errorf("RotateSKSOperatorsCA: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("RotateSKSOperatorsCA: prepare Json response: %w", err)
 	}
@@ -14980,7 +15529,7 @@ func (c Client) UpgradeSKSCluster(ctx context.Context, id UUID, req UpgradeSKSCl
 		return nil, fmt.Errorf("UpgradeSKSCluster: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("UpgradeSKSCluster: prepare Json response: %w", err)
 	}
@@ -15024,7 +15573,7 @@ func (c Client) UpgradeSKSClusterServiceLevel(ctx context.Context, id UUID) (*Op
 		return nil, fmt.Errorf("UpgradeSKSClusterServiceLevel: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("UpgradeSKSClusterServiceLevel: prepare Json response: %w", err)
 	}
@@ -15079,7 +15628,7 @@ func (c Client) GetActiveNodepoolTemplate(ctx context.Context, kubeVersion strin
 		return nil, fmt.Errorf("GetActiveNodepoolTemplate: http response: %w", err)
 	}
 
-	bodyresp := &GetActiveNodepoolTemplateResponse{}
+	bodyresp := new(GetActiveNodepoolTemplateResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("GetActiveNodepoolTemplate: prepare Json response: %w", err)
 	}
@@ -15146,7 +15695,7 @@ func (c Client) ListSnapshots(ctx context.Context) (*ListSnapshotsResponse, erro
 		return nil, fmt.Errorf("ListSnapshots: http response: %w", err)
 	}
 
-	bodyresp := &ListSnapshotsResponse{}
+	bodyresp := new(ListSnapshotsResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("ListSnapshots: prepare Json response: %w", err)
 	}
@@ -15190,7 +15739,7 @@ func (c Client) DeleteSnapshot(ctx context.Context, id UUID) (*Operation, error)
 		return nil, fmt.Errorf("DeleteSnapshot: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("DeleteSnapshot: prepare Json response: %w", err)
 	}
@@ -15234,7 +15783,7 @@ func (c Client) GetSnapshot(ctx context.Context, id UUID) (*Snapshot, error) {
 		return nil, fmt.Errorf("GetSnapshot: http response: %w", err)
 	}
 
-	bodyresp := &Snapshot{}
+	bodyresp := new(Snapshot)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("GetSnapshot: prepare Json response: %w", err)
 	}
@@ -15278,7 +15827,7 @@ func (c Client) ExportSnapshot(ctx context.Context, id UUID) (*Operation, error)
 		return nil, fmt.Errorf("ExportSnapshot: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("ExportSnapshot: prepare Json response: %w", err)
 	}
@@ -15342,7 +15891,7 @@ func (c Client) PromoteSnapshotToTemplate(ctx context.Context, id UUID, req Prom
 		return nil, fmt.Errorf("PromoteSnapshotToTemplate: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("PromoteSnapshotToTemplate: prepare Json response: %w", err)
 	}
@@ -15409,7 +15958,7 @@ func (c Client) ListSOSBucketsUsage(ctx context.Context) (*ListSOSBucketsUsageRe
 		return nil, fmt.Errorf("ListSOSBucketsUsage: http response: %w", err)
 	}
 
-	bodyresp := &ListSOSBucketsUsageResponse{}
+	bodyresp := new(ListSOSBucketsUsageResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("ListSOSBucketsUsage: prepare Json response: %w", err)
 	}
@@ -15473,7 +16022,7 @@ func (c Client) GetSOSPresignedURL(ctx context.Context, bucket string, opts ...G
 		return nil, fmt.Errorf("GetSOSPresignedURL: http response: %w", err)
 	}
 
-	bodyresp := &GetSOSPresignedURLResponse{}
+	bodyresp := new(GetSOSPresignedURLResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("GetSOSPresignedURL: prepare Json response: %w", err)
 	}
@@ -15540,7 +16089,7 @@ func (c Client) ListSSHKeys(ctx context.Context) (*ListSSHKeysResponse, error) {
 		return nil, fmt.Errorf("ListSSHKeys: http response: %w", err)
 	}
 
-	bodyresp := &ListSSHKeysResponse{}
+	bodyresp := new(ListSSHKeysResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("ListSSHKeys: prepare Json response: %w", err)
 	}
@@ -15598,7 +16147,7 @@ func (c Client) RegisterSSHKey(ctx context.Context, req RegisterSSHKeyRequest) (
 		return nil, fmt.Errorf("RegisterSSHKey: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("RegisterSSHKey: prepare Json response: %w", err)
 	}
@@ -15642,7 +16191,7 @@ func (c Client) DeleteSSHKey(ctx context.Context, name string) (*Operation, erro
 		return nil, fmt.Errorf("DeleteSSHKey: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("DeleteSSHKey: prepare Json response: %w", err)
 	}
@@ -15686,7 +16235,7 @@ func (c Client) GetSSHKey(ctx context.Context, name string) (*SSHKey, error) {
 		return nil, fmt.Errorf("GetSSHKey: http response: %w", err)
 	}
 
-	bodyresp := &SSHKey{}
+	bodyresp := new(SSHKey)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("GetSSHKey: prepare Json response: %w", err)
 	}
@@ -15782,7 +16331,7 @@ func (c Client) ListTemplates(ctx context.Context, opts ...ListTemplatesOpt) (*L
 		return nil, fmt.Errorf("ListTemplates: http response: %w", err)
 	}
 
-	bodyresp := &ListTemplatesResponse{}
+	bodyresp := new(ListTemplatesResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("ListTemplates: prepare Json response: %w", err)
 	}
@@ -15867,7 +16416,7 @@ func (c Client) RegisterTemplate(ctx context.Context, req RegisterTemplateReques
 		return nil, fmt.Errorf("RegisterTemplate: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("RegisterTemplate: prepare Json response: %w", err)
 	}
@@ -15911,7 +16460,7 @@ func (c Client) DeleteTemplate(ctx context.Context, id UUID) (*Operation, error)
 		return nil, fmt.Errorf("DeleteTemplate: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("DeleteTemplate: prepare Json response: %w", err)
 	}
@@ -15955,7 +16504,7 @@ func (c Client) GetTemplate(ctx context.Context, id UUID) (*Template, error) {
 		return nil, fmt.Errorf("GetTemplate: http response: %w", err)
 	}
 
-	bodyresp := &Template{}
+	bodyresp := new(Template)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("GetTemplate: prepare Json response: %w", err)
 	}
@@ -16011,7 +16560,7 @@ func (c Client) CopyTemplate(ctx context.Context, id UUID, req CopyTemplateReque
 		return nil, fmt.Errorf("CopyTemplate: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("CopyTemplate: prepare Json response: %w", err)
 	}
@@ -16069,7 +16618,7 @@ func (c Client) UpdateTemplate(ctx context.Context, id UUID, req UpdateTemplateR
 		return nil, fmt.Errorf("UpdateTemplate: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("UpdateTemplate: prepare Json response: %w", err)
 	}
@@ -16151,7 +16700,7 @@ func (c Client) GetUsageReport(ctx context.Context, opts ...GetUsageReportOpt) (
 		return nil, fmt.Errorf("GetUsageReport: http response: %w", err)
 	}
 
-	bodyresp := &GetUsageReportResponse{}
+	bodyresp := new(GetUsageReportResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("GetUsageReport: prepare Json response: %w", err)
 	}
@@ -16218,7 +16767,7 @@ func (c Client) ListUsers(ctx context.Context) (*ListUsersResponse, error) {
 		return nil, fmt.Errorf("ListUsers: http response: %w", err)
 	}
 
-	bodyresp := &ListUsersResponse{}
+	bodyresp := new(ListUsersResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("ListUsers: prepare Json response: %w", err)
 	}
@@ -16276,7 +16825,7 @@ func (c Client) CreateUser(ctx context.Context, req CreateUserRequest) (*Operati
 		return nil, fmt.Errorf("CreateUser: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("CreateUser: prepare Json response: %w", err)
 	}
@@ -16320,7 +16869,7 @@ func (c Client) DeleteUser(ctx context.Context, id UUID) (*Operation, error) {
 		return nil, fmt.Errorf("DeleteUser: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("DeleteUser: prepare Json response: %w", err)
 	}
@@ -16376,7 +16925,7 @@ func (c Client) UpdateUserRole(ctx context.Context, id UUID, req UpdateUserRoleR
 		return nil, fmt.Errorf("UpdateUserRole: http response: %w", err)
 	}
 
-	bodyresp := &Operation{}
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("UpdateUserRole: prepare Json response: %w", err)
 	}
@@ -16443,7 +16992,7 @@ func (c Client) ListZones(ctx context.Context) (*ListZonesResponse, error) {
 		return nil, fmt.Errorf("ListZones: http response: %w", err)
 	}
 
-	bodyresp := &ListZonesResponse{}
+	bodyresp := new(ListZonesResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("ListZones: prepare Json response: %w", err)
 	}

--- a/vendor/github.com/exoscale/egoscale/v3/schemas.go
+++ b/vendor/github.com/exoscale/egoscale/v3/schemas.go
@@ -74,6 +74,52 @@ type AccessKeyResource struct {
 	ResourceType AccessKeyResourceResourceType `json:"resource-type,omitempty"`
 }
 
+// AI deployment
+type Aideployment struct {
+	// Creation time
+	CreatedAT time.Time `json:"created-at,omitempty"`
+	// Deployment size (>=1)
+	DeploymentSize int64 `json:"deployment-size,omitempty" validate:"omitempty,gt=0"`
+	// Deployment URL (nullable)
+	DeploymentURL string `json:"deployment-url,omitempty"`
+	// Endpoint URL (nullable)
+	EndpointURL string `json:"endpoint-url,omitempty"`
+	// Deployment ID
+	ID UUID `json:"id,omitempty"`
+	// Instance type
+	InstanceType string `json:"instance-type,omitempty" validate:"omitempty,gte=1"`
+	// Associated model ID
+	ModelID UUID `json:"model-id,omitempty"`
+	// Deployment name
+	Name string `json:"name,omitempty" validate:"omitempty,gte=1"`
+	// Organization ID
+	OrganizationID UUID `json:"organization-id,omitempty"`
+	// Service level
+	ServiceLevel string `json:"service-level,omitempty" validate:"omitempty,gte=1"`
+	// Deployment status
+	Status string `json:"status,omitempty"`
+	// Update time
+	UpdatedAT time.Time `json:"updated-at,omitempty"`
+}
+
+// AI model
+type Aimodel struct {
+	// Creation time
+	CreatedAT time.Time `json:"created-at,omitempty"`
+	// Model ID
+	ID UUID `json:"id,omitempty"`
+	// Model size (nullable)
+	ModelSize int64 `json:"model-size,omitempty" validate:"omitempty,gte=0"`
+	// Model name
+	Name string `json:"name,omitempty" validate:"omitempty,gte=1"`
+	// Organization ID
+	OrganizationID UUID `json:"organization-id,omitempty"`
+	// Model status
+	Status string `json:"status,omitempty"`
+	// Update time
+	UpdatedAT time.Time `json:"updated-at,omitempty"`
+}
+
 // Anti-affinity Group
 type AntiAffinityGroup struct {
 	// Anti-affinity Group description
@@ -696,7 +742,7 @@ type DBAASKafkaTopicAclEntry struct {
 }
 
 type DBAASMigrationStatusDetails struct {
-	// Migrated db name (PG) or number (Valkey)
+	// Migrated db name
 	Dbname string `json:"dbname,omitempty"`
 	// Error message in case that migration has failed
 	Error string `json:"error,omitempty"`
@@ -808,6 +854,7 @@ const (
 	DBAASPGTargetVersions14 DBAASPGTargetVersions = "14"
 	DBAASPGTargetVersions17 DBAASPGTargetVersions = "17"
 	DBAASPGTargetVersions15 DBAASPGTargetVersions = "15"
+	DBAASPGTargetVersions18 DBAASPGTargetVersions = "18"
 	DBAASPGTargetVersions13 DBAASPGTargetVersions = "13"
 	DBAASPGTargetVersions16 DBAASPGTargetVersions = "16"
 )
@@ -2071,6 +2118,51 @@ const (
 	EnumSortOrderAsc  EnumSortOrder = "asc"
 )
 
+type EnvImpactDetail struct {
+	// Amount
+	Amount float64 `json:"amount,omitempty"`
+	// Unit
+	Unit string `json:"unit,omitempty"`
+	// Value
+	Value string `json:"value,omitempty"`
+}
+
+type EnvImpactIndicator struct {
+	// Amount
+	Amount float64 `json:"amount,omitempty"`
+	// Details
+	Details []EnvImpactDetail `json:"details,omitempty"`
+	// Unit
+	Unit string `json:"unit,omitempty"`
+	// Value
+	Value string `json:"value,omitempty"`
+}
+
+type EnvImpactReport struct {
+	// Metadata
+	Metadata []EnvMetadataEntry `json:"metadata,omitempty"`
+	// Products
+	Products []EnvProduct `json:"products,omitempty"`
+}
+
+type EnvMetadataEntry struct {
+	// Amount
+	Amount float64 `json:"amount,omitempty"`
+	// Unit
+	Unit string `json:"unit,omitempty"`
+	// Value
+	Value string `json:"value,omitempty"`
+}
+
+type EnvProduct struct {
+	// Impacts
+	Impacts []EnvImpactIndicator `json:"impacts,omitempty"`
+	// Metadata
+	Metadata []EnvMetadataEntry `json:"metadata,omitempty"`
+	// Value
+	Value string `json:"value,omitempty"`
+}
+
 // A notable Mutation Event which happened on the infrastructure
 type Event struct {
 	// Body parameters (free form map)
@@ -2354,6 +2446,7 @@ const (
 	InstanceTypeSizeMega       InstanceTypeSize = "mega"
 	InstanceTypeSizeSmall      InstanceTypeSize = "small"
 	InstanceTypeSizeExtraLarge InstanceTypeSize = "extra-large"
+	InstanceTypeSizeTitan48c   InstanceTypeSize = "titan48c"
 	InstanceTypeSizeTitan      InstanceTypeSize = "titan"
 	InstanceTypeSizeMicro      InstanceTypeSize = "micro"
 	InstanceTypeSizeColossus   InstanceTypeSize = "colossus"
@@ -3960,7 +4053,8 @@ const (
 
 // SKS Cluster
 type SKSCluster struct {
-	Addons *SKSClusterAddons `json:"addons,omitempty"`
+	// Cluster addons
+	Addons []string `json:"addons,omitempty"`
 	// Kubernetes Audit parameters
 	Audit *SKSAudit `json:"audit,omitempty"`
 	// Enable auto upgrade of the control plane to the latest patch version available
@@ -3993,8 +4087,6 @@ type SKSCluster struct {
 	// Control plane Kubernetes version
 	Version string `json:"version,omitempty"`
 }
-
-type SKSClusterAddons []string
 
 type SKSClusterDeprecatedResource struct {
 	Group          string `json:"group,omitempty"`

--- a/vendor/github.com/exoscale/egoscale/v3/schemas.go
+++ b/vendor/github.com/exoscale/egoscale/v3/schemas.go
@@ -74,52 +74,6 @@ type AccessKeyResource struct {
 	ResourceType AccessKeyResourceResourceType `json:"resource-type,omitempty"`
 }
 
-// AI deployment
-type Aideployment struct {
-	// Creation time
-	CreatedAT time.Time `json:"created-at,omitempty"`
-	// Deployment size (>=1)
-	DeploymentSize int64 `json:"deployment-size,omitempty" validate:"omitempty,gt=0"`
-	// Deployment URL (nullable)
-	DeploymentURL string `json:"deployment-url,omitempty"`
-	// Endpoint URL (nullable)
-	EndpointURL string `json:"endpoint-url,omitempty"`
-	// Deployment ID
-	ID UUID `json:"id,omitempty"`
-	// Instance type
-	InstanceType string `json:"instance-type,omitempty" validate:"omitempty,gte=1"`
-	// Associated model ID
-	ModelID UUID `json:"model-id,omitempty"`
-	// Deployment name
-	Name string `json:"name,omitempty" validate:"omitempty,gte=1"`
-	// Organization ID
-	OrganizationID UUID `json:"organization-id,omitempty"`
-	// Service level
-	ServiceLevel string `json:"service-level,omitempty" validate:"omitempty,gte=1"`
-	// Deployment status
-	Status string `json:"status,omitempty"`
-	// Update time
-	UpdatedAT time.Time `json:"updated-at,omitempty"`
-}
-
-// AI model
-type Aimodel struct {
-	// Creation time
-	CreatedAT time.Time `json:"created-at,omitempty"`
-	// Model ID
-	ID UUID `json:"id,omitempty"`
-	// Model size (nullable)
-	ModelSize int64 `json:"model-size,omitempty" validate:"omitempty,gte=0"`
-	// Model name
-	Name string `json:"name,omitempty" validate:"omitempty,gte=1"`
-	// Organization ID
-	OrganizationID UUID `json:"organization-id,omitempty"`
-	// Model status
-	Status string `json:"status,omitempty"`
-	// Update time
-	UpdatedAT time.Time `json:"updated-at,omitempty"`
-}
-
 // Anti-affinity Group
 type AntiAffinityGroup struct {
 	// Anti-affinity Group description
@@ -209,6 +163,27 @@ type BlockStorageVolume struct {
 type BlockStorageVolumeTarget struct {
 	// Block storage volume ID
 	ID UUID `json:"id,omitempty"`
+}
+
+// Deployment an AI model onto a set of GPUs
+type CreateDeploymentRequest struct {
+	// Number of GPUs (1-8)
+	GpuCount int64 `json:"gpu-count" validate:"required,gt=0"`
+	// GPU type family (e.g., gpua5000, gpu3080ti)
+	GpuType string    `json:"gpu-type" validate:"required"`
+	Model   *ModelRef `json:"model,omitempty"`
+	// Deployment name
+	Name string `json:"name,omitempty" validate:"omitempty,gte=1"`
+	// Number of replicas (>=1)
+	Replicas int64 `json:"replicas" validate:"required,gt=0"`
+}
+
+// AI model
+type CreateModelRequest struct {
+	// Huggingface Token
+	HuggingfaceToken string `json:"huggingface-token,omitempty"`
+	// Model name
+	Name string `json:"name,omitempty" validate:"omitempty,gte=1"`
 }
 
 // DBaaS plan backup config
@@ -1852,6 +1827,12 @@ type DBAASUserValkeySecrets struct {
 	Username string `json:"username,omitempty"`
 }
 
+// Model is in use: deletion forbidden
+type DeleteModelConflictResponse struct {
+	// Deployments using models
+	Deployments []string `json:"deployments,omitempty"`
+}
+
 type DeployTargetType string
 
 const (
@@ -2163,6 +2144,12 @@ type EnvProduct struct {
 	Value string `json:"value,omitempty"`
 }
 
+// Error
+type ErrorResponse struct {
+	// Error description
+	Error string `json:"error,omitempty"`
+}
+
 // A notable Mutation Event which happened on the infrastructure
 type Event struct {
 	// Body parameters (free form map)
@@ -2195,6 +2182,67 @@ type Event struct {
 	URI string `json:"uri,omitempty"`
 	// Operation targeted zone
 	Zone string `json:"zone,omitempty"`
+}
+
+type GetDeploymentLogsResponse string
+
+type GetDeploymentResponseStatus string
+
+const (
+	GetDeploymentResponseStatusReady     GetDeploymentResponseStatus = "ready"
+	GetDeploymentResponseStatusCreating  GetDeploymentResponseStatus = "creating"
+	GetDeploymentResponseStatusError     GetDeploymentResponseStatus = "error"
+	GetDeploymentResponseStatusDeploying GetDeploymentResponseStatus = "deploying"
+)
+
+// AI deployment
+type GetDeploymentResponse struct {
+	// Creation time
+	CreatedAT time.Time `json:"created-at,omitempty"`
+	// Deployment URL (nullable)
+	DeploymentURL string `json:"deployment-url,omitempty"`
+	// Number of GPUs
+	GpuCount int64 `json:"gpu-count,omitempty" validate:"omitempty,gt=0"`
+	// GPU type family
+	GpuType string `json:"gpu-type,omitempty" validate:"omitempty,gte=1"`
+	// Deployment ID
+	ID    UUID      `json:"id,omitempty"`
+	Model *ModelRef `json:"model,omitempty"`
+	// Deployment name
+	Name string `json:"name,omitempty" validate:"omitempty,gte=1"`
+	// Number of replicas (>=0)
+	Replicas int64 `json:"replicas,omitempty" validate:"omitempty,gte=0"`
+	// Service level
+	ServiceLevel string `json:"service-level,omitempty" validate:"omitempty,gte=1"`
+	// Deployment status
+	Status GetDeploymentResponseStatus `json:"status,omitempty"`
+	// Update time
+	UpdatedAT time.Time `json:"updated-at,omitempty"`
+}
+
+type GetModelResponseStatus string
+
+const (
+	GetModelResponseStatusReady       GetModelResponseStatus = "ready"
+	GetModelResponseStatusCreating    GetModelResponseStatus = "creating"
+	GetModelResponseStatusDownloading GetModelResponseStatus = "downloading"
+	GetModelResponseStatusError       GetModelResponseStatus = "error"
+)
+
+// AI model
+type GetModelResponse struct {
+	// Creation time
+	CreatedAT time.Time `json:"created-at,omitempty"`
+	// Model ID
+	ID UUID `json:"id,omitempty"`
+	// Model size (nullable)
+	ModelSize int64 `json:"model-size,omitempty" validate:"omitempty,gte=0"`
+	// Model name
+	Name string `json:"name,omitempty" validate:"omitempty,gte=1"`
+	// Model status
+	Status GetModelResponseStatus `json:"status,omitempty"`
+	// Update time
+	UpdatedAT time.Time `json:"updated-at,omitempty"`
 }
 
 // IAM API Key
@@ -2289,6 +2337,8 @@ type InstancePrivateNetworks struct {
 type Instance struct {
 	// Instance Anti-affinity Groups
 	AntiAffinityGroups []AntiAffinityGroup `json:"anti-affinity-groups,omitempty"`
+	// Indicates if the instance will take application-consistent snapshots
+	ApplicationConsistentSnapshotEnabled *bool `json:"application-consistent-snapshot-enabled,omitempty"`
 	// Instance creation date
 	CreatedAT time.Time `json:"created-at,omitempty"`
 	// Deploy target
@@ -2423,17 +2473,18 @@ type InstanceTarget struct {
 type InstanceTypeFamily string
 
 const (
-	InstanceTypeFamilyGpu3      InstanceTypeFamily = "gpu3"
-	InstanceTypeFamilyGpua30    InstanceTypeFamily = "gpua30"
-	InstanceTypeFamilyGpu3080ti InstanceTypeFamily = "gpu3080ti"
-	InstanceTypeFamilyGpu2      InstanceTypeFamily = "gpu2"
-	InstanceTypeFamilyGpu       InstanceTypeFamily = "gpu"
-	InstanceTypeFamilyMemory    InstanceTypeFamily = "memory"
-	InstanceTypeFamilyGpua5000  InstanceTypeFamily = "gpua5000"
-	InstanceTypeFamilyStorage   InstanceTypeFamily = "storage"
-	InstanceTypeFamilyStandard  InstanceTypeFamily = "standard"
-	InstanceTypeFamilyColossus  InstanceTypeFamily = "colossus"
-	InstanceTypeFamilyCPU       InstanceTypeFamily = "cpu"
+	InstanceTypeFamilyGpu3          InstanceTypeFamily = "gpu3"
+	InstanceTypeFamilyGpua30        InstanceTypeFamily = "gpua30"
+	InstanceTypeFamilyGpu3080ti     InstanceTypeFamily = "gpu3080ti"
+	InstanceTypeFamilyGpu2          InstanceTypeFamily = "gpu2"
+	InstanceTypeFamilyGpu           InstanceTypeFamily = "gpu"
+	InstanceTypeFamilyMemory        InstanceTypeFamily = "memory"
+	InstanceTypeFamilyGpua5000      InstanceTypeFamily = "gpua5000"
+	InstanceTypeFamilyGpurtx6000pro InstanceTypeFamily = "gpurtx6000pro"
+	InstanceTypeFamilyStorage       InstanceTypeFamily = "storage"
+	InstanceTypeFamilyStandard      InstanceTypeFamily = "standard"
+	InstanceTypeFamilyColossus      InstanceTypeFamily = "colossus"
+	InstanceTypeFamilyCPU           InstanceTypeFamily = "cpu"
 )
 
 type InstanceTypeSize string
@@ -3303,37 +3354,37 @@ type JSONSchemaOpensearch struct {
 
 // Autovacuum settings
 type JSONSchemaPGAutovacuum struct {
-	// Specifies a fraction of the table size to add to autovacuum_analyze_threshold when deciding whether to trigger an ANALYZE. The default is 0.2 (20% of table size)
+	// Specifies a fraction of the table size to add to autovacuum_analyze_threshold when deciding whether to trigger an ANALYZE (e.g. `0.2` for 20% of the table size). The default is `0.2`.
 	AutovacuumAnalyzeScaleFactor float64 `json:"autovacuum_analyze_scale_factor,omitempty" validate:"omitempty,gte=0,lte=1"`
-	// Specifies the minimum number of inserted, updated or deleted tuples needed to trigger an ANALYZE in any one table. The default is 50 tuples.
+	// Specifies the minimum number of inserted, updated or deleted tuples needed to trigger an ANALYZE in any one table. The default is `50`.
 	AutovacuumAnalyzeThreshold int `json:"autovacuum_analyze_threshold,omitempty" validate:"omitempty,gte=0,lte=2.147483647e+09"`
-	// Specifies the maximum age (in transactions) that a table's pg_class.relfrozenxid field can attain before a VACUUM operation is forced to prevent transaction ID wraparound within the table. Note that the system will launch autovacuum processes to prevent wraparound even when autovacuum is otherwise disabled. This parameter will cause the server to be restarted.
+	// Specifies the maximum age (in transactions) that a table's pg_class.relfrozenxid field can attain before a VACUUM operation is forced to prevent transaction ID wraparound within the table. The system launches autovacuum processes to prevent wraparound even when autovacuum is otherwise disabled. Changing this parameter causes a service restart.
 	AutovacuumFreezeMaxAge int `json:"autovacuum_freeze_max_age,omitempty" validate:"omitempty,gte=2e+08,lte=1.5e+09"`
-	// Specifies the maximum number of autovacuum processes (other than the autovacuum launcher) that may be running at any one time. The default is three. This parameter can only be set at server start.
+	// Specifies the maximum number of autovacuum processes (other than the autovacuum launcher) that may be running at any one time. The default is `3`. Changing this parameter causes a service restart.
 	AutovacuumMaxWorkers int `json:"autovacuum_max_workers,omitempty" validate:"omitempty,gte=1,lte=20"`
-	// Specifies the minimum delay between autovacuum runs on any given database. The delay is measured in seconds, and the default is one minute
+	// Specifies the minimum delay between autovacuum runs on any given database. The delay is measured in seconds. The default is `60`.
 	AutovacuumNaptime int `json:"autovacuum_naptime,omitempty" validate:"omitempty,gte=1,lte=86400"`
-	// Specifies the cost delay value that will be used in automatic VACUUM operations. If -1 is specified, the regular vacuum_cost_delay value will be used. The default value is 20 milliseconds
+	// Specifies the cost delay value that will be used in automatic VACUUM operations. If `-1` is specified, the regular vacuum_cost_delay value will be used. The default is `2` (upstream default).
 	AutovacuumVacuumCostDelay int `json:"autovacuum_vacuum_cost_delay,omitempty" validate:"omitempty,gte=-1,lte=100"`
-	// Specifies the cost limit value that will be used in automatic VACUUM operations. If -1 is specified (which is the default), the regular vacuum_cost_limit value will be used.
+	// Specifies the cost limit value that will be used in automatic VACUUM operations. If `-1` is specified, the regular vacuum_cost_limit value will be used. The default is `-1` (upstream default).
 	AutovacuumVacuumCostLimit int `json:"autovacuum_vacuum_cost_limit,omitempty" validate:"omitempty,gte=-1,lte=10000"`
-	// Specifies a fraction of the table size to add to autovacuum_vacuum_threshold when deciding whether to trigger a VACUUM. The default is 0.2 (20% of table size)
+	// Specifies a fraction of the table size to add to autovacuum_vacuum_threshold when deciding whether to trigger a VACUUM (e.g. `0.2` for 20% of the table size). The default is `0.2`.
 	AutovacuumVacuumScaleFactor float64 `json:"autovacuum_vacuum_scale_factor,omitempty" validate:"omitempty,gte=0,lte=1"`
-	// Specifies the minimum number of updated or deleted tuples needed to trigger a VACUUM in any one table. The default is 50 tuples
+	// Specifies the minimum number of updated or deleted tuples needed to trigger a VACUUM in any one table. The default is `50`.
 	AutovacuumVacuumThreshold int `json:"autovacuum_vacuum_threshold,omitempty" validate:"omitempty,gte=0,lte=2.147483647e+09"`
-	// Causes each action executed by autovacuum to be logged if it ran for at least the specified number of milliseconds. Setting this to zero logs all autovacuum actions. Minus-one (the default) disables logging autovacuum actions.
+	// Causes each action executed by autovacuum to be logged if it ran for at least the specified number of milliseconds. Setting this to zero logs all autovacuum actions. Minus-one disables logging autovacuum actions. The default is `1000`.
 	LogAutovacuumMinDuration int `json:"log_autovacuum_min_duration,omitempty" validate:"omitempty,gte=-1,lte=2.147483647e+09"`
 }
 
 // Background (BG) writer settings
 type JSONSchemaPGBGWriter struct {
-	// Specifies the delay between activity rounds for the background writer in milliseconds. Default is 200.
+	// Specifies the delay between activity rounds for the background writer in milliseconds. The default is `200`.
 	BgwriterDelay int `json:"bgwriter_delay,omitempty" validate:"omitempty,gte=10,lte=10000"`
-	// Whenever more than bgwriter_flush_after bytes have been written by the background writer, attempt to force the OS to issue these writes to the underlying storage. Specified in kilobytes, default is 512. Setting of 0 disables forced writeback.
+	// Whenever more than bgwriter_flush_after bytes have been written by the background writer, attempt to force the OS to issue these writes to the underlying storage. Specified in kilobytes. Setting of 0 disables forced writeback. The default is `512`.
 	BgwriterFlushAfter int `json:"bgwriter_flush_after,omitempty" validate:"omitempty,gte=0,lte=2048"`
-	// In each round, no more than this many buffers will be written by the background writer. Setting this to zero disables background writing. Default is 100.
+	// In each round, no more than this many buffers will be written by the background writer. Setting this to zero disables background writing. The default is `100`.
 	BgwriterLruMaxpages int `json:"bgwriter_lru_maxpages,omitempty" validate:"omitempty,gte=0,lte=1.073741823e+09"`
-	// The average recent need for new buffers is multiplied by bgwriter_lru_multiplier to arrive at an estimate of the number that will be needed during the next round, (up to bgwriter_lru_maxpages). 1.0 represents a “just in time” policy of writing exactly the number of buffers predicted to be needed. Larger values provide some cushion against spikes in demand, while smaller values intentionally leave writes to be done by server processes. The default is 2.0.
+	// The average recent need for new buffers is multiplied by bgwriter_lru_multiplier to arrive at an estimate of the number that will be needed during the next round, (up to bgwriter_lru_maxpages). 1.0 represents a “just in time” policy of writing exactly the number of buffers predicted to be needed. Larger values provide some cushion against spikes in demand, while smaller values intentionally leave writes to be done by server processes. The default is `2.0`.
 	BgwriterLruMultiplier float64 `json:"bgwriter_lru_multiplier,omitempty" validate:"omitempty,gte=0,lte=10"`
 }
 
@@ -3344,12 +3395,27 @@ const (
 	JSONSchemaPGDefaultToastCompressionPglz JSONSchemaPGDefaultToastCompression = "pglz"
 )
 
+type JSONSchemaPGIoMethod string
+
+const (
+	JSONSchemaPGIoMethodWorker  JSONSchemaPGIoMethod = "worker"
+	JSONSchemaPGIoMethodSync    JSONSchemaPGIoMethod = "sync"
+	JSONSchemaPGIoMethodIoUring JSONSchemaPGIoMethod = "io_uring"
+)
+
 type JSONSchemaPGLogErrorVerbosity string
 
 const (
 	JSONSchemaPGLogErrorVerbosityTERSE   JSONSchemaPGLogErrorVerbosity = "TERSE"
 	JSONSchemaPGLogErrorVerbosityDEFAULT JSONSchemaPGLogErrorVerbosity = "DEFAULT"
 	JSONSchemaPGLogErrorVerbosityVERBOSE JSONSchemaPGLogErrorVerbosity = "VERBOSE"
+)
+
+type JSONSchemaPGPasswordEncryption string
+
+const (
+	JSONSchemaPGPasswordEncryptionMd5         JSONSchemaPGPasswordEncryption = "md5"
+	JSONSchemaPGPasswordEncryptionScramSha256 JSONSchemaPGPasswordEncryption = "scram-sha-256"
 )
 
 type JSONSchemaPGPGStatStatementsTrack string
@@ -3384,13 +3450,13 @@ const (
 
 // Write-ahead log (WAL) settings
 type JSONSchemaPGWal struct {
-	// PostgreSQL maximum WAL size (MB) reserved for replication slots. Default is -1 (unlimited). wal_keep_size minimum WAL size setting takes precedence over this.
+	// PostgreSQL maximum WAL size (MB) reserved for replication slots. If `-1` is specified, replication slots may retain an unlimited amount of WAL files. The default is `-1` (upstream default). wal_keep_size minimum WAL size setting takes precedence over this.
 	MaxSlotWalKeepSize int `json:"max_slot_wal_keep_size,omitempty" validate:"omitempty,gte=-1,lte=2.147483647e+09"`
-	// PostgreSQL maximum WAL senders
-	MaxWalSenders int `json:"max_wal_senders,omitempty" validate:"omitempty,gte=20,lte=64"`
+	// PostgreSQL maximum WAL senders. The default is `20`. Changing this parameter causes a service restart.
+	MaxWalSenders int `json:"max_wal_senders,omitempty" validate:"omitempty,gte=20,lte=256"`
 	// Terminate replication connections that are inactive for longer than this amount of time, in milliseconds.
 	WalSenderTimeout int `json:"wal_sender_timeout,omitempty" validate:"omitempty,gte=0,lte=1.08e+07"`
-	// WAL flush interval in milliseconds. Note that setting this value to lower than the default 200ms may negatively impact performance
+	// WAL flush interval in milliseconds. The default is `200`. Setting this parameter to a lower value may negatively impact performance.
 	WalWriterDelay int `json:"wal_writer_delay,omitempty" validate:"omitempty,gte=10,lte=200"`
 }
 
@@ -3400,67 +3466,81 @@ type JSONSchemaPG struct {
 	Autovacuum *JSONSchemaPGAutovacuum `json:"autovacuum,omitempty"`
 	// Background (BG) writer settings
 	BGWriter *JSONSchemaPGBGWriter `json:"bg-writer,omitempty"`
-	// This is the amount of time, in milliseconds, to wait on a lock before checking to see if there is a deadlock condition.
+	// This is the amount of time, in milliseconds, to wait on a lock before checking to see if there is a deadlock condition. The default is `1000` (upstream default).
 	DeadlockTimeout int `json:"deadlock_timeout,omitempty" validate:"omitempty,gte=500,lte=1.8e+06"`
-	// Specifies the default TOAST compression method for values of compressible columns (the default is lz4).
+	// Specifies the default TOAST compression method for values of compressible columns. The default is `lz4`. Only available for PostgreSQL 14+.
 	DefaultToastCompression JSONSchemaPGDefaultToastCompression `json:"default_toast_compression,omitempty"`
 	// Time out sessions with open transactions after this number of milliseconds
 	IdleInTransactionSessionTimeout int `json:"idle_in_transaction_session_timeout,omitempty" validate:"omitempty,gte=0,lte=6.048e+08"`
+	// EXPERIMENTAL: Controls the largest I/O size in operations that combine I/O in 8kB units. Version 17 and up only.
+	IoCombineLimit int `json:"io_combine_limit,omitempty" validate:"omitempty,gte=1,lte=32"`
+	// EXPERIMENTAL: Controls the largest I/O size in operations that combine I/O in 8kB units, and silently limits the user-settable parameter io_combine_limit. Version 18 and up only. Changing this parameter causes a service restart.
+	IoMaxCombineLimit int `json:"io_max_combine_limit,omitempty" validate:"omitempty,gte=1,lte=128"`
+	// EXPERIMENTAL: Controls the maximum number of I/O operations that one process can execute simultaneously. Version 18 and up only. Changing this parameter causes a service restart.
+	IoMaxConcurrency int `json:"io_max_concurrency,omitempty" validate:"omitempty,gte=-1,lte=1024"`
+	// EXPERIMENTAL: Controls the maximum number of I/O operations that one process can execute simultaneously. Version 18 and up only. Changing this parameter causes a service restart.
+	IoMethod JSONSchemaPGIoMethod `json:"io_method,omitempty"`
+	// EXPERIMENTAL: Number of IO worker processes, for io_method=worker. Version 18 and up only. Changing this parameter causes a service restart.
+	IoWorkers int `json:"io_workers,omitempty" validate:"omitempty,gte=1,lte=32"`
 	// Controls system-wide use of Just-in-Time Compilation (JIT).
 	Jit *bool `json:"jit,omitempty"`
 	// Controls the amount of detail written in the server log for each message that is logged.
 	LogErrorVerbosity JSONSchemaPGLogErrorVerbosity `json:"log_error_verbosity,omitempty"`
-	// Choose from one of the available log-formats. These can support popular log analyzers like pgbadger, pganalyze etc.
+	// Choose from one of the available log formats.
 	LogLinePrefix string `json:"log_line_prefix,omitempty"`
 	// Log statements that take more than this number of milliseconds to run, -1 disables
 	LogMinDurationStatement int `json:"log_min_duration_statement,omitempty" validate:"omitempty,gte=-1,lte=8.64e+07"`
 	// Log statements for each temporary file created larger than this number of kilobytes, -1 disables
 	LogTempFiles int `json:"log_temp_files,omitempty" validate:"omitempty,gte=-1,lte=2.147483647e+09"`
-	// PostgreSQL maximum number of files that can be open per process
+	// PostgreSQL maximum number of files that can be open per process. The default is `1000` (upstream default). Changing this parameter causes a service restart.
 	MaxFilesPerProcess int `json:"max_files_per_process,omitempty" validate:"omitempty,gte=1000,lte=4096"`
-	// PostgreSQL maximum locks per transaction
+	// PostgreSQL maximum locks per transaction. Changing this parameter causes a service restart.
 	MaxLocksPerTransaction int `json:"max_locks_per_transaction,omitempty" validate:"omitempty,gte=64,lte=6400"`
-	// PostgreSQL maximum logical replication workers (taken from the pool of max_parallel_workers)
-	MaxLogicalReplicationWorkers int `json:"max_logical_replication_workers,omitempty" validate:"omitempty,gte=4,lte=64"`
-	// Sets the maximum number of workers that the system can support for parallel queries
+	// PostgreSQL maximum logical replication workers (taken from the pool of max_parallel_workers). The default is `4` (upstream default). Changing this parameter causes a service restart.
+	MaxLogicalReplicationWorkers int `json:"max_logical_replication_workers,omitempty" validate:"omitempty,gte=4,lte=256"`
+	// Sets the maximum number of workers that the system can support for parallel queries. The default is `8` (upstream default).
 	MaxParallelWorkers int `json:"max_parallel_workers,omitempty" validate:"omitempty,gte=0,lte=96"`
-	// Sets the maximum number of workers that can be started by a single Gather or Gather Merge node
+	// Sets the maximum number of workers that can be started by a single Gather or Gather Merge node. The default is `2` (upstream default).
 	MaxParallelWorkersPerGather int `json:"max_parallel_workers_per_gather,omitempty" validate:"omitempty,gte=0,lte=96"`
-	// PostgreSQL maximum predicate locks per transaction
+	// PostgreSQL maximum predicate locks per transaction. The default is `64` (upstream default). Changing this parameter causes a service restart.
 	MaxPredLocksPerTransaction int `json:"max_pred_locks_per_transaction,omitempty" validate:"omitempty,gte=64,lte=5120"`
-	// PostgreSQL maximum prepared transactions
+	// PostgreSQL maximum prepared transactions. The default is `0`. Changing this parameter causes a service restart.
 	MaxPreparedTransactions int `json:"max_prepared_transactions,omitempty" validate:"omitempty,gte=0,lte=10000"`
-	// PostgreSQL maximum replication slots
-	MaxReplicationSlots int `json:"max_replication_slots,omitempty" validate:"omitempty,gte=8,lte=64"`
-	// Maximum depth of the stack in bytes
+	// PostgreSQL maximum replication slots. The default is `20`. Changing this parameter causes a service restart.
+	MaxReplicationSlots int `json:"max_replication_slots,omitempty" validate:"omitempty,gte=8,lte=256"`
+	// Maximum depth of the stack in bytes. The default is `2097152` (upstream default).
 	MaxStackDepth int `json:"max_stack_depth,omitempty" validate:"omitempty,gte=2.097152e+06,lte=6.291456e+06"`
-	// Max standby archive delay in milliseconds
+	// Max standby archive delay in milliseconds. The default is `30000` (upstream default).
 	MaxStandbyArchiveDelay int `json:"max_standby_archive_delay,omitempty" validate:"omitempty,gte=1,lte=4.32e+07"`
-	// Max standby streaming delay in milliseconds
+	// Max standby streaming delay in milliseconds. The default is `30000` (upstream default).
 	MaxStandbyStreamingDelay int `json:"max_standby_streaming_delay,omitempty" validate:"omitempty,gte=1,lte=4.32e+07"`
-	// Sets the maximum number of background processes that the system can support
-	MaxWorkerProcesses int `json:"max_worker_processes,omitempty" validate:"omitempty,gte=8,lte=96"`
-	// Sets the time interval to run pg_partman's scheduled tasks
+	// Maximum number of synchronization workers per subscription. The default is `2`.
+	MaxSyncWorkersPerSubscription int `json:"max_sync_workers_per_subscription,omitempty" validate:"omitempty,gte=2,lte=8"`
+	// Sets the maximum number of background processes that the system can support. The default is `8`. Changing this parameter causes a service restart.
+	MaxWorkerProcesses int `json:"max_worker_processes,omitempty" validate:"omitempty,gte=8,lte=288"`
+	// Chooses the algorithm for encrypting passwords.
+	PasswordEncryption JSONSchemaPGPasswordEncryption `json:"password_encryption,omitempty"`
+	// Sets the time interval in seconds to run pg_partman's scheduled tasks. The default is `3600`.
 	PGPartmanBgwInterval int `json:"pg_partman_bgw.interval,omitempty" validate:"omitempty,gte=3600,lte=604800"`
 	// Controls which role to use for pg_partman's scheduled background tasks.
 	PGPartmanBgwRole string `json:"pg_partman_bgw.role,omitempty" validate:"omitempty,lte=64"`
-	// Enables or disables query plan monitoring
+	// Enables or disables query plan monitoring. Changing this parameter causes a service restart. Only available for PostgreSQL 13+.
 	PGStatMonitorPgsmEnableQueryPlan *bool `json:"pg_stat_monitor.pgsm_enable_query_plan,omitempty"`
-	// Sets the maximum number of buckets
+	// Sets the maximum number of buckets. Changing this parameter causes a service restart. Only available for PostgreSQL 13+.
 	PGStatMonitorPgsmMaxBuckets int `json:"pg_stat_monitor.pgsm_max_buckets,omitempty" validate:"omitempty,gte=1,lte=10"`
-	// Controls which statements are counted. Specify top to track top-level statements (those issued directly by clients), all to also track nested statements (such as statements invoked within functions), or none to disable statement statistics collection. The default value is top.
+	// Controls which statements are counted. Specify top to track top-level statements (those issued directly by clients), all to also track nested statements (such as statements invoked within functions), or none to disable statement statistics collection. The default is `top`.
 	PGStatStatementsTrack JSONSchemaPGPGStatStatementsTrack `json:"pg_stat_statements.track,omitempty"`
 	// PostgreSQL temporary file limit in KiB, -1 for unlimited
 	TempFileLimit int `json:"temp_file_limit,omitempty" validate:"omitempty,gte=-1,lte=2.147483647e+09"`
 	// PostgreSQL service timezone
 	Timezone string `json:"timezone,omitempty" validate:"omitempty,lte=64"`
-	// Specifies the number of bytes reserved to track the currently executing command for each active session.
+	// Specifies the number of bytes reserved to track the currently executing command for each active session. Changing this parameter causes a service restart.
 	TrackActivityQuerySize int `json:"track_activity_query_size,omitempty" validate:"omitempty,gte=1024,lte=10240"`
-	// Record commit time of transactions.
+	// Record commit time of transactions. Changing this parameter causes a service restart.
 	TrackCommitTimestamp JSONSchemaPGTrackCommitTimestamp `json:"track_commit_timestamp,omitempty"`
 	// Enables tracking of function call counts and time used.
 	TrackFunctions JSONSchemaPGTrackFunctions `json:"track_functions,omitempty"`
-	// Enables timing of database I/O calls. This parameter is off by default, because it will repeatedly query the operating system for the current time, which may cause significant overhead on some platforms.
+	// Enables timing of database I/O calls. The default is `off`. When on, it will repeatedly query the operating system for the current time, which may cause significant overhead on some platforms.
 	TrackIoTiming JSONSchemaPGTrackIoTiming `json:"track_io_timing,omitempty"`
 	// Write-ahead log (WAL) settings
 	Wal *JSONSchemaPGWal `json:"wal,omitempty"`
@@ -3547,12 +3627,12 @@ type JSONSchemaThanos struct {
 	// Configuration options for Thanos Query.
 	Query *JSONSchemaThanosQuery `json:"query,omitempty"`
 	// Configuration options for Thanos Query Frontend.
-	QueryFrontend *JSONSchemaThanosQueryFrontend `json:"query_frontend,omitempty"`
+	QueryFrontend *JSONSchemaThanosQueryFrontend `json:"query-frontend,omitempty"`
 }
 
 // System-wide settings for the timescaledb extension
 type JSONSchemaTimescaledb struct {
-	// The number of background workers for timescaledb operations. You should configure this setting to the sum of your number of databases and the total number of concurrent background workers you want running at any given point in time.
+	// The number of background workers for timescaledb operations. You should configure this setting to the sum of your number of databases and the total number of concurrent background workers you want running at any given point in time. Changing this parameter causes a service restart.
 	MaxBackgroundWorkers int `json:"max_background_workers,omitempty" validate:"omitempty,gte=1,lte=4096"`
 }
 
@@ -3617,6 +3697,75 @@ type KubeletImageGC struct {
 }
 
 type Labels map[string]string
+
+// AI model list
+type ListDeploymentsResponse struct {
+	Deployments []ListDeploymentsResponseEntry `json:"deployments,omitempty"`
+}
+
+type ListDeploymentsResponseEntryStatus string
+
+const (
+	ListDeploymentsResponseEntryStatusReady     ListDeploymentsResponseEntryStatus = "ready"
+	ListDeploymentsResponseEntryStatusCreating  ListDeploymentsResponseEntryStatus = "creating"
+	ListDeploymentsResponseEntryStatusError     ListDeploymentsResponseEntryStatus = "error"
+	ListDeploymentsResponseEntryStatusDeploying ListDeploymentsResponseEntryStatus = "deploying"
+)
+
+// AI deployment
+type ListDeploymentsResponseEntry struct {
+	// Creation time
+	CreatedAT time.Time `json:"created-at,omitempty"`
+	// Deployment URL (nullable)
+	DeploymentURL string `json:"deployment-url,omitempty"`
+	// Number of GPUs
+	GpuCount int64 `json:"gpu-count,omitempty" validate:"omitempty,gt=0"`
+	// GPU type family
+	GpuType string `json:"gpu-type,omitempty" validate:"omitempty,gte=1"`
+	// Deployment ID
+	ID    UUID      `json:"id,omitempty"`
+	Model *ModelRef `json:"model,omitempty"`
+	// Deployment name
+	Name string `json:"name,omitempty" validate:"omitempty,gte=1"`
+	// Number of replicas (>=0)
+	Replicas int64 `json:"replicas,omitempty" validate:"omitempty,gte=0"`
+	// Service level
+	ServiceLevel string `json:"service-level,omitempty" validate:"omitempty,gte=1"`
+	// Deployment status
+	Status ListDeploymentsResponseEntryStatus `json:"status,omitempty"`
+	// Update time
+	UpdatedAT time.Time `json:"updated-at,omitempty"`
+}
+
+// AI model list
+type ListModelsResponse struct {
+	Models []ListModelsResponseEntry `json:"models,omitempty"`
+}
+
+type ListModelsResponseEntryStatus string
+
+const (
+	ListModelsResponseEntryStatusReady       ListModelsResponseEntryStatus = "ready"
+	ListModelsResponseEntryStatusCreating    ListModelsResponseEntryStatus = "creating"
+	ListModelsResponseEntryStatusDownloading ListModelsResponseEntryStatus = "downloading"
+	ListModelsResponseEntryStatusError       ListModelsResponseEntryStatus = "error"
+)
+
+// AI model
+type ListModelsResponseEntry struct {
+	// Creation time
+	CreatedAT time.Time `json:"created-at,omitempty"`
+	// Model ID
+	ID UUID `json:"id,omitempty"`
+	// Model size (nullable)
+	ModelSize int64 `json:"model-size,omitempty" validate:"omitempty,gte=0"`
+	// Model name
+	Name string `json:"name,omitempty" validate:"omitempty,gte=1"`
+	// Model status
+	Status ListModelsResponseEntryStatus `json:"status,omitempty"`
+	// Update time
+	UpdatedAT time.Time `json:"updated-at,omitempty"`
+}
 
 type LoadBalancerState string
 
@@ -3753,6 +3902,13 @@ type Manager struct {
 	ID UUID `json:"id,omitempty"`
 	// Manager type
 	Type ManagerType `json:"type,omitempty"`
+}
+
+type ModelRef struct {
+	// Associated model ID
+	ID UUID `json:"id,omitempty"`
+	// Associated model name
+	Name string `json:"name,omitempty" validate:"omitempty,gte=1"`
 }
 
 // Cluster networking configuration.
@@ -3907,8 +4063,19 @@ type Resource struct {
 	Name string `json:"name,omitempty"`
 }
 
+// AI deployment inference endpoint authentication key
+type RevealDeploymentAPIKeyResponse struct {
+	APIKey string `json:"api-key,omitempty"`
+}
+
 type ReverseDNSRecord struct {
 	DomainName DomainName `json:"domain-name,omitempty" validate:"omitempty,gte=1,lte=253"`
+}
+
+// Scale AI deployment
+type ScaleDeploymentRequest struct {
+	// Number of replicas (>=0)
+	Replicas int64 `json:"replicas" validate:"required,gte=0"`
 }
 
 // Security Group
@@ -4233,6 +4400,8 @@ const (
 
 // Snapshot
 type Snapshot struct {
+	// Indicates whether the snapshot was taken using an application-consistent method
+	ApplicationConsistent *bool `json:"application-consistent,omitempty"`
 	// Snapshot creation date
 	CreatedAT time.Time `json:"created-at,omitempty"`
 	// Exported snapshot information

--- a/vendor/github.com/exoscale/egoscale/v3/version.go
+++ b/vendor/github.com/exoscale/egoscale/v3/version.go
@@ -1,4 +1,4 @@
 package v3
 
 // Version represents the current egoscale v3 version.
-const Version = "v3.1.27"
+const Version = "v3.1.28"

--- a/vendor/github.com/exoscale/egoscale/v3/version.go
+++ b/vendor/github.com/exoscale/egoscale/v3/version.go
@@ -1,4 +1,4 @@
 package v3
 
 // Version represents the current egoscale v3 version.
-const Version = "v3.1.28"
+const Version = "v3.1.30"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -271,7 +271,7 @@ github.com/exoscale/egoscale/v2
 github.com/exoscale/egoscale/v2/api
 github.com/exoscale/egoscale/v2/oapi
 github.com/exoscale/egoscale/version
-# github.com/exoscale/egoscale/v3 v3.1.28
+# github.com/exoscale/egoscale/v3 v3.1.31
 ## explicit; go 1.23.8
 github.com/exoscale/egoscale/v3
 github.com/exoscale/egoscale/v3/credentials

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -271,7 +271,7 @@ github.com/exoscale/egoscale/v2
 github.com/exoscale/egoscale/v2/api
 github.com/exoscale/egoscale/v2/oapi
 github.com/exoscale/egoscale/version
-# github.com/exoscale/egoscale/v3 v3.1.27
+# github.com/exoscale/egoscale/v3 v3.1.28
 ## explicit; go 1.23.8
 github.com/exoscale/egoscale/v3
 github.com/exoscale/egoscale/v3/credentials


### PR DESCRIPTION
# Description

- egoscale v3.1.31;
- SKS fixes for Addon type change;
- Restrict AWS provider version for SOS bucket policy resource test (latest don't work with SOS).

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Acceptance tests OK
* [x] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing

```
$ TF_ACC=1 go test ./... -run 'TestAccResourceSKSCluster'                                                                                 
?       github.com/exoscale/terraform-provider-exoscale [no test files]                   
ok      github.com/exoscale/terraform-provider-exoscale/exoscale        431.735s                                                                                                     
?       github.com/exoscale/terraform-provider-exoscale/pkg/config      [no test files]                                                                                              
ok      github.com/exoscale/terraform-provider-exoscale/pkg/filter      (cached) [no tests to run]                                                                                   
?       github.com/exoscale/terraform-provider-exoscale/pkg/general     [no test files]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/list        (cached) [no tests to run]                          
?       github.com/exoscale/terraform-provider-exoscale/pkg/provider    [no test files]                                                                                              
?       github.com/exoscale/terraform-provider-exoscale/pkg/provider/config     [no test files]                                                                                      
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/anti_affinity_group       (cached) [no tests to run]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/block_storage     (cached) [no tests to run]                                                                   
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/database  (cached) [no tests to run]                                                                           
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/iam       (cached) [no tests to run]                                                                           
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/instance  (cached) [no tests to run]                                                                           
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/instance_pool     (cached) [no tests to run]                                                                   
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/nlb_service       (cached) [no tests to run]                                                                   
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/sos_bucket_policy (cached) [no tests to run]                                                                   
?       github.com/exoscale/terraform-provider-exoscale/pkg/resources/zones     [no test files]                                                                                      
?       github.com/exoscale/terraform-provider-exoscale/pkg/sos [no test files]                                                                                                      
?       github.com/exoscale/terraform-provider-exoscale/pkg/testutils   [no test files]                                                                                              
?       github.com/exoscale/terraform-provider-exoscale/pkg/utils       [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/validators  [no test files]   
?       github.com/exoscale/terraform-provider-exoscale/pkg/version     [no test files]   
?       github.com/exoscale/terraform-provider-exoscale/version [no test files]
```
