### PR TITLE
dbaas: fix for PG scale issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 IMPROVEMENTS:
 
+- dbaas: fix for PG scale issue #477
 - Bump egoscale & fix breaking change #468
 
 ## 0.67.1

--- a/pkg/resources/database/resource_service.go
+++ b/pkg/resources/database/resource_service.go
@@ -527,10 +527,10 @@ func (r *ServiceResource) Update(ctx context.Context, req resource.UpdateRequest
 	}
 
 	// Save updated data into Terraform state
-	resp.Diagnostics.Append(resp.State.Set(ctx, &planData)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &stateData)...)
 
-	tflog.Trace(ctx, "resource updated", map[string]interface{}{
-		"id": planData.Id,
+	tflog.Trace(ctx, "resource updated", map[string]any{
+		"id": stateData.Id,
 	})
 }
 

--- a/pkg/resources/database/resource_service.go
+++ b/pkg/resources/database/resource_service.go
@@ -511,6 +511,9 @@ func (r *ServiceResource) Update(ctx context.Context, req resource.UpdateRequest
 	switch planData.Type.ValueString() {
 	case "pg":
 		r.updatePg(ctx, &stateData, &planData, &resp.Diagnostics)
+		// Pg update changed merge planData into stateData (which is then merged instead of planData).
+		// NOTE: This should be ported in the future to all other services.
+		resp.Diagnostics.Append(resp.State.Set(ctx, &stateData)...)
 	case "mysql":
 		r.updateMysql(ctx, &stateData, &planData, &resp.Diagnostics)
 	case "valkey":
@@ -526,8 +529,10 @@ func (r *ServiceResource) Update(ctx context.Context, req resource.UpdateRequest
 		return
 	}
 
-	// Save updated data into Terraform state
-	resp.Diagnostics.Append(resp.State.Set(ctx, &stateData)...)
+	// Save updated data into Terraform state (except Pg, see note above)
+	if planData.Type.ValueString() != "pg" {
+		resp.Diagnostics.Append(resp.State.Set(ctx, &planData)...)
+	}
 
 	tflog.Trace(ctx, "resource updated", map[string]any{
 		"id": stateData.Id,

--- a/pkg/resources/database/resource_service_pg_test.go
+++ b/pkg/resources/database/resource_service_pg_test.go
@@ -156,6 +156,24 @@ func testResourcePg(t *testing.T) {
 	}
 	configUpdate := buf.String()
 
+	serviceDataScale := serviceDataUpdate
+	serviceDataScale.Plan = "startup-4"
+
+	buf = &bytes.Buffer{}
+	err = serviceTpl.Execute(buf, &serviceDataScale)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = userTpl.Execute(buf, &userDataUpdate)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = dbTpl.Execute(buf, &dbDataUpdate)
+	if err != nil {
+		t.Fatal(err)
+	}
+	configScale := buf.String()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testutils.AccPreCheck(t) },
 		CheckDestroy:             CheckServiceDestroy("pg", serviceDataBase.Name),
@@ -248,6 +266,21 @@ func testResourcePg(t *testing.T) {
 						if err != nil {
 							return err
 						}
+						return nil
+					},
+				),
+			},
+			{
+				// Scale
+				Config: configScale,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Service
+					func(s *terraform.State) error {
+						err := CheckExistsPg(serviceDataBase.Name, &serviceDataScale)
+						if err != nil {
+							return err
+						}
+
 						return nil
 					},
 				),


### PR DESCRIPTION
# Description

This PR fixes few issues when PG DBaaS service plan changes.
- Sets backup schedule correctly for update (only when specified in plan);
- Sets only computed attributes on update;
- Waits for service to be running before completing create (otherwise plan scale will fail on Aiven side with obscure error).
- Adds test for plan scale.

Solves https://github.com/exoscale/terraform-provider-exoscale/issues/476

**Note: DBaaS PG resource test now takes significantly longer to complete!**

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Acceptance tests OK
* [x] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing

```bash
$ TF_ACC=1 go test ./... -run TestDatabase/ResourcePg -timeout 15m
?       github.com/exoscale/terraform-provider-exoscale [no test files]
ok      github.com/exoscale/terraform-provider-exoscale/exoscale        0.094s [no tests to run]
?       github.com/exoscale/terraform-provider-exoscale/pkg/config      [no test files]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/filter      0.007s [no tests to run]
?       github.com/exoscale/terraform-provider-exoscale/pkg/general     [no test files]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/list        0.055s [no tests to run]
?       github.com/exoscale/terraform-provider-exoscale/pkg/provider    [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/provider/config     [no test files]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/anti_affinity_group       0.064s [no tests to run]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/block_storage     0.058s [no tests to run]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/database  762.058s
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/iam       0.039s [no tests to run]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/instance  0.062s [no tests to run]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/instance_pool     0.046s [no tests to run]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/nlb_service       0.046s [no tests to run]
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/sos_bucket_policy 0.038s [no tests to run]
?       github.com/exoscale/terraform-provider-exoscale/pkg/resources/zones     [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/sos [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/testutils   [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/utils       [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/validators  [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/version     [no test files]
?       github.com/exoscale/terraform-provider-exoscale/version [no test files]
```
