### PR TITLE
Sc 164424/support iam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ BUG FIXES:
 
 - fix(dbaas): improve terraform refresh #488
 - dbaas: handle correctly terraform refresh for db and user #490
+- fix(iam): improve terraform refresh #494
+- fix(iam): prevent type error when rules are empty for resource exoscale_iam_org_policy
 
 BREAKING CHANGES:
 - update dbaas schema, check the [migration guide](docs/guides/migration-of-dbaas-from-v0_67_x-to-v0_68_x.md) #488

--- a/pkg/resources/iam/resource_org_policy.go
+++ b/pkg/resources/iam/resource_org_policy.go
@@ -270,6 +270,9 @@ func (r *ResourceOrgPolicy) read(
 		for name, service := range policy.Services {
 			serviceModel := PolicyServiceModel{
 				Type: types.StringPointerValue(service.Type),
+				Rules: types.ListNull(types.ObjectType{
+					AttrTypes: PolicyServiceRuleModel{}.Types(),
+				}),
 			}
 
 			if len(service.Rules) > 0 {


### PR DESCRIPTION
# Description
* handle correctly terraform refresh when the resource doesn't exist
* prevent type error for organisation policy when rule is empty

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Acceptance tests OK
* [ ] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing
```bash
TF_ACC=1 go test ./... -run "TestIAM" -v -timeout 40m
=== RUN   TestIAM
=== RUN   TestIAM/DataSourceOrgPolicy
=== RUN   TestIAM/ResourceOrgPolicy
=== RUN   TestIAM/ResourceRole
=== RUN   TestIAM/DataSourceRole
=== RUN   TestIAM/DataSourceAPIKey
=== RUN   TestIAM/ResourceAPIKey
--- PASS: TestIAM (51.45s)
    --- PASS: TestIAM/DataSourceOrgPolicy (0.82s)
    --- PASS: TestIAM/ResourceOrgPolicy (7.51s)
    --- PASS: TestIAM/ResourceRole (14.63s)
    --- PASS: TestIAM/DataSourceRole (7.62s)
    --- PASS: TestIAM/DataSourceAPIKey (10.38s)
    --- PASS: TestIAM/ResourceAPIKey (10.49s)
PASS
ok  	github.com/exoscale/terraform-provider-exoscale/pkg/resources/iam	51.460s

```