### PR TITLE
fix: prevent uuid parse error while refresh block storage volume

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ terraform.tfstate
 *.iml
 dist
 release
+dev.tfrc
 
 # Test exclusions
 !command/test-fixtures/**/*.tfstate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ IMPROVEMENTS:
 - dbaas: fix for PG scale issue #477
 - Bump egoscale & fix breaking change #468
 
+BUG FIXES:
+- fix: prevent uuid parse error while refresh block storage volume #479
+
 ## 0.67.1
 
 IMPROVEMENTS:

--- a/pkg/resources/block_storage/resource_volume.go
+++ b/pkg/resources/block_storage/resource_volume.go
@@ -321,7 +321,7 @@ func (r *ResourceVolume) Read(ctx context.Context, req resource.ReadRequest, res
 
 	// Read remote state.
 	// Check if ID is empty (resource doesn't exist yet or was just created)
-	if state.ID.ValueString() == "" || state.ID.IsNull() || state.ID.IsUnknown() {
+	if state.ID.ValueString() == "" {
 		// Resource doesn't exist yet, nothing to read
 		return
 	}

--- a/pkg/resources/block_storage/resource_volume.go
+++ b/pkg/resources/block_storage/resource_volume.go
@@ -320,6 +320,12 @@ func (r *ResourceVolume) Read(ctx context.Context, req resource.ReadRequest, res
 	}
 
 	// Read remote state.
+	// Check if ID is empty (resource doesn't exist yet or was just created)
+	if state.ID.ValueString() == "" || state.ID.IsNull() || state.ID.IsUnknown() {
+		// Resource doesn't exist yet, nothing to read
+		return
+	}
+
 	id, err := exoscale.ParseUUID(state.ID.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError(


### PR DESCRIPTION
# Description
The Read function try to parse a nonexistent string in a uuid which create an error while refreshing the terraform state. It's a mistake that almost never happens but this step is mandatory for the crossplane provider.

step to reproduce:
```tf
# main.tf
terraform {
  required_providers {
    exoscale = {
      source  = "exoscale/exoscale"
      version = "~> 0.59.0"  # Use your version
    }
  }
}

provider "exoscale" {
  key    = var.exoscale_api_key
  secret = var.exoscale_api_secret
}

resource "exoscale_block_storage_volume" "test" {
  name = "test-volume"
  size = 10
  zone = "ch-gva-2"
}
```

```bash
$> terraform init

$> cat > terraform.tfstate <<EOF
{
  "version": 4,
  "terraform_version": "1.14.0",
  "serial": 1,
  "lineage": "test",
  "outputs": {},
  "resources": [
    {
      "mode": "managed",
      "type": "exoscale_block_storage_volume",
      "name": "test",
      "provider": "provider[\"registry.terraform.io/exoscale/exoscale\"]",
      "instances": [
        {
          "schema_version": 0,
          "attributes": {
            "id": "",
            "name": "test-volume",
            "size": 10,
            "zone": "ch-gva-2"
          }
        }
      ]
    }
  ]
}
EOF

$> terraform refresh
exoscale_block_storage_volume.test: Refreshing state...
│ Error: unable to parse volume ID
│ 
│   with exoscale_block_storage_volume.test,
│   on main.tf line 15, in resource "exoscale_block_storage_volume" "test":
│   15: resource "exoscale_block_storage_volume" "test" {
│ 
│ invalid UUID length: 0
```

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Acceptance tests OK
* [ ] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing
build code + refresh from partial state (cf. description)
and acceptance test
``` bash
$> cd pkg/resources/block_storage
$> go test ./... -run TestBlockStorage -v
=== RUN   TestBlockStorage
--- PASS: TestBlockStorage (82.83s)
PASS
ok  	github.com/exoscale/terraform-provider-exoscale/pkg/resources/block_storage	82.844s

```
