### PR TITLE
fix(block storage): remove source if not existing during read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ IMPROVEMENTS:
 
 BUG FIXES:
 - fix: prevent uuid parse error while refresh block storage volume #479
+- fix(block storage): remove source if not existing during read #480
 
 ## 0.67.1
 

--- a/pkg/resources/block_storage/resource_volume.go
+++ b/pkg/resources/block_storage/resource_volume.go
@@ -320,9 +320,9 @@ func (r *ResourceVolume) Read(ctx context.Context, req resource.ReadRequest, res
 	}
 
 	// Read remote state.
-	// Check if ID is empty (resource doesn't exist yet or was just created)
+	// Check if ID is empty (resource doesn't exist yet)
 	if state.ID.ValueString() == "" {
-		// Resource doesn't exist yet, nothing to read
+		resp.State.RemoveResource(ctx)
 		return
 	}
 


### PR DESCRIPTION
# Description
The Read function try to parse a nonexistent string in a uuid which create an error while refreshing the terraform state. It's a mistake that almost never happens but this step is mandatory for the crossplane provider.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Acceptance tests OK
* [ ] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing
```bash
$> cd pkg/resources/block_storage
$> go test ./... -run TestBlockStorage -v
=== RUN   TestBlockStorage
--- PASS: TestBlockStorage (89.01s)
PASS
ok  	github.com/exoscale/terraform-provider-exoscale/pkg/resources/block_storage	89.026s

```
