### PR TITLE
fix(dbaas): handle correctly terraform refresh for db and user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ IMPROVEMENTS:
 BUG FIXES:
 
 - fix(dbaas): improve terraform refresh #488
+- dbaas: handle correctly terraform refresh for db and user #490
 
 BREAKING CHANGES:
 - update dbaas schema, check the [migration guide](docs/guides/migration-of-dbaas-from-v0_67_x-to-v0_68_x.md) #488


### PR DESCRIPTION
# Description
crossplane use terraform refresh and we need to be able to clear the resource from the state if it does not exists 

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Acceptance tests OK
* [ ] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing
```bash
$> cd pkg/resources/database
$> TF_ACC=1 go test ./... -run "TestDatabase" -v -timeout 40m
=== RUN   TestDatabase
=== RUN   TestDatabase/ResourcePg
=== PAUSE TestDatabase/ResourcePg
=== RUN   TestDatabase/ResourceMysql
=== PAUSE TestDatabase/ResourceMysql
=== RUN   TestDatabase/ResourceValkey
=== PAUSE TestDatabase/ResourceValkey
=== RUN   TestDatabase/ResourceKafka
=== PAUSE TestDatabase/ResourceKafka
=== RUN   TestDatabase/ResourceOpensearch
=== PAUSE TestDatabase/ResourceOpensearch
=== RUN   TestDatabase/ResourceGrafana
=== PAUSE TestDatabase/ResourceGrafana
=== RUN   TestDatabase/DataSourceURI
=== PAUSE TestDatabase/DataSourceURI
=== CONT  TestDatabase/ResourcePg
=== CONT  TestDatabase/ResourceOpensearch
=== CONT  TestDatabase/ResourceValkey
=== CONT  TestDatabase/DataSourceURI
=== CONT  TestDatabase/ResourceMysql
=== CONT  TestDatabase/ResourceKafka
=== CONT  TestDatabase/ResourceGrafana
--- PASS: TestDatabase (0.00s)
    --- PASS: TestDatabase/ResourceValkey (6.39s)
    --- PASS: TestDatabase/ResourceGrafana (188.70s)
    --- PASS: TestDatabase/ResourceOpensearch (260.84s)
    --- PASS: TestDatabase/ResourceMysql (297.30s)
    --- PASS: TestDatabase/ResourceKafka (349.25s)
    --- PASS: TestDatabase/ResourcePg (597.48s)
    --- PASS: TestDatabase/DataSourceURI (1055.91s)
PASS
ok  	github.com/exoscale/terraform-provider-exoscale/pkg/resources/database	1055.926s
```
