### PR TITLE
CI: make check-documentation-clean.sh fail when `go generate` fails

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,5 +17,6 @@ jobs:
       - uses: actions/checkout@v3
       - run: make go.mk
       - uses: ./go.mk/.github/actions/setup
+      - uses: hashicorp/setup-terraform@v3
       - name: Check documentation is up to date
         run: './scripts/check-documentation-clean.sh'

--- a/scripts/check-documentation-clean.sh
+++ b/scripts/check-documentation-clean.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
+
+set -euo pipefail
 
 go generate
 if [ -z "$(git status --untracked-files=no --porcelain)" ]; then


### PR DESCRIPTION
# Description
Previously the CI step that checks that the documentation was up to date didn't fail when `go generate` failed. It only failed when there was a git diff afterwards. We fix that.

## Checklist
(For exoscale contributors)

* [ ] Changelog updated (under *Unreleased* block)
* [ ] Acceptance tests OK
* [ ] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing
```shell
bash-5.3$ ./scripts/check-documentation-clean.sh 
main.go:18: running "terraform": exec: "terraform": executable file not found in $PATH
documentation is up to date
bash-5.3$ echo $?
0
```
After adding `set -e`:
```shell
bash-5.3$ ./scripts/check-documentation-clean.sh 
main.go:18: running "terraform": exec: "terraform": executable file not found in $PATH
bash-5.3$ echo $?
1
```

