### PR TITLE
Fix dbaas service update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ IMPROVEMENTS:
 - Bump egoscale & fix breaking change #468
 - feat: make instance pool state computed only #486
 - feat: make sks computed cert sensitive #487
+- Fix valkey and mysql update #482
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ IMPROVEMENTS:
 - Bump egoscale & fix breaking change #468
 - feat: make instance pool state computed only #486
 - feat: make sks computed cert sensitive #487
-- Fix valkey and mysql update #482
+- Fix dbaas service update #482
 
 BUG FIXES:
 

--- a/pkg/resources/database/resource_service.go
+++ b/pkg/resources/database/resource_service.go
@@ -528,7 +528,7 @@ func (r *ServiceResource) Update(ctx context.Context, req resource.UpdateRequest
 
 	// Pg, Mysql and Valkey are merging planData into stateData (which is then saved to state).
 	// NOTE: This should be ported to all other services.
-	if planData.Type.ValueString() != "pg" || planData.Type.ValueString() != "valkey" || planData.Type.ValueString() == "mysql" {
+	if planData.Type.ValueString() != "pg" || planData.Type.ValueString() != "valkey" || planData.Type.ValueString() == "mysql" || planData.Type.ValueString() != "kafka" {
 		resp.Diagnostics.Append(resp.State.Set(ctx, &stateData)...)
 	} else {
 		resp.Diagnostics.Append(resp.State.Set(ctx, &planData)...)

--- a/pkg/resources/database/resource_service.go
+++ b/pkg/resources/database/resource_service.go
@@ -434,7 +434,7 @@ func (r *ServiceResource) Create(ctx context.Context, req resource.CreateRequest
 	// Save data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 
-	tflog.Trace(ctx, "resource created", map[string]interface{}{
+	tflog.Trace(ctx, "resource created", map[string]any{
 		"id": data.Id,
 	})
 }
@@ -481,7 +481,7 @@ func (r *ServiceResource) Read(ctx context.Context, req resource.ReadRequest, re
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 
-	tflog.Trace(ctx, "resource read done", map[string]interface{}{
+	tflog.Trace(ctx, "resource read done", map[string]any{
 		"id": data.Id,
 	})
 }
@@ -526,13 +526,7 @@ func (r *ServiceResource) Update(ctx context.Context, req resource.UpdateRequest
 		return
 	}
 
-	// Pg, Mysql and Valkey are merging planData into stateData (which is then saved to state).
-	// NOTE: This should be ported to all other services.
-	if planData.Type.ValueString() != "pg" || planData.Type.ValueString() != "valkey" || planData.Type.ValueString() == "mysql" || planData.Type.ValueString() != "kafka" {
-		resp.Diagnostics.Append(resp.State.Set(ctx, &stateData)...)
-	} else {
-		resp.Diagnostics.Append(resp.State.Set(ctx, &planData)...)
-	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &stateData)...)
 
 	tflog.Trace(ctx, "resource updated", map[string]any{
 		"id": stateData.Id,
@@ -565,7 +559,7 @@ func (r *ServiceResource) Delete(ctx context.Context, req resource.DeleteRequest
 		return
 	}
 
-	tflog.Trace(ctx, "resource deleted", map[string]interface{}{
+	tflog.Trace(ctx, "resource deleted", map[string]any{
 		"id": data.Id,
 	})
 }
@@ -614,7 +608,7 @@ func (r *ServiceResource) ImportState(ctx context.Context, req resource.ImportSt
 	// Save data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 
-	tflog.Trace(ctx, "resource imported", map[string]interface{}{
+	tflog.Trace(ctx, "resource imported", map[string]any{
 		"id": data.Id,
 	})
 }

--- a/pkg/resources/database/resource_service.go
+++ b/pkg/resources/database/resource_service.go
@@ -526,9 +526,9 @@ func (r *ServiceResource) Update(ctx context.Context, req resource.UpdateRequest
 		return
 	}
 
-	// Pg and Valkey are merging  planData into stateData (which is then saved to state).
+	// Pg, Mysql and Valkey are merging planData into stateData (which is then saved to state).
 	// NOTE: This should be ported to all other services.
-	if planData.Type.ValueString() != "pg" || planData.Type.ValueString() != "valkey" {
+	if planData.Type.ValueString() != "pg" || planData.Type.ValueString() != "valkey" || planData.Type.ValueString() == "mysql" {
 		resp.Diagnostics.Append(resp.State.Set(ctx, &stateData)...)
 	} else {
 		resp.Diagnostics.Append(resp.State.Set(ctx, &planData)...)

--- a/pkg/resources/database/resource_service_kafka.go
+++ b/pkg/resources/database/resource_service_kafka.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -103,9 +104,6 @@ func (r *ServiceResource) createKafka(ctx context.Context, data *ServiceResource
 	service := oapi.CreateDbaasServiceKafkaJSONRequestBody{
 		Plan:                  data.Plan.ValueString(),
 		TerminationProtection: data.TerminationProtection.ValueBoolPointer(),
-		KafkaConnectEnabled:   data.Kafka.EnableKafkaConnect.ValueBoolPointer(),
-		KafkaRestEnabled:      data.Kafka.EnableKafkaREST.ValueBoolPointer(),
-		SchemaRegistryEnabled: data.Kafka.EnableSchemaRegistry.ValueBoolPointer(),
 	}
 
 	if !data.MaintenanceDOW.IsUnknown() && !data.MaintenanceTime.IsUnknown() {
@@ -118,77 +116,83 @@ func (r *ServiceResource) createKafka(ctx context.Context, data *ServiceResource
 		}
 	}
 
-	if !data.Kafka.Version.IsUnknown() {
-		service.Version = data.Kafka.Version.ValueStringPointer()
-	}
+	if data.Kafka != nil {
+		service.KafkaConnectEnabled = data.Kafka.EnableKafkaConnect.ValueBoolPointer()
+		service.KafkaRestEnabled = data.Kafka.EnableKafkaREST.ValueBoolPointer()
+		service.SchemaRegistryEnabled = data.Kafka.EnableSchemaRegistry.ValueBoolPointer()
 
-	if !data.Kafka.EnableCertAuth.IsUnknown() || !data.Kafka.EnableSASLAuth.IsUnknown() {
-		service.AuthenticationMethods = &struct {
-			Certificate *bool `json:"certificate,omitempty"`
-			Sasl        *bool `json:"sasl,omitempty"`
-		}{
-			Certificate: data.Kafka.EnableCertAuth.ValueBoolPointer(),
-			Sasl:        data.Kafka.EnableSASLAuth.ValueBoolPointer(),
+		if !data.Kafka.Version.IsUnknown() {
+			service.Version = data.Kafka.Version.ValueStringPointer()
 		}
-	}
 
-	if !data.Kafka.IpFilter.IsUnknown() {
-		obj := []string{}
-		if len(data.Kafka.IpFilter.Elements()) > 0 {
-			dg := data.Kafka.IpFilter.ElementsAs(ctx, &obj, false)
-			if dg.HasError() {
-				diagnostics.Append(dg...)
-				return
+		if !data.Kafka.EnableCertAuth.IsUnknown() || !data.Kafka.EnableSASLAuth.IsUnknown() {
+			service.AuthenticationMethods = &struct {
+				Certificate *bool `json:"certificate,omitempty"`
+				Sasl        *bool `json:"sasl,omitempty"`
+			}{
+				Certificate: data.Kafka.EnableCertAuth.ValueBoolPointer(),
+				Sasl:        data.Kafka.EnableSASLAuth.ValueBoolPointer(),
 			}
 		}
 
-		service.IpFilter = &obj
-	}
+		if !data.Kafka.IpFilter.IsUnknown() {
+			obj := []string{}
+			if len(data.Kafka.IpFilter.Elements()) > 0 {
+				dg := data.Kafka.IpFilter.ElementsAs(ctx, &obj, false)
+				if dg.HasError() {
+					diagnostics.Append(dg...)
+					return
+				}
+			}
 
-	settingsSchema, err := r.client.GetDbaasSettingsKafkaWithResponse(ctx)
-	if err != nil {
-		diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read database settings schema, got error: %s", err))
-		return
-	}
-	if settingsSchema.StatusCode() != http.StatusOK {
-		diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read database settings schema, unexpected status: %s", settingsSchema.Status()))
-		return
-	}
+			service.IpFilter = &obj
+		}
 
-	if !data.Kafka.Settings.IsUnknown() {
-		obj, err := validateSettings(data.Kafka.Settings.ValueString(), settingsSchema.JSON200.Settings.Kafka)
+		settingsSchema, err := r.client.GetDbaasSettingsKafkaWithResponse(ctx)
 		if err != nil {
-			diagnostics.AddError("Validation error", fmt.Sprintf("invalid settings: %s", err))
+			diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read database settings schema, got error: %s", err))
 			return
 		}
-		service.KafkaSettings = &obj
-	}
-
-	if !data.Kafka.ConnectSettings.IsUnknown() {
-		obj, err := validateSettings(data.Kafka.ConnectSettings.ValueString(), settingsSchema.JSON200.Settings.KafkaConnect)
-		if err != nil {
-			diagnostics.AddError("Validation error", fmt.Sprintf("invalid Kafka Connect settings: %s", err))
+		if settingsSchema.StatusCode() != http.StatusOK {
+			diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read database settings schema, unexpected status: %s", settingsSchema.Status()))
 			return
 		}
-		service.KafkaConnectSettings = &obj
-	}
 
-	if !data.Kafka.RestSettings.IsUnknown() {
-		obj, err := validateSettings(data.Kafka.RestSettings.ValueString(), settingsSchema.JSON200.Settings.KafkaRest)
-		if err != nil {
-			diagnostics.AddError("Validation error", fmt.Sprintf("invalid Kafka REST settings: %s", err))
-			return
+		if !data.Kafka.Settings.IsUnknown() {
+			obj, err := validateSettings(data.Kafka.Settings.ValueString(), settingsSchema.JSON200.Settings.Kafka)
+			if err != nil {
+				diagnostics.AddError("Validation error", fmt.Sprintf("invalid settings: %s", err))
+				return
+			}
+			service.KafkaSettings = &obj
 		}
-		service.KafkaRestSettings = &obj
-	}
 
-	if !data.Kafka.SchemaRegistrySettings.IsUnknown() {
-		obj, err := validateSettings(data.Kafka.SchemaRegistrySettings.ValueString(), settingsSchema.JSON200.Settings.SchemaRegistry)
-		if err != nil {
-			diagnostics.AddError("Validation error", fmt.Sprintf("invalid Schema Registry settings: %s", err))
-			return
+		if !data.Kafka.ConnectSettings.IsUnknown() {
+			obj, err := validateSettings(data.Kafka.ConnectSettings.ValueString(), settingsSchema.JSON200.Settings.KafkaConnect)
+			if err != nil {
+				diagnostics.AddError("Validation error", fmt.Sprintf("invalid Kafka Connect settings: %s", err))
+				return
+			}
+			service.KafkaConnectSettings = &obj
 		}
-		service.SchemaRegistrySettings = &obj
+
+		if !data.Kafka.RestSettings.IsUnknown() {
+			obj, err := validateSettings(data.Kafka.RestSettings.ValueString(), settingsSchema.JSON200.Settings.KafkaRest)
+			if err != nil {
+				diagnostics.AddError("Validation error", fmt.Sprintf("invalid Kafka REST settings: %s", err))
+				return
+			}
+			service.KafkaRestSettings = &obj
+		}
+
+		if !data.Kafka.SchemaRegistrySettings.IsUnknown() {
+			obj, err := validateSettings(data.Kafka.SchemaRegistrySettings.ValueString(), settingsSchema.JSON200.Settings.SchemaRegistry)
+			if err != nil {
+				diagnostics.AddError("Validation error", fmt.Sprintf("invalid Schema Registry settings: %s", err))
+				return
+			}
+			service.SchemaRegistrySettings = &obj
+		}
 	}
 
 	res, err := r.client.CreateDbaasServiceKafkaWithResponse(
@@ -205,7 +209,159 @@ func (r *ServiceResource) createKafka(ctx context.Context, data *ServiceResource
 		return
 	}
 
-	r.readKafka(ctx, data, diagnostics)
+	tflog.Info(ctx, "DB Service created, waiting for the service to be in 'running' state")
+
+	apiService := &oapi.DbaasServiceKafka{}
+pooling:
+	for {
+		select {
+		case <-ctx.Done():
+			diagnostics.AddError("Error", ctx.Err().Error())
+			return
+		default:
+			res, err := r.client.GetDbaasServiceKafkaWithResponse(ctx, oapi.DbaasServiceName(data.Id.ValueString()))
+			if err != nil {
+				diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read database service kafka, got error: %s", err))
+				return
+			}
+			if res.StatusCode() != http.StatusOK {
+				diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read database service kafka, unexpected status: %s", res.Status()))
+				return
+			}
+			if res.JSON200.State != nil {
+				if *res.JSON200.State == oapi.EnumServiceStatePoweroff {
+					diagnostics.AddError("Client Error", fmt.Sprintf("Unexpected service state: %s", *res.JSON200.State))
+					return
+				}
+				if *res.JSON200.State == oapi.EnumServiceStateRunning {
+					apiService = res.JSON200
+					break pooling
+				}
+			}
+			time.Sleep(time.Second * 2)
+		}
+	}
+
+	// Fill in unknown values.
+	caCert, err := r.client.GetDatabaseCACertificate(ctx, data.Zone.ValueString())
+	if err != nil {
+		diagnostics.AddError("Client Error", fmt.Sprintf("Unable to get CA Certificate: %s", err))
+		return
+	}
+	data.CA = types.StringValue(caCert)
+
+	data.CreatedAt = types.StringValue(apiService.CreatedAt.String())
+	data.DiskSize = types.Int64PointerValue(apiService.DiskSize)
+	data.NodeCPUs = types.Int64PointerValue(apiService.NodeCpuCount)
+	data.NodeMemory = types.Int64PointerValue(apiService.NodeMemory)
+	data.Nodes = types.Int64PointerValue(apiService.NodeCount)
+	data.State = types.StringPointerValue((*string)(apiService.State))
+	data.UpdatedAt = types.StringValue(apiService.UpdatedAt.String())
+
+	if data.TerminationProtection.IsUnknown() {
+		data.TerminationProtection = types.BoolPointerValue(apiService.TerminationProtection)
+	}
+
+	if data.MaintenanceDOW.IsUnknown() && data.MaintenanceTime.IsUnknown() {
+		data.MaintenanceDOW = types.StringNull()
+		data.MaintenanceTime = types.StringNull()
+		if apiService.Maintenance != nil {
+			data.MaintenanceDOW = types.StringValue(string(apiService.Maintenance.Dow))
+			data.MaintenanceTime = types.StringValue(apiService.Maintenance.Time)
+		}
+	}
+
+	if data.Kafka != nil {
+		if data.Kafka.EnableKafkaConnect.IsUnknown() {
+			data.Kafka.EnableKafkaConnect = types.BoolPointerValue(apiService.KafkaConnectEnabled)
+		}
+		if data.Kafka.EnableKafkaREST.IsUnknown() {
+			data.Kafka.EnableKafkaREST = types.BoolPointerValue(apiService.KafkaRestEnabled)
+		}
+		if data.Kafka.EnableSchemaRegistry.IsUnknown() {
+			data.Kafka.EnableSchemaRegistry = types.BoolPointerValue(apiService.SchemaRegistryEnabled)
+		}
+		if data.Kafka.EnableSASLAuth.IsUnknown() {
+			data.Kafka.EnableSASLAuth = types.BoolNull()
+			if apiService.AuthenticationMethods != nil {
+				data.Kafka.EnableSASLAuth = types.BoolPointerValue(apiService.AuthenticationMethods.Sasl)
+			}
+		}
+		if data.Kafka.EnableCertAuth.IsUnknown() {
+			data.Kafka.EnableCertAuth = types.BoolNull()
+			if apiService.AuthenticationMethods != nil {
+				data.Kafka.EnableCertAuth = types.BoolPointerValue(apiService.AuthenticationMethods.Certificate)
+			}
+		}
+		if data.Kafka.IpFilter.IsUnknown() {
+			data.Kafka.IpFilter = types.SetNull(types.StringType)
+			if apiService.IpFilter != nil {
+				v, dg := types.SetValueFrom(ctx, types.StringType, *apiService.IpFilter)
+				if dg.HasError() {
+					diagnostics.Append(dg...)
+					return
+				}
+
+				data.Kafka.IpFilter = v
+			}
+		}
+
+		if data.Kafka.Version.IsUnknown() {
+			data.Kafka.Version = types.StringNull()
+			if apiService.Version != nil {
+				version := strings.SplitN(*apiService.Version, ".", 3)
+				data.Kafka.Version = types.StringValue(version[0] + "." + version[1])
+			}
+		}
+
+		if data.Kafka.Settings.IsUnknown() {
+			data.Kafka.Settings = types.StringNull()
+			if apiService.KafkaSettings != nil {
+				settings, err := json.Marshal(*apiService.KafkaSettings)
+				if err != nil {
+					diagnostics.AddError("Validation error", fmt.Sprintf("invalid settings: %s", err))
+					return
+				}
+				data.Kafka.Settings = types.StringValue(string(settings))
+			}
+		}
+
+		if data.Kafka.ConnectSettings.IsUnknown() {
+			data.Kafka.ConnectSettings = types.StringNull()
+			if apiService.KafkaConnectSettings != nil {
+				settings, err := json.Marshal(*apiService.KafkaConnectSettings)
+				if err != nil {
+					diagnostics.AddError("Validation error", fmt.Sprintf("invalid settings: %s", err))
+					return
+				}
+				data.Kafka.ConnectSettings = types.StringValue(string(settings))
+			}
+		}
+
+		if data.Kafka.RestSettings.IsUnknown() {
+			data.Kafka.RestSettings = types.StringNull()
+			if apiService.KafkaRestSettings != nil {
+				settings, err := json.Marshal(*apiService.KafkaRestSettings)
+				if err != nil {
+					diagnostics.AddError("Validation error", fmt.Sprintf("invalid settings: %s", err))
+					return
+				}
+				data.Kafka.RestSettings = types.StringValue(string(settings))
+			}
+		}
+
+		if data.Kafka.SchemaRegistrySettings.IsUnknown() {
+			data.Kafka.SchemaRegistrySettings = types.StringNull()
+			if apiService.SchemaRegistrySettings != nil {
+				settings, err := json.Marshal(*apiService.SchemaRegistrySettings)
+				if err != nil {
+					diagnostics.AddError("Validation error", fmt.Sprintf("invalid settings: %s", err))
+					return
+				}
+				data.Kafka.SchemaRegistrySettings = types.StringValue(string(settings))
+			}
+		}
+	}
 }
 
 // readKafka function handles Kafka specific part of database resource Read logic.
@@ -337,16 +493,20 @@ func (r *ServiceResource) updateKafka(ctx context.Context, stateData *ServiceRes
 			Dow:  oapi.UpdateDbaasServiceKafkaJSONBodyMaintenanceDow(planData.MaintenanceDOW.ValueString()),
 			Time: planData.MaintenanceTime.ValueString(),
 		}
+		stateData.MaintenanceDOW = planData.MaintenanceDOW
+		stateData.MaintenanceTime = planData.MaintenanceTime
 		updated = true
 	}
 
 	if !planData.Plan.Equal(stateData.Plan) {
 		service.Plan = planData.Plan.ValueStringPointer()
+		stateData.Plan = planData.Plan
 		updated = true
 	}
 
 	if !planData.TerminationProtection.Equal(stateData.TerminationProtection) {
 		service.TerminationProtection = planData.TerminationProtection.ValueBoolPointer()
+		stateData.TerminationProtection = planData.TerminationProtection
 		updated = true
 	}
 
@@ -365,21 +525,25 @@ func (r *ServiceResource) updateKafka(ctx context.Context, stateData *ServiceRes
 				}
 			}
 			service.IpFilter = &obj
+			stateData.Kafka.IpFilter = planData.Kafka.IpFilter
 			updated = true
 		}
 
 		if !planData.Kafka.EnableKafkaConnect.Equal(stateData.Kafka.EnableKafkaConnect) {
 			service.KafkaConnectEnabled = planData.Kafka.EnableKafkaConnect.ValueBoolPointer()
+			stateData.Kafka.EnableKafkaConnect = planData.Kafka.EnableKafkaConnect
 			updated = true
 		}
 
 		if !planData.Kafka.EnableKafkaREST.Equal(stateData.Kafka.EnableKafkaREST) {
 			service.KafkaRestEnabled = planData.Kafka.EnableKafkaREST.ValueBoolPointer()
+			stateData.Kafka.EnableKafkaREST = planData.Kafka.EnableKafkaREST
 			updated = true
 		}
 
 		if !planData.Kafka.EnableSchemaRegistry.Equal(stateData.Kafka.EnableSchemaRegistry) {
 			service.SchemaRegistryEnabled = planData.Kafka.EnableSchemaRegistry.ValueBoolPointer()
+			stateData.Kafka.EnableSchemaRegistry = planData.Kafka.EnableSchemaRegistry
 			updated = true
 		}
 
@@ -391,6 +555,8 @@ func (r *ServiceResource) updateKafka(ctx context.Context, stateData *ServiceRes
 				Certificate: planData.Kafka.EnableCertAuth.ValueBoolPointer(),
 				Sasl:        planData.Kafka.EnableSASLAuth.ValueBoolPointer(),
 			}
+			stateData.Kafka.EnableCertAuth = planData.Kafka.EnableCertAuth
+			stateData.Kafka.EnableSASLAuth = planData.Kafka.EnableSASLAuth
 			updated = true
 		}
 
@@ -413,6 +579,7 @@ func (r *ServiceResource) updateKafka(ctx context.Context, stateData *ServiceRes
 				}
 				service.KafkaSettings = &obj
 			}
+			stateData.Kafka.Settings = planData.Kafka.Settings
 			updated = true
 		}
 
@@ -425,6 +592,7 @@ func (r *ServiceResource) updateKafka(ctx context.Context, stateData *ServiceRes
 				}
 				service.KafkaConnectSettings = &obj
 			}
+			stateData.Kafka.ConnectSettings = planData.Kafka.ConnectSettings
 			updated = true
 		}
 
@@ -437,6 +605,7 @@ func (r *ServiceResource) updateKafka(ctx context.Context, stateData *ServiceRes
 				}
 				service.KafkaRestSettings = &obj
 			}
+			stateData.Kafka.RestSettings = planData.Kafka.RestSettings
 			updated = true
 		}
 
@@ -449,27 +618,137 @@ func (r *ServiceResource) updateKafka(ctx context.Context, stateData *ServiceRes
 				}
 				service.SchemaRegistrySettings = &obj
 			}
+			stateData.Kafka.SchemaRegistrySettings = planData.Kafka.SchemaRegistrySettings
 			updated = true
 		}
 	}
 
 	if !updated {
-		tflog.Info(ctx, "no updates detected", map[string]interface{}{})
-	} else {
-		res, err := r.client.UpdateDbaasServiceKafkaWithResponse(
-			ctx,
-			oapi.DbaasServiceName(planData.Id.ValueString()),
-			service,
-		)
-		if err != nil {
-			diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create database service kafka, got error: %s", err))
-			return
-		}
-		if res.StatusCode() != http.StatusOK {
-			diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create database service kafka, unexpected status: %s", res.Status()))
-			return
-		}
+		tflog.Info(ctx, "no updates detected", map[string]any{})
+		return
 	}
 
-	r.readKafka(ctx, planData, diagnostics)
+	res, err := r.client.UpdateDbaasServiceKafkaWithResponse(
+		ctx,
+		oapi.DbaasServiceName(planData.Id.ValueString()),
+		service,
+	)
+	if err != nil {
+		diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create database service kafka, got error: %s", err))
+		return
+	}
+	if res.StatusCode() != http.StatusOK {
+		diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create database service kafka, unexpected status: %s", res.Status()))
+		return
+	}
+
+	apiService := &oapi.DbaasServiceKafka{}
+	if res, err := r.client.GetDbaasServiceKafkaWithResponse(
+		ctx,
+		oapi.DbaasServiceName(stateData.Id.ValueString()),
+	); err != nil {
+		diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read database service kafka, got error: %s", err))
+		return
+	} else if res.StatusCode() != http.StatusOK {
+		diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read database service kafka, unexpected status: %s", res.Status()))
+		return
+	} else {
+		apiService = res.JSON200
+	}
+
+	// Set computed values
+	stateData.NodeCPUs = types.Int64PointerValue(apiService.NodeCpuCount)
+	stateData.NodeMemory = types.Int64PointerValue(apiService.NodeMemory)
+	stateData.Nodes = types.Int64PointerValue(apiService.NodeCount)
+	stateData.State = types.StringPointerValue((*string)(apiService.State))
+	if apiService.UpdatedAt != nil {
+		stateData.UpdatedAt = types.StringValue(apiService.UpdatedAt.String())
+	}
+	if stateData.TerminationProtection.IsUnknown() {
+		stateData.TerminationProtection = types.BoolPointerValue(apiService.TerminationProtection)
+	}
+
+	if stateData.Kafka == nil {
+		return
+	}
+
+	if stateData.Kafka.Version.IsUnknown() {
+		stateData.Kafka.Version = types.StringPointerValue(apiService.Version)
+	}
+	if stateData.Kafka.EnableKafkaConnect.IsUnknown() {
+		stateData.Kafka.EnableKafkaConnect = types.BoolPointerValue(apiService.KafkaConnectEnabled)
+	}
+	if stateData.Kafka.EnableKafkaREST.IsUnknown() {
+		stateData.Kafka.EnableKafkaREST = types.BoolPointerValue(apiService.KafkaRestEnabled)
+	}
+	if stateData.Kafka.EnableSchemaRegistry.IsUnknown() {
+		stateData.Kafka.EnableSchemaRegistry = types.BoolPointerValue(apiService.SchemaRegistryEnabled)
+	}
+	if stateData.Kafka.EnableSASLAuth.IsUnknown() {
+		stateData.Kafka.EnableSASLAuth = types.BoolNull()
+		if apiService.AuthenticationMethods != nil {
+			stateData.Kafka.EnableSASLAuth = types.BoolPointerValue(apiService.AuthenticationMethods.Sasl)
+		}
+	}
+	if stateData.Kafka.EnableCertAuth.IsUnknown() {
+		stateData.Kafka.EnableCertAuth = types.BoolNull()
+		if apiService.AuthenticationMethods != nil {
+			stateData.Kafka.EnableCertAuth = types.BoolPointerValue(apiService.AuthenticationMethods.Certificate)
+		}
+	}
+	if stateData.Kafka.IpFilter.IsUnknown() {
+		stateData.Kafka.IpFilter = types.SetNull(types.StringType)
+		if apiService.IpFilter != nil {
+			v, dg := types.SetValueFrom(ctx, types.StringType, *apiService.IpFilter)
+			if dg.HasError() {
+				diagnostics.Append(dg...)
+				return
+			}
+			stateData.Kafka.IpFilter = v
+		}
+	}
+	if stateData.Kafka.Settings.IsUnknown() {
+		stateData.Kafka.Settings = types.StringNull()
+		if apiService.KafkaSettings != nil {
+			settings, err := json.Marshal(*apiService.KafkaSettings)
+			if err != nil {
+				diagnostics.AddError("Validation error", fmt.Sprintf("invalid settings: %s", err))
+				return
+			}
+			stateData.Kafka.Settings = types.StringValue(string(settings))
+		}
+	}
+	if stateData.Kafka.ConnectSettings.IsUnknown() {
+		stateData.Kafka.ConnectSettings = types.StringNull()
+		if apiService.KafkaConnectSettings != nil {
+			settings, err := json.Marshal(*apiService.KafkaConnectSettings)
+			if err != nil {
+				diagnostics.AddError("Validation error", fmt.Sprintf("invalid KafkaConnectSettings: %s", err))
+				return
+			}
+			stateData.Kafka.ConnectSettings = types.StringValue(string(settings))
+		}
+	}
+	if stateData.Kafka.RestSettings.IsUnknown() {
+		stateData.Kafka.RestSettings = types.StringNull()
+		if apiService.KafkaRestSettings != nil {
+			settings, err := json.Marshal(*apiService.KafkaRestSettings)
+			if err != nil {
+				diagnostics.AddError("Validation error", fmt.Sprintf("invalid settings: %s", err))
+				return
+			}
+			stateData.Kafka.RestSettings = types.StringValue(string(settings))
+		}
+	}
+	if stateData.Kafka.SchemaRegistrySettings.IsUnknown() {
+		stateData.Kafka.SchemaRegistrySettings = types.StringNull()
+		if apiService.SchemaRegistrySettings != nil {
+			settings, err := json.Marshal(*apiService.SchemaRegistrySettings)
+			if err != nil {
+				diagnostics.AddError("Validation error", fmt.Sprintf("invalid settings: %s", err))
+				return
+			}
+			stateData.Kafka.SchemaRegistrySettings = types.StringValue(string(settings))
+		}
+	}
 }

--- a/pkg/resources/database/resource_service_kafka.go
+++ b/pkg/resources/database/resource_service_kafka.go
@@ -656,7 +656,7 @@ func (r *ServiceResource) updateKafka(ctx context.Context, stateData *ServiceRes
 		apiService = res.JSON200
 	}
 
-	// Set computed values
+	// Fill in unknown values.
 	stateData.NodeCPUs = types.Int64PointerValue(apiService.NodeCpuCount)
 	stateData.NodeMemory = types.Int64PointerValue(apiService.NodeMemory)
 	stateData.Nodes = types.Int64PointerValue(apiService.NodeCount)

--- a/pkg/resources/database/resource_service_kafka_test.go
+++ b/pkg/resources/database/resource_service_kafka_test.go
@@ -366,7 +366,8 @@ func CheckExistsKafka(name string, data *TemplateModelKafka) error {
 		}
 	}
 
-	if data.Version != *service.Version {
+	version := strings.SplitN(*service.Version, ".", 3)
+	if data.Version != version[0]+"."+version[1] {
 		return fmt.Errorf("kafka.version: expected %q, got %q", data.Version, *service.Version)
 	}
 

--- a/pkg/resources/database/resource_service_mysql.go
+++ b/pkg/resources/database/resource_service_mysql.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -69,39 +70,9 @@ var ResourceMysqlSchema = schema.SingleNestedBlock{
 
 // createMysql function handles MySQL specific part of database resource creation logic.
 func (r *ServiceResource) createMysql(ctx context.Context, data *ServiceResourceModel, diagnostics *diag.Diagnostics) {
-	mysqlData := &ResourceMysqlModel{}
-	if data.Mysql != nil {
-		mysqlData = data.Mysql
-	}
-
 	service := oapi.CreateDbaasServiceMysqlJSONRequestBody{
 		Plan:                  data.Plan.ValueString(),
 		TerminationProtection: data.TerminationProtection.ValueBoolPointer(),
-	}
-
-	if !mysqlData.Version.IsUnknown() {
-		service.Version = mysqlData.Version.ValueStringPointer()
-	}
-
-	if !mysqlData.AdminPassword.IsNull() {
-		service.AdminPassword = mysqlData.AdminPassword.ValueStringPointer()
-	}
-
-	if !mysqlData.AdminUsername.IsNull() {
-		service.AdminUsername = mysqlData.AdminUsername.ValueStringPointer()
-	}
-
-	if !mysqlData.IpFilter.IsUnknown() {
-		obj := []string{}
-		if len(mysqlData.IpFilter.Elements()) > 0 {
-			dg := mysqlData.IpFilter.ElementsAs(ctx, &obj, false)
-			if dg.HasError() {
-				diagnostics.Append(dg...)
-				return
-			}
-		}
-
-		service.IpFilter = &obj
 	}
 
 	if !data.MaintenanceDOW.IsUnknown() && !data.MaintenanceTime.IsUnknown() {
@@ -114,39 +85,66 @@ func (r *ServiceResource) createMysql(ctx context.Context, data *ServiceResource
 		}
 	}
 
-	if !mysqlData.BackupSchedule.IsUnknown() {
-		bh, bm, err := parseBackupSchedule(mysqlData.BackupSchedule.ValueString())
+	if data.Mysql != nil {
+		if !data.Mysql.Version.IsUnknown() {
+			service.Version = data.Mysql.Version.ValueStringPointer()
+		}
+
+		if !data.Mysql.AdminPassword.IsNull() {
+			service.AdminPassword = data.Mysql.AdminPassword.ValueStringPointer()
+		}
+
+		if !data.Mysql.AdminUsername.IsNull() {
+			service.AdminUsername = data.Mysql.AdminUsername.ValueStringPointer()
+		}
+
+		if !data.Mysql.IpFilter.IsUnknown() {
+			obj := []string{}
+			if len(data.Mysql.IpFilter.Elements()) > 0 {
+				dg := data.Mysql.IpFilter.ElementsAs(ctx, &obj, false)
+				if dg.HasError() {
+					diagnostics.Append(dg...)
+					return
+				}
+			}
+
+			service.IpFilter = &obj
+		}
+
+		if !data.Mysql.BackupSchedule.IsUnknown() {
+			bh, bm, err := parseBackupSchedule(data.Mysql.BackupSchedule.ValueString())
+			if err != nil {
+				diagnostics.AddError("Validation error", fmt.Sprintf("Unable to parse backup schedule, got error: %s", err))
+				return
+			}
+
+			service.BackupSchedule = &struct {
+				BackupHour   *int64 `json:"backup-hour,omitempty"`
+				BackupMinute *int64 `json:"backup-minute,omitempty"`
+			}{
+				BackupHour:   &bh,
+				BackupMinute: &bm,
+			}
+		}
+
+		settingsSchema, err := r.client.GetDbaasSettingsMysqlWithResponse(ctx)
 		if err != nil {
-			diagnostics.AddError("Validation error", fmt.Sprintf("Unable to parse backup schedule, got error: %s", err))
+			diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read database settings schema, got error: %s", err))
+			return
+		}
+		if settingsSchema.StatusCode() != http.StatusOK {
+			diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read database settings schema, unexpected status: %s", settingsSchema.Status()))
 			return
 		}
 
-		service.BackupSchedule = &struct {
-			BackupHour   *int64 `json:"backup-hour,omitempty"`
-			BackupMinute *int64 `json:"backup-minute,omitempty"`
-		}{
-			BackupHour:   &bh,
-			BackupMinute: &bm,
+		if !data.Mysql.Settings.IsUnknown() {
+			obj, err := validateSettings(data.Mysql.Settings.ValueString(), settingsSchema.JSON200.Settings.Mysql)
+			if err != nil {
+				diagnostics.AddError("Validation error", fmt.Sprintf("invalid settings: %s", err))
+				return
+			}
+			service.MysqlSettings = &obj
 		}
-	}
-
-	settingsSchema, err := r.client.GetDbaasSettingsMysqlWithResponse(ctx)
-	if err != nil {
-		diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read database settings schema, got error: %s", err))
-		return
-	}
-	if settingsSchema.StatusCode() != http.StatusOK {
-		diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read database settings schema, unexpected status: %s", settingsSchema.Status()))
-		return
-	}
-
-	if !mysqlData.Settings.IsUnknown() {
-		obj, err := validateSettings(mysqlData.Settings.ValueString(), settingsSchema.JSON200.Settings.Mysql)
-		if err != nil {
-			diagnostics.AddError("Validation error", fmt.Sprintf("invalid settings: %s", err))
-			return
-		}
-		service.MysqlSettings = &obj
 	}
 
 	res, err := r.client.CreateDbaasServiceMysqlWithResponse(
@@ -163,11 +161,115 @@ func (r *ServiceResource) createMysql(ctx context.Context, data *ServiceResource
 		return
 	}
 
-	r.readMysql(ctx, data, diagnostics)
+	tflog.Info(ctx, "DB Service created, waiting for the service to be in 'running' state")
+
+	apiService := &oapi.DbaasServiceMysql{}
+pooling:
+	for {
+		select {
+		case <-ctx.Done():
+			diagnostics.AddError("Error", ctx.Err().Error())
+			return
+		default:
+			res, err := r.client.GetDbaasServiceMysqlWithResponse(ctx, oapi.DbaasServiceName(data.Id.ValueString()))
+			if err != nil {
+				diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read database service mysql, got error: %s", err))
+				return
+			}
+			if res.StatusCode() != http.StatusOK {
+				diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read database service mysql, unexpected status: %s", res.Status()))
+				return
+			}
+			if res.JSON200.State != nil {
+				if *res.JSON200.State == oapi.EnumServiceStatePoweroff {
+					diagnostics.AddError("Client Error", fmt.Sprintf("Unexpected service state: %s", *res.JSON200.State))
+					return
+				}
+				if *res.JSON200.State == oapi.EnumServiceStateRunning {
+					apiService = res.JSON200
+					break pooling
+				}
+			}
+			time.Sleep(time.Second * 2)
+		}
+	}
+
+	// Setting values for `Unknown` attributes.
+	caCert, err := r.client.GetDatabaseCACertificate(ctx, data.Zone.ValueString())
+	if err != nil {
+		diagnostics.AddError("Client Error", fmt.Sprintf("Unable to get CA Certificate: %s", err))
+		return
+	}
+	data.CA = types.StringValue(caCert)
+
+	data.CreatedAt = types.StringValue(apiService.CreatedAt.String())
+	data.DiskSize = types.Int64PointerValue(apiService.DiskSize)
+	data.NodeCPUs = types.Int64PointerValue(apiService.NodeCpuCount)
+	data.NodeMemory = types.Int64PointerValue(apiService.NodeMemory)
+	data.Nodes = types.Int64PointerValue(apiService.NodeCount)
+	data.State = types.StringPointerValue((*string)(apiService.State))
+	data.UpdatedAt = types.StringValue(apiService.UpdatedAt.String())
+
+	if data.TerminationProtection.IsUnknown() {
+		data.TerminationProtection = types.BoolPointerValue(apiService.TerminationProtection)
+	}
+
+	if data.MaintenanceDOW.IsUnknown() && data.MaintenanceTime.IsUnknown() {
+		data.MaintenanceDOW = types.StringNull()
+		data.MaintenanceTime = types.StringNull()
+		if apiService.Maintenance != nil {
+			data.MaintenanceDOW = types.StringValue(string(apiService.Maintenance.Dow))
+			data.MaintenanceTime = types.StringValue(apiService.Maintenance.Time)
+		}
+	}
+
+	if data.Mysql.BackupSchedule.IsUnknown() {
+		data.Mysql.BackupSchedule = types.StringNull()
+		if apiService.BackupSchedule != nil {
+			backupHour := types.Int64PointerValue(apiService.BackupSchedule.BackupHour)
+			backupMinute := types.Int64PointerValue(apiService.BackupSchedule.BackupMinute)
+			data.Mysql.BackupSchedule = types.StringValue(fmt.Sprintf(
+				"%02d:%02d",
+				backupHour.ValueInt64(),
+				backupMinute.ValueInt64(),
+			))
+		}
+	}
+
+	if data.Mysql.IpFilter.IsUnknown() {
+		data.Mysql.IpFilter = types.SetNull(types.StringType)
+		if apiService.IpFilter != nil {
+			v, dg := types.SetValueFrom(ctx, types.StringType, *apiService.IpFilter)
+			if dg.HasError() {
+				diagnostics.Append(dg...)
+				return
+			}
+
+			data.Mysql.IpFilter = v
+		}
+	}
+
+	if data.Mysql.Version.IsUnknown() {
+		data.Mysql.Version = types.StringNull()
+		if apiService.Version != nil {
+			data.Mysql.Version = types.StringValue(strings.SplitN(*apiService.Version, ".", 2)[0])
+		}
+	}
+
+	if data.Mysql.Settings.IsUnknown() {
+		data.Mysql.Settings = types.StringNull()
+		if apiService.MysqlSettings != nil {
+			settings, err := json.Marshal(*apiService.MysqlSettings)
+			if err != nil {
+				diagnostics.AddError("Validation error", fmt.Sprintf("invalid settings: %s", err))
+				return
+			}
+			data.Mysql.Settings = types.StringValue(string(settings))
+		}
+	}
 }
 
 // readMysql function handles MySQL specific part of database resource Read logic.
-// It is used in the dedicated Read action but also as a finishing step of Create, Update and Import.
 func (r *ServiceResource) readMysql(ctx context.Context, data *ServiceResourceModel, diagnostics *diag.Diagnostics) {
 	caCert, err := r.client.GetDatabaseCACertificate(ctx, data.Zone.ValueString())
 	if err != nil {
@@ -261,16 +363,20 @@ func (r *ServiceResource) updateMysql(ctx context.Context, stateData *ServiceRes
 			Dow:  oapi.UpdateDbaasServiceMysqlJSONBodyMaintenanceDow(planData.MaintenanceDOW.ValueString()),
 			Time: planData.MaintenanceTime.ValueString(),
 		}
+		stateData.MaintenanceDOW = planData.MaintenanceDOW
+		stateData.MaintenanceTime = planData.MaintenanceTime
 		updated = true
 	}
 
 	if !planData.Plan.Equal(stateData.Plan) {
 		service.Plan = planData.Plan.ValueStringPointer()
+		stateData.Plan = planData.Plan
 		updated = true
 	}
 
 	if !planData.TerminationProtection.Equal(stateData.TerminationProtection) {
 		service.TerminationProtection = planData.TerminationProtection.ValueBoolPointer()
+		stateData.TerminationProtection = planData.TerminationProtection
 		updated = true
 	}
 
@@ -293,6 +399,7 @@ func (r *ServiceResource) updateMysql(ctx context.Context, stateData *ServiceRes
 				BackupHour:   &bh,
 				BackupMinute: &bm,
 			}
+			stateData.Mysql.BackupSchedule = planData.Mysql.BackupSchedule
 			updated = true
 		}
 
@@ -306,6 +413,7 @@ func (r *ServiceResource) updateMysql(ctx context.Context, stateData *ServiceRes
 				}
 			}
 			service.IpFilter = &obj
+			stateData.Mysql.IpFilter = planData.Mysql.IpFilter
 			updated = true
 		}
 
@@ -328,44 +436,81 @@ func (r *ServiceResource) updateMysql(ctx context.Context, stateData *ServiceRes
 				}
 				service.MysqlSettings = &obj
 			}
+			stateData.Mysql.Settings = planData.Mysql.Settings
 			updated = true
-		}
-
-		// Aiven would overwrite the backup schedule with random value if we don't specify it explicitly every time.
-		if service.BackupSchedule == nil {
-			bh, bm, err := parseBackupSchedule(planData.Mysql.BackupSchedule.ValueString())
-			if err != nil {
-				diagnostics.AddError("Validation error", fmt.Sprintf("Unable to parse backup schedule, got error: %s", err))
-				return
-			}
-
-			service.BackupSchedule = &struct {
-				BackupHour   *int64 `json:"backup-hour,omitempty"`
-				BackupMinute *int64 `json:"backup-minute,omitempty"`
-			}{
-				BackupHour:   &bh,
-				BackupMinute: &bm,
-			}
 		}
 	}
 
 	if !updated {
 		tflog.Info(ctx, "no updates detected", map[string]interface{}{})
-	} else {
-		res, err := r.client.UpdateDbaasServiceMysqlWithResponse(
-			ctx,
-			oapi.DbaasServiceName(planData.Id.ValueString()),
-			service,
-		)
+		return
+	}
+
+	// Aiven would overwrite the backup schedule with random value if we don't specify it explicitly every time.
+	if service.BackupSchedule == nil {
+		bh, bm, err := parseBackupSchedule(planData.Mysql.BackupSchedule.ValueString())
 		if err != nil {
-			diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create database service mysql, got error: %s", err))
+			diagnostics.AddError("Validation error", fmt.Sprintf("Unable to parse backup schedule, got error: %s", err))
 			return
 		}
-		if res.StatusCode() != http.StatusOK {
-			diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create database service mysql, unexpected status: %s", res.Status()))
-			return
+
+		service.BackupSchedule = &struct {
+			BackupHour   *int64 `json:"backup-hour,omitempty"`
+			BackupMinute *int64 `json:"backup-minute,omitempty"`
+		}{
+			BackupHour:   &bh,
+			BackupMinute: &bm,
 		}
 	}
 
-	r.readMysql(ctx, planData, diagnostics)
+	res, err := r.client.UpdateDbaasServiceMysqlWithResponse(
+		ctx,
+		oapi.DbaasServiceName(planData.Id.ValueString()),
+		service,
+	)
+	if err != nil {
+		diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create database service mysql, got error: %s", err))
+		return
+	}
+	if res.StatusCode() != http.StatusOK {
+		diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create database service mysql, unexpected status: %s", res.Status()))
+		return
+	}
+
+	apiService := &oapi.DbaasServiceMysql{}
+	if res, err := r.client.GetDbaasServiceMysqlWithResponse(
+		ctx,
+		oapi.DbaasServiceName(stateData.Id.ValueString()),
+	); err != nil {
+		diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read database service mysql, got error: %s", err))
+		return
+	} else if res.StatusCode() != http.StatusOK {
+		diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read database service mysql, unexpected status: %s", res.Status()))
+		return
+	} else {
+		apiService = res.JSON200
+	}
+
+	// Updating computed attributes
+	stateData.NodeCPUs = types.Int64PointerValue(apiService.NodeCpuCount)
+	stateData.NodeMemory = types.Int64PointerValue(apiService.NodeMemory)
+	stateData.Nodes = types.Int64PointerValue(apiService.NodeCount)
+	stateData.State = types.StringPointerValue((*string)(apiService.State))
+	if apiService.UpdatedAt != nil {
+		stateData.UpdatedAt = types.StringValue(apiService.UpdatedAt.String())
+	}
+	if stateData.TerminationProtection.IsUnknown() {
+		stateData.TerminationProtection = types.BoolPointerValue(apiService.TerminationProtection)
+	}
+	if stateData.Mysql != nil && stateData.Mysql.IpFilter.IsUnknown() {
+		stateData.Mysql.IpFilter = types.SetNull(types.StringType)
+		if apiService.IpFilter != nil {
+			v, dg := types.SetValueFrom(ctx, types.StringType, *apiService.IpFilter)
+			if dg.HasError() {
+				diagnostics.Append(dg...)
+				return
+			}
+			stateData.Mysql.IpFilter = v
+		}
+	}
 }

--- a/pkg/resources/database/resource_service_opensearch_test.go
+++ b/pkg/resources/database/resource_service_opensearch_test.go
@@ -41,7 +41,6 @@ type TemplateModelOpensearch struct {
 	IndexTemplate            *TemplateModelOpensearchIndexTemplate
 	Dashboards               *TemplateModelOpensearchDashboards
 	KeepIndexRefreshInterval bool
-	MaxIndexCount            string
 	OpensearchSettings       string
 	Version                  string
 }
@@ -111,7 +110,6 @@ func testResourceOpensearch(t *testing.T) {
 	serviceDataCreate.Dashboards = &TemplateModelOpensearchDashboards{true, 129, 30001}
 	serviceDataCreate.KeepIndexRefreshInterval = true
 	serviceDataCreate.IpFilter = []string{"0.0.0.0/0"}
-	serviceDataCreate.MaxIndexCount = "4"
 
 	userDataCreate := userDataBase
 
@@ -136,7 +134,6 @@ func testResourceOpensearch(t *testing.T) {
 	serviceDataUpdate.IndexTemplate = &TemplateModelOpensearchIndexTemplate{5, 4, 3}
 	serviceDataUpdate.Dashboards = &TemplateModelOpensearchDashboards{true, 132, 30006}
 	serviceDataUpdate.KeepIndexRefreshInterval = true
-	serviceDataUpdate.MaxIndexCount = "0"
 	serviceDataUpdate.IpFilter = []string{"1.1.1.1/32"}
 	serviceDataUpdate.IpFilter = nil
 

--- a/pkg/resources/database/resource_service_pg.go
+++ b/pkg/resources/database/resource_service_pg.go
@@ -651,7 +651,6 @@ func (r *ServiceResource) updatePg(ctx context.Context, stateData *ServiceResour
 	// Updating computed attributes
 	stateData.NodeCPUs = types.Int64PointerValue(apiService.NodeCpuCount)
 	stateData.NodeMemory = types.Int64PointerValue(apiService.NodeMemory)
-	stateData.DiskSize = types.Int64PointerValue(apiService.DiskSize)
 	stateData.Nodes = types.Int64PointerValue(apiService.NodeCount)
 	stateData.State = types.StringPointerValue((*string)(apiService.State))
 	if apiService.UpdatedAt != nil {

--- a/pkg/resources/database/resource_service_pg.go
+++ b/pkg/resources/database/resource_service_pg.go
@@ -222,7 +222,7 @@ pooling:
 		}
 	}
 
-	// Set computed attributes.
+	// Fill in unknown values.
 	caCert, err := r.client.GetDatabaseCACertificate(ctx, data.Zone.ValueString())
 	if err != nil {
 		diagnostics.AddError("Client Error", fmt.Sprintf("Unable to get CA Certificate: %s", err))
@@ -408,7 +408,7 @@ func (r *ServiceResource) readPg(ctx context.Context, data *ServiceResourceModel
 			data.Pg.Settings = types.StringValue(string(settings))
 		}
 	} else if data.Pg.Settings.ValueString() != "" {
-		var userSettings map[string]interface{}
+		var userSettings map[string]any
 
 		if err := json.Unmarshal([]byte(data.Pg.Settings.ValueString()), &userSettings); err != nil {
 			diagnostics.AddError("Validation error", fmt.Sprintf("unable to unmarshal JSON: %s", err))
@@ -436,7 +436,7 @@ func (r *ServiceResource) readPg(ctx context.Context, data *ServiceResourceModel
 			data.Pg.PgbouncerSettings = types.StringValue(string(settings))
 		}
 	} else if data.Pg.PgbouncerSettings.ValueString() != "" {
-		var userSettings map[string]interface{}
+		var userSettings map[string]any
 
 		if err := json.Unmarshal([]byte(data.Pg.PgbouncerSettings.ValueString()), &userSettings); err != nil {
 			diagnostics.AddError("Validation error", fmt.Sprintf("unable to unmarshal JSON: %s", err))
@@ -464,7 +464,7 @@ func (r *ServiceResource) readPg(ctx context.Context, data *ServiceResourceModel
 			data.Pg.PglookoutSettings = types.StringValue(string(settings))
 		}
 	} else if data.Pg.PglookoutSettings.ValueString() != "" {
-		var userSettings map[string]interface{}
+		var userSettings map[string]any
 
 		if err := json.Unmarshal([]byte(data.Pg.PglookoutSettings.ValueString()), &userSettings); err != nil {
 			diagnostics.AddError("Validation error", fmt.Sprintf("unable to unmarshal JSON: %s", err))
@@ -601,7 +601,7 @@ func (r *ServiceResource) updatePg(ctx context.Context, stateData *ServiceResour
 	}
 
 	if !updated {
-		tflog.Info(ctx, "no updates detected", map[string]interface{}{})
+		tflog.Info(ctx, "no updates detected", map[string]any{})
 		return
 	}
 
@@ -648,7 +648,7 @@ func (r *ServiceResource) updatePg(ctx context.Context, stateData *ServiceResour
 		apiService = res.JSON200
 	}
 
-	// Updating computed attributes
+	// Fill in unknown values.
 	stateData.NodeCPUs = types.Int64PointerValue(apiService.NodeCpuCount)
 	stateData.NodeMemory = types.Int64PointerValue(apiService.NodeMemory)
 	stateData.Nodes = types.Int64PointerValue(apiService.NodeCount)
@@ -659,7 +659,12 @@ func (r *ServiceResource) updatePg(ctx context.Context, stateData *ServiceResour
 	if stateData.TerminationProtection.IsUnknown() {
 		stateData.TerminationProtection = types.BoolPointerValue(apiService.TerminationProtection)
 	}
-	if stateData.Pg != nil && stateData.Pg.IpFilter.IsUnknown() {
+
+	if stateData.Pg == nil {
+		return
+	}
+
+	if stateData.Pg.IpFilter.IsUnknown() {
 		stateData.Pg.IpFilter = types.SetNull(types.StringType)
 		if apiService.IpFilter != nil {
 			v, dg := types.SetValueFrom(ctx, types.StringType, *apiService.IpFilter)
@@ -668,6 +673,49 @@ func (r *ServiceResource) updatePg(ctx context.Context, stateData *ServiceResour
 				return
 			}
 			stateData.Pg.IpFilter = v
+		}
+	}
+
+	if stateData.Pg.Version.IsUnknown() {
+		stateData.Pg.Version = types.StringNull()
+		if apiService.Version != nil {
+			stateData.Pg.Version = types.StringValue(strings.SplitN(*apiService.Version, ".", 2)[0])
+		}
+	}
+
+	if stateData.Pg.Settings.IsUnknown() {
+		stateData.Pg.Settings = types.StringNull()
+		if apiService.PgSettings != nil {
+			settings, err := json.Marshal(*apiService.PgSettings)
+			if err != nil {
+				diagnostics.AddError("Validation error", fmt.Sprintf("invalid settings: %s", err))
+				return
+			}
+			stateData.Pg.Settings = types.StringValue(string(settings))
+		}
+	}
+
+	if stateData.Pg.PgbouncerSettings.IsUnknown() {
+		stateData.Pg.PgbouncerSettings = types.StringNull()
+		if apiService.PgbouncerSettings != nil {
+			settings, err := json.Marshal(*apiService.PgbouncerSettings)
+			if err != nil {
+				diagnostics.AddError("Validation error", fmt.Sprintf("invalid settings: %s", err))
+				return
+			}
+			stateData.Pg.PgbouncerSettings = types.StringValue(string(settings))
+		}
+	}
+
+	if stateData.Pg.PglookoutSettings.IsUnknown() {
+		stateData.Pg.PglookoutSettings = types.StringNull()
+		if apiService.PglookoutSettings != nil {
+			settings, err := json.Marshal(*apiService.PglookoutSettings)
+			if err != nil {
+				diagnostics.AddError("Validation error", fmt.Sprintf("invalid settings: %s", err))
+				return
+			}
+			stateData.Pg.PglookoutSettings = types.StringValue(string(settings))
 		}
 	}
 }

--- a/pkg/resources/database/resource_service_valkey.go
+++ b/pkg/resources/database/resource_service_valkey.go
@@ -363,7 +363,6 @@ func (r *ServiceResource) updateValkey(ctx context.Context, stateData *ServiceRe
 
 	// Update all computed attributes
 	stateData.State = types.StringValue(string(res.State))
-	stateData.DiskSize = types.Int64PointerValue(&res.DiskSize)
 	stateData.NodeCPUs = types.Int64PointerValue(&res.NodeCPUCount)
 	stateData.Nodes = types.Int64PointerValue(&res.NodeCount)
 	stateData.NodeMemory = types.Int64PointerValue(&res.NodeMemory)

--- a/pkg/resources/database/resource_service_valkey.go
+++ b/pkg/resources/database/resource_service_valkey.go
@@ -254,6 +254,7 @@ func (r *ServiceResource) readValkey(ctx context.Context, data *ServiceResourceM
 // updateValkey function handles Valkey specific part of database resource Update logic.
 func (r *ServiceResource) updateValkey(ctx context.Context, stateData *ServiceResourceModel, planData *ServiceResourceModel, diagnostics *diag.Diagnostics) {
 	var updated bool
+
 	client, err := utils.SwitchClientZone(ctx, r.clientV3, v3.ZoneName(stateData.Zone.ValueString()))
 
 	if err != nil {
@@ -269,16 +270,20 @@ func (r *ServiceResource) updateValkey(ctx context.Context, stateData *ServiceRe
 			Dow:  v3.UpdateDBAASServiceValkeyRequestMaintenanceDow(planData.MaintenanceDOW.ValueString()),
 			Time: planData.MaintenanceTime.ValueString(),
 		}
+		stateData.MaintenanceDOW = planData.MaintenanceDOW
+		stateData.MaintenanceTime = planData.MaintenanceTime
 		updated = true
 	}
 
 	if !planData.Plan.Equal(stateData.Plan) {
 		service.Plan = planData.Plan.ValueString()
+		stateData.Plan = planData.Plan
 		updated = true
 	}
 
 	if !planData.TerminationProtection.Equal(stateData.TerminationProtection) {
 		service.TerminationProtection = planData.TerminationProtection.ValueBoolPointer()
+		stateData.TerminationProtection = planData.TerminationProtection
 		updated = true
 	}
 
@@ -297,6 +302,7 @@ func (r *ServiceResource) updateValkey(ctx context.Context, stateData *ServiceRe
 				}
 			}
 			service.IPFilter = ips
+			stateData.Valkey.IPFilter = planData.Valkey.IPFilter
 			updated = true
 		}
 
@@ -329,81 +335,55 @@ func (r *ServiceResource) updateValkey(ctx context.Context, stateData *ServiceRe
 					Timeout:                       getSettingFloat64(settings, "timeout"),
 				}
 			}
+			stateData.Valkey.Settings = planData.Valkey.Settings
 			updated = true
 		}
 	}
 
 	if !updated {
 		tflog.Info(ctx, "no updates detected", map[string]interface{}{})
+		return
+	}
+
+	if _, err := client.UpdateDBAASServiceValkey(
+		ctx,
+		planData.Id.ValueString(),
+		service,
+	); err != nil {
+		diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create database service valkey, got error: %s", err))
+		return
+	}
+
+	// Get the current state after update
+	res, err := client.GetDBAASServiceValkey(ctx, planData.Id.ValueString())
+	if err != nil {
+		diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read database service valkey, got error: %s", err))
+		return
+	}
+
+	// Update all computed attributes
+	stateData.State = types.StringValue(string(res.State))
+	stateData.DiskSize = types.Int64PointerValue(&res.DiskSize)
+	stateData.NodeCPUs = types.Int64PointerValue(&res.NodeCPUCount)
+	stateData.Nodes = types.Int64PointerValue(&res.NodeCount)
+	stateData.NodeMemory = types.Int64PointerValue(&res.NodeMemory)
+	stateData.UpdatedAt = types.StringValue(res.UpdatedAT.String())
+	stateData.TerminationProtection = types.BoolPointerValue(res.TerminationProtection)
+
+	// Update maintenance settings
+	if res.Maintenance != nil {
+		if !stateData.MaintenanceDOW.IsUnknown() {
+			stateData.MaintenanceDOW = types.StringValue(string(res.Maintenance.Dow))
+		}
+		if !stateData.MaintenanceTime.IsUnknown() {
+			stateData.MaintenanceTime = types.StringValue(res.Maintenance.Time)
+		}
 	} else {
-		_, err := client.UpdateDBAASServiceValkey(
-			ctx,
-			planData.Id.ValueString(),
-			service,
-		)
-		if err != nil {
-			diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create database service valkey, got error: %s", err))
-			return
+		if !stateData.MaintenanceDOW.IsUnknown() {
+			stateData.MaintenanceDOW = types.StringNull()
 		}
-
-		// Get the current state after update
-		res, err := client.GetDBAASServiceValkey(ctx, planData.Id.ValueString())
-		if err != nil {
-			diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read database service valkey, got error: %s", err))
-			return
-		}
-
-		// Update all computed attributes
-		planData.State = types.StringValue(string(res.State))
-		planData.DiskSize = types.Int64PointerValue(&res.DiskSize)
-		planData.NodeCPUs = types.Int64PointerValue(&res.NodeCPUCount)
-		planData.Nodes = types.Int64PointerValue(&res.NodeCount)
-		planData.NodeMemory = types.Int64PointerValue(&res.NodeMemory)
-		planData.UpdatedAt = types.StringValue(res.UpdatedAT.String())
-		planData.TerminationProtection = types.BoolPointerValue(res.TerminationProtection)
-
-		// Update maintenance settings
-		if res.Maintenance != nil {
-			if !planData.MaintenanceDOW.IsUnknown() {
-				planData.MaintenanceDOW = types.StringValue(string(res.Maintenance.Dow))
-			}
-			if !planData.MaintenanceTime.IsUnknown() {
-				planData.MaintenanceTime = types.StringValue(res.Maintenance.Time)
-			}
-		} else {
-			if !planData.MaintenanceDOW.IsUnknown() {
-				planData.MaintenanceDOW = types.StringNull()
-			}
-			if !planData.MaintenanceTime.IsUnknown() {
-				planData.MaintenanceTime = types.StringNull()
-			}
-		}
-
-		// Update Valkey specific settings
-		if planData.Valkey != nil {
-			// Update IP filter
-			if res.IPFilter != nil && !planData.Valkey.IPFilter.IsUnknown() {
-				v, dg := types.SetValueFrom(ctx, types.StringType, res.IPFilter)
-				if dg.HasError() {
-					diagnostics.Append(dg...)
-					return
-				}
-				planData.Valkey.IPFilter = v
-			} else if !planData.Valkey.IPFilter.IsUnknown() {
-				planData.Valkey.IPFilter = types.SetNull(types.StringType)
-			}
-
-			// Update Valkey settings
-			if res.ValkeySettings != nil && !planData.Valkey.Settings.IsUnknown() {
-				settings, err := json.Marshal(*res.ValkeySettings)
-				if err != nil {
-					diagnostics.AddError("Validation error", fmt.Sprintf("invalid settings: %s", err))
-					return
-				}
-				planData.Valkey.Settings = types.StringValue(string(settings))
-			} else if !planData.Valkey.Settings.IsUnknown() {
-				planData.Valkey.Settings = types.StringNull()
-			}
+		if !stateData.MaintenanceTime.IsUnknown() {
+			stateData.MaintenanceTime = types.StringNull()
 		}
 	}
 }

--- a/pkg/resources/database/testdata/resource_opensearch.tmpl
+++ b/pkg/resources/database/testdata/resource_opensearch.tmpl
@@ -57,10 +57,6 @@ resource "exoscale_dbaas" {{ .ResourceName }} {
     keep_index_refresh_interval = {{ .KeepIndexRefreshInterval }}
     {{- end }}
 
-    {{- if .MaxIndexCount }}
-    max_index_count = {{ .MaxIndexCount }}
-    {{- end }}
-
     {{- if .IpFilter }}
     ip_filter = [
     {{- range $k,$v := .IpFilter }}


### PR DESCRIPTION
# Description

Fixes a bug with all dbaas services update when upstream injects default values.
This resource was not correctly implemented when we switch from tf sdk to framework and create/updated relied on generic `get`. This was working with sdk but with framework we get error if upstream shows any drift. Notably for dbaas service settings Aiven injects default values which error out.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Acceptance tests OK
* [x] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing

<!--
Describe the tests you did
-->
