### PR TITLE
test: skip acceptance tests unless TF_ACC is set

### DIFF
--- a/exoscale/resource_exoscale_sks_cluster_test.go
+++ b/exoscale/resource_exoscale_sks_cluster_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -354,6 +355,11 @@ resource "exoscale_sks_cluster" "test-with-karpenter" {
 )
 
 func TestAccResourceSKSCluster(t *testing.T) {
+	if os.Getenv(resource.EnvTfAcc) == "" {
+		t.Skipf("Acceptance tests skipped unless env '%s' set", resource.EnvTfAcc)
+		return
+	}
+
 	var (
 		r          = "exoscale_sks_cluster.test"
 		sksCluster egoscale.SKSCluster
@@ -542,6 +548,11 @@ func TestAccResourceSKSCluster(t *testing.T) {
 }
 
 func TestAccResourceSKSClusterSKSClusterWithAudit(t *testing.T) {
+	if os.Getenv(resource.EnvTfAcc) == "" {
+		t.Skipf("Acceptance tests skipped unless env '%s' set", resource.EnvTfAcc)
+		return
+	}
+
 	var (
 		r          = "exoscale_sks_cluster.test-with-audit"
 		sksCluster egoscale.SKSCluster
@@ -666,6 +677,11 @@ func TestAccResourceSKSClusterSKSClusterWithAudit(t *testing.T) {
 }
 
 func TestAccResourceSKSClusterWithKarpenter(t *testing.T) {
+	if os.Getenv(resource.EnvTfAcc) == "" {
+		t.Skipf("Acceptance tests skipped unless env '%s' set", resource.EnvTfAcc)
+		return
+	}
+
 	var (
 		r          = "exoscale_sks_cluster.test-with-karpenter"
 		sksCluster egoscale.SKSCluster
@@ -823,6 +839,7 @@ func testGetSKSClusterVersions(t *testing.T) []string {
 
 	return versions
 }
+
 func testAccCheckResourceSKSClusterExists(r string, sksCluster *egoscale.SKSCluster) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[r]


### PR DESCRIPTION
# Description
<!--
* Prefix: the title with the component name being changed. Add a short and self describing sentence to ease the review
* Please add a few lines providing context and describing the change
* Please self comment changes whenever applicable to help with the review process
* Please keep the checklist as part of the PR. Tick what applies to this change.
-->

Running `make test` still runs some acceptance tests, which fail if API credentials aren't set in the environment. E.g.:

```
--- FAIL: TestAccResourceSKSClusterSKSClusterWithAudit (0.00s)
    resource_exoscale_sks_cluster_test.go:809: unable to initialize Exoscale client: missing or incomplete API credentials
```

This is because they call `testGetSKSClusterVersions`, which attempts to initialize an API client. I tried moving the call inside `resource.Test`, which would skip them because the same `TF_ACC` check is done inside, but some of our tests use the result of `testGetSKSClusterVersions` to set the `resource.TestStep.Config` string, so we'd need to lazy eval it somehow, which would require more complex changes than this.

Also, I noticed that `make test-acc` runs `go test -tags=testacc`[1], but that build tag is not used anywhere, so we could remove this.

An alternative way to run acceptance tests could be with `-run 'TestAcc.*'`, since we use a consistent naming scheme from what I've seen.

[1]: https://github.com/exoscale/terraform-provider-exoscale/blob/963f0275a423d7edfdad376ac204a09b818fb5ee/Makefile#L54

## Checklist
(For exoscale contributors)

* [ ] Changelog updated (under *Unreleased* block)
* [ ] Acceptance tests OK
* [ ] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing

Just ran `make test` to confirm no acceptance tests are being run.

I also tried `make test-acc`, but many fail due to quota limits in my personal account:
```
Error: CreateInstance: http response: Conflict: Usage of resource 'instance' has been exceeded.
```