### PR TITLE
feat: allow parallel testing for pkg package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 IMPROVEMENTS:
 
 - Migrate Security Group resource to framework #493
+- Add parallel testing in pkg package #500
 
 BUG FIXES:
 

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,6 @@ test-verbose: GO_TEST_EXTRA_ARGS+=$(EXTRA_ARGS)
 test-acc: GO_TEST_EXTRA_ARGS=-v $(EXTRA_ARGS)
 test-acc: ## Runs acceptance tests (requires valid Exoscale API credentials)
 	TF_ACC=1 $(GO) test			\
-		-race                   \
 		-timeout=90m            \
 		-tags=testacc           \
 		$(GO_TEST_EXTRA_ARGS)   \

--- a/pkg/filter/filter_test.go
+++ b/pkg/filter/filter_test.go
@@ -6,6 +6,8 @@ import (
 )
 
 func TestComputeInstanceListFilterString(t *testing.T) {
+	t.Parallel()
+
 	attributeToMatch := "my-test-attr"
 	valueToMatch := "string-to-match"
 
@@ -26,6 +28,8 @@ func TestComputeInstanceListFilterString(t *testing.T) {
 }
 
 func TestComputeInstanceListFilterRegex(t *testing.T) {
+	t.Parallel()
+
 	attributeToMatch := "my-test-attr"
 	valueToMatch := "string-123-to-match-by-regex"
 
@@ -46,6 +50,8 @@ func TestComputeInstanceListFilterRegex(t *testing.T) {
 }
 
 func TestComputeInstanceListFilterLabelsExactly(t *testing.T) {
+	t.Parallel()
+
 	labelToMatch := "my-label"
 
 	dataToFilter := map[string]interface{}{
@@ -69,6 +75,8 @@ func TestComputeInstanceListFilterLabelsExactly(t *testing.T) {
 }
 
 func TestComputeInstanceListFilterLabelsRegex(t *testing.T) {
+	t.Parallel()
+
 	labelToMatch := "my-label"
 
 	dataToFilter := map[string]interface{}{

--- a/pkg/list/filterable_list_datasource_test.go
+++ b/pkg/list/filterable_list_datasource_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestFilterableListDataSource(t *testing.T) {
+	t.Parallel()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testutils.AccPreCheck(t) },
 		ProtoV6ProviderFactories: testutils.TestAccProtoV6ProviderFactories,

--- a/pkg/resources/anti_affinity_group/datasource_test.go
+++ b/pkg/resources/anti_affinity_group/datasource_test.go
@@ -18,6 +18,8 @@ import (
 var dsGroupName = acctest.RandomWithPrefix(testutils.Prefix)
 
 func testDataSource(t *testing.T) {
+	t.Parallel()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testutils.AccPreCheck(t) },
 		ProtoV6ProviderFactories: testutils.TestAccProtoV6ProviderFactories,

--- a/pkg/resources/anti_affinity_group/main_test.go
+++ b/pkg/resources/anti_affinity_group/main_test.go
@@ -3,6 +3,8 @@ package anti_affinity_group_test
 import "testing"
 
 func TestAntiAffinityGroup(t *testing.T) {
+	t.Parallel()
+
 	t.Run("DataSource", testDataSource)
 	t.Run("Resource", testResource)
 }

--- a/pkg/resources/anti_affinity_group/resource_test.go
+++ b/pkg/resources/anti_affinity_group/resource_test.go
@@ -31,6 +31,8 @@ resource "exoscale_anti_affinity_group" "test" {
 )
 
 func testResource(t *testing.T) {
+	t.Parallel()
+
 	var (
 		r   = aagroup.Name + ".test"
 		res egoscale.AntiAffinityGroup

--- a/pkg/resources/block_storage/main_test.go
+++ b/pkg/resources/block_storage/main_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestBlockStorage(t *testing.T) {
+	t.Parallel()
+
 	volumeResourceName := "exoscale_block_storage_volume.test_volume"
 	volumeDataSourceName := "data." + volumeResourceName
 	snapshotResourceName := "exoscale_block_storage_volume_snapshot.test_snapshot"
@@ -52,7 +54,7 @@ func TestBlockStorage(t *testing.T) {
 					resource.TestCheckNoResourceAttr(volumeDataSourceName, "instance"),
 				),
 			},
-			// // 2 Update volume name only
+			// 2 Update volume name only
 			{
 				Config: testutils.ParseTestdataConfig("./testdata/002.volume_rename.tf.tmpl", &testdataSpec),
 				Check: resource.ComposeAggregateTestCheckFunc(

--- a/pkg/resources/database/datasource_uri_test.go
+++ b/pkg/resources/database/datasource_uri_test.go
@@ -21,6 +21,8 @@ type DataSourceURIModel struct {
 }
 
 func testDataSourceURI(t *testing.T) {
+	t.Parallel()
+
 	tplData, err := template.ParseFiles("testdata/datasource.tmpl")
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/resources/database/main_test.go
+++ b/pkg/resources/database/main_test.go
@@ -18,6 +18,8 @@ import (
 )
 
 func TestDatabase(t *testing.T) {
+	t.Parallel()
+
 	t.Run("ResourcePg", testResourcePg)
 	t.Run("ResourceMysql", testResourceMysql)
 	t.Run("ResourceValkey", testResourceValkey)

--- a/pkg/resources/database/resource_db_mysql.go
+++ b/pkg/resources/database/resource_db_mysql.go
@@ -188,10 +188,6 @@ func (data MysqlDatabaseResourceModel) ReadResource(ctx context.Context, client 
 		if errors.Is(err, v3.ErrNotFound) {
 			return true
 		}
-		if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
-			// Timed out waiting for the database to appear → treat as deleted
-			return true
-		}
 		diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read service mysql, got error: %s", err))
 		return false
 	}

--- a/pkg/resources/database/resource_db_mysql.go
+++ b/pkg/resources/database/resource_db_mysql.go
@@ -224,18 +224,16 @@ func (data MysqlDatabaseResourceModel) CreateResource(ctx context.Context, clien
 		return
 	}
 
-	svc, err := client.GetDBAASServiceMysql(ctx, data.Service.ValueString())
-	if err != nil {
-		diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read database service pg, got error: %s", err))
-		return
-	}
-
-	for _, db := range svc.Databases {
-		if string(db) == data.DatabaseName.ValueString() {
-			return
+	if _, err := waitForDBAASServiceReadyForFn(ctx, client.GetDBAASServiceMysql, data.Service.ValueString(), func(t *v3.DBAASServiceMysql) bool {
+		for _, db := range t.Databases {
+			if string(db) == data.DatabaseName.ValueString() {
+				return true
+			}
 		}
+		return false
+	}); err != nil {
+		diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read database service mysql, got error: %s", err))
 	}
-	diagnostics.AddError("Client Error", "Unable to find newly created database for the service")
 }
 
 // DeleteResource deletes the resource

--- a/pkg/resources/database/resource_db_mysql.go
+++ b/pkg/resources/database/resource_db_mysql.go
@@ -174,24 +174,29 @@ func (p *MysqlDatabaseResource) Update(ctx context.Context, req resource.UpdateR
 
 // ReadResource reads resource from remote and populate the model accordingly
 func (data MysqlDatabaseResourceModel) ReadResource(ctx context.Context, client *v3.Client, diagnostics *diag.Diagnostics) (clearState bool) {
-	svc, err := waitForDBAASServiceReadyForFn(ctx, client.GetDBAASServiceMysql, data.Service.ValueString(), func(t *v3.DBAASServiceMysql) bool {
-		return t.State == v3.EnumServiceStateRunning && len(t.Databases) > 0
-	})
-	if err != nil {
+	if _, err := waitForDBAASServiceReadyForFn(ctx, client.GetDBAASServiceMysql, data.Service.ValueString(), func(t *v3.DBAASServiceMysql) bool {
+		if t.State != v3.EnumServiceStateRunning {
+			return false
+		}
+		for _, db := range t.Databases {
+			if string(db) == data.DatabaseName.ValueString() {
+				return true
+			}
+		}
+		return false
+	}); err != nil {
 		if errors.Is(err, v3.ErrNotFound) {
+			return true
+		}
+		if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+			// Timed out waiting for the database to appear → treat as deleted
 			return true
 		}
 		diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read service mysql, got error: %s", err))
 		return false
 	}
 
-	for _, db := range svc.Databases {
-		if string(db) == data.DatabaseName.ValueString() {
-			return false
-		}
-	}
-
-	return true
+	return false
 }
 
 // CreateResource creates the resource according to the model, and then
@@ -262,7 +267,7 @@ func (MysqlDatabaseResourceModel) UpdateResource(ctx context.Context, client *v3
 
 func (data MysqlDatabaseResourceModel) WaitForService(ctx context.Context, client *v3.Client, diagnostics *diag.Diagnostics) {
 	_, err := waitForDBAASServiceReadyForFn(ctx, client.GetDBAASServiceMysql, data.Service.ValueString(), func(t *v3.DBAASServiceMysql) bool {
-		return t.State == v3.EnumServiceStateRunning && len(t.Databases) > 0
+		return t.State == v3.EnumServiceStateRunning
 	})
 
 	time.Sleep(SERVICE_READY_DELAY)

--- a/pkg/resources/database/resource_service_grafana_test.go
+++ b/pkg/resources/database/resource_service_grafana_test.go
@@ -39,6 +39,8 @@ type TemplateModelGrafana struct {
 }
 
 func testResourceGrafana(t *testing.T) {
+	t.Parallel()
+
 	tpl, err := template.ParseFiles("testdata/resource_grafana.tmpl")
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/resources/database/resource_service_kafka_test.go
+++ b/pkg/resources/database/resource_service_kafka_test.go
@@ -63,6 +63,8 @@ type TemplateModelKafkaUser struct {
 }
 
 func testResourceKafka(t *testing.T) {
+	t.Parallel()
+
 	serviceTpl, err := template.ParseFiles("testdata/resource_kafka.tmpl")
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/resources/database/resource_service_mysql_test.go
+++ b/pkg/resources/database/resource_service_mysql_test.go
@@ -65,6 +65,8 @@ type TemplateModelMysqlDb struct {
 }
 
 func testResourceMysql(t *testing.T) {
+	t.Parallel()
+
 	serviceTpl, err := template.ParseFiles("testdata/resource_mysql.tmpl")
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/resources/database/resource_service_opensearch_test.go
+++ b/pkg/resources/database/resource_service_opensearch_test.go
@@ -72,6 +72,8 @@ type TemplateModelOpensearchUser struct {
 }
 
 func testResourceOpensearch(t *testing.T) {
+	t.Parallel()
+
 	serviceTpl, err := template.ParseFiles("testdata/resource_opensearch.tmpl")
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/resources/database/resource_service_pg_test.go
+++ b/pkg/resources/database/resource_service_pg_test.go
@@ -61,6 +61,8 @@ type TemplateModelPgDb struct {
 }
 
 func testResourcePg(t *testing.T) {
+	t.Parallel()
+
 	serviceTpl, err := template.ParseFiles("testdata/resource_pg.tmpl")
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/resources/database/resource_service_valkey_test.go
+++ b/pkg/resources/database/resource_service_valkey_test.go
@@ -36,6 +36,8 @@ type TemplateModelValkey struct {
 }
 
 func testResourceValkey(t *testing.T) {
+	t.Parallel()
+
 	tpl, err := template.ParseFiles("testdata/resource_valkey.tmpl")
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/resources/database/resource_user_mysql.go
+++ b/pkg/resources/database/resource_user_mysql.go
@@ -242,10 +242,6 @@ func (data *MysqlUserResourceModel) ReadResource(ctx context.Context, client *ex
 		if errors.Is(err, exoscale.ErrNotFound) {
 			return true
 		}
-		if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
-			// Timed out waiting for the database to appear → treat as deleted
-			return true
-		}
 		diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read service mysql user, got error: %s", err))
 		return false
 	}

--- a/pkg/resources/database/resource_user_mysql.go
+++ b/pkg/resources/database/resource_user_mysql.go
@@ -171,7 +171,14 @@ func (data *MysqlUserResourceModel) CreateResource(ctx context.Context, client *
 		return
 	}
 
-	svc, err := client.GetDBAASServiceMysql(ctx, data.Service.ValueString())
+	svc, err := waitForDBAASServiceReadyForFn(ctx, client.GetDBAASServiceMysql, data.Service.ValueString(), func(t *exoscale.DBAASServiceMysql) bool {
+		for _, user := range t.Users {
+			if user.Username == data.Username.ValueString() {
+				return true
+			}
+		}
+		return false
+	})
 	if err != nil {
 		diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read database service mysql, got error: %s", err))
 		return
@@ -221,10 +228,22 @@ func (data *MysqlUserResourceModel) DeleteResource(ctx context.Context, client *
 func (data *MysqlUserResourceModel) ReadResource(ctx context.Context, client *exoscale.Client, diagnostics *diag.Diagnostics) (clearState bool) {
 
 	svc, err := waitForDBAASServiceReadyForFn(ctx, client.GetDBAASServiceMysql, data.Service.ValueString(), func(t *exoscale.DBAASServiceMysql) bool {
-		return t.State == exoscale.EnumServiceStateRunning && len(t.Users) > 0
+		if t.State != exoscale.EnumServiceStateRunning {
+			return false
+		}
+		for _, user := range t.Users {
+			if user.Username == data.Username.ValueString() {
+				return true
+			}
+		}
+		return false
 	})
 	if err != nil {
 		if errors.Is(err, exoscale.ErrNotFound) {
+			return true
+		}
+		if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+			// Timed out waiting for the database to appear → treat as deleted
 			return true
 		}
 		diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read service mysql user, got error: %s", err))

--- a/pkg/resources/database/utils_test.go
+++ b/pkg/resources/database/utils_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestPartialSettingsPatch(t *testing.T) {
+	t.Parallel()
+
 	type testCaseInput struct {
 		data  map[string]interface{}
 		patch map[string]interface{}

--- a/pkg/resources/iam/datasource_api_key_test.go
+++ b/pkg/resources/iam/datasource_api_key_test.go
@@ -7,11 +7,18 @@ import (
 
 	"github.com/exoscale/terraform-provider-exoscale/pkg/testutils"
 
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func testDataSourceAPIKey(t *testing.T) {
-	fullResourceName := "data.exoscale_iam_api_key.test"
+	t.Parallel()
+
+	var (
+		roleName         string = acctest.RandomWithPrefix(testutils.Prefix + "-role")
+		apiKeyName       string = acctest.RandomWithPrefix(testutils.Prefix + "-api-key")
+		fullResourceName string = "data.exoscale_iam_api_key.test"
+	)
 
 	// Role
 	tpl1, err := template.ParseFiles("../../testutils/testdata/resource_iam_role.tmpl")
@@ -21,7 +28,7 @@ func testDataSourceAPIKey(t *testing.T) {
 
 	data1 := testutils.ResourceIAMRole{
 		ResourceName: "test",
-		Name:         "test",
+		Name:         roleName,
 		Description:  "Foo Bar",
 		Policy: &testutils.ResourceIAMOrgPolicyModel{
 			DefaultServiceStrategy: "allow",
@@ -43,7 +50,7 @@ func testDataSourceAPIKey(t *testing.T) {
 
 	data2 := testutils.ResourceAPIKeyModel{
 		ResourceName: "test",
-		Name:         "test",
+		Name:         apiKeyName,
 		RoleID:       "exoscale_iam_role.test.id",
 	}
 
@@ -66,7 +73,7 @@ func testDataSourceAPIKey(t *testing.T) {
 			{
 				Config: configCreate,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(fullResourceName, "name", "test"),
+					resource.TestCheckResourceAttr(fullResourceName, "name", apiKeyName),
 					resource.TestCheckResourceAttrSet(fullResourceName, "role_id"),
 				),
 			},

--- a/pkg/resources/iam/datasource_org_policy_test.go
+++ b/pkg/resources/iam/datasource_org_policy_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func testDataSourceOrgPolicy(t *testing.T) {
+	t.Parallel()
+
 	fullResourceName := "data.exoscale_iam_org_policy.test"
 
 	resource.Test(t, resource.TestCase{

--- a/pkg/resources/iam/datasource_role_test.go
+++ b/pkg/resources/iam/datasource_role_test.go
@@ -7,10 +7,17 @@ import (
 
 	"github.com/exoscale/terraform-provider-exoscale/pkg/testutils"
 
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func testDataSourceRole(t *testing.T) {
+	t.Parallel()
+
+	var (
+		iamRoleName string = acctest.RandomWithPrefix(testutils.Prefix + "-role")
+	)
+
 	// Role
 	tpl, err := template.ParseFiles("../../testutils/testdata/resource_iam_role.tmpl")
 	if err != nil {
@@ -19,7 +26,7 @@ func testDataSourceRole(t *testing.T) {
 
 	data := testutils.ResourceIAMRole{
 		ResourceName: "test",
-		Name:         "test",
+		Name:         iamRoleName,
 		Description:  "foo bar",
 		Editable:     true,
 		Labels:       map[string]string{"foo": "bar"},
@@ -67,7 +74,7 @@ func testDataSourceRole(t *testing.T) {
 			{
 				Config: config,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(fullResourceName1, "name", "test"),
+					resource.TestCheckResourceAttr(fullResourceName1, "name", iamRoleName),
 					resource.TestCheckResourceAttr(fullResourceName1, "description", "foo bar"),
 					resource.TestCheckResourceAttr(fullResourceName1, "editable", "true"),
 					resource.TestCheckResourceAttr(fullResourceName1, "labels.foo", "bar"),

--- a/pkg/resources/iam/main_test.go
+++ b/pkg/resources/iam/main_test.go
@@ -3,6 +3,8 @@ package iam_test
 import "testing"
 
 func TestIAM(t *testing.T) {
+	t.Parallel()
+
 	t.Run("DataSourceOrgPolicy", testDataSourceOrgPolicy)
 	t.Run("ResourceOrgPolicy", testResourceOrgPolicy)
 	t.Run("ResourceRole", testResourceRole)

--- a/pkg/resources/iam/resource_api_key_test.go
+++ b/pkg/resources/iam/resource_api_key_test.go
@@ -7,12 +7,19 @@ import (
 
 	"github.com/exoscale/terraform-provider-exoscale/pkg/testutils"
 
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func testResourceAPIKey(t *testing.T) {
-	fullResourceName := "exoscale_iam_api_key.test"
+	t.Parallel()
+
+	var (
+		roleName         string = acctest.RandomWithPrefix(testutils.Prefix + "-role")
+		apiKeyName       string = acctest.RandomWithPrefix(testutils.Prefix + "-api-key")
+		fullResourceName string = "exoscale_iam_api_key.test"
+	)
 
 	// Role
 	tpl1, err := template.ParseFiles("../../testutils/testdata/resource_iam_role.tmpl")
@@ -22,7 +29,7 @@ func testResourceAPIKey(t *testing.T) {
 
 	data1 := testutils.ResourceIAMRole{
 		ResourceName: "test",
-		Name:         "test",
+		Name:         roleName,
 		Description:  "foo bar",
 		Editable:     true,
 		Labels:       map[string]string{"foo": "bar"},
@@ -58,7 +65,7 @@ func testResourceAPIKey(t *testing.T) {
 
 	data2 := testutils.ResourceAPIKeyModel{
 		ResourceName: "test",
-		Name:         "test",
+		Name:         apiKeyName,
 		RoleID:       "exoscale_iam_role.test.id",
 	}
 
@@ -77,7 +84,7 @@ func testResourceAPIKey(t *testing.T) {
 			{
 				Config: configCreate,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(fullResourceName, "name", "test"),
+					resource.TestCheckResourceAttr(fullResourceName, "name", apiKeyName),
 					resource.TestCheckResourceAttrSet(fullResourceName, "role_id"),
 					resource.TestCheckResourceAttrSet(fullResourceName, "key"),
 					resource.TestCheckResourceAttrSet(fullResourceName, "secret"),

--- a/pkg/resources/iam/resource_org_policy_test.go
+++ b/pkg/resources/iam/resource_org_policy_test.go
@@ -12,8 +12,12 @@ import (
 )
 
 func testResourceOrgPolicy(t *testing.T) {
-	fullResourceName := "exoscale_iam_org_policy.test"
-	expression := acctest.RandomWithPrefix(testutils.Prefix)
+	t.Parallel()
+
+	var (
+		fullResourceName string = "exoscale_iam_org_policy.test"
+		orgPolicyExpName string = acctest.RandomWithPrefix(testutils.Prefix + "-org-policy-expr")
+	)
 
 	tpl, err := template.ParseFiles("../../testutils/testdata/resource_iam_org_policy.tmpl")
 	if err != nil {
@@ -29,7 +33,7 @@ func testResourceOrgPolicy(t *testing.T) {
 				Rules: []testutils.ResourceIAMPolicyServiceRules{
 					{
 						Action:     "deny",
-						Expression: expression,
+						Expression: orgPolicyExpName,
 					},
 				},
 			},
@@ -64,7 +68,7 @@ func testResourceOrgPolicy(t *testing.T) {
 					resource.TestCheckResourceAttr(fullResourceName, "services.sos.type", "rules"),
 					resource.TestCheckResourceAttr(fullResourceName, "services.sos.rules.#", "1"),
 					resource.TestCheckResourceAttr(fullResourceName, "services.sos.rules.0.action", "deny"),
-					resource.TestCheckResourceAttr(fullResourceName, "services.sos.rules.0.expression", expression),
+					resource.TestCheckResourceAttr(fullResourceName, "services.sos.rules.0.expression", orgPolicyExpName),
 				),
 			},
 			// Update (reverts to default org policy)

--- a/pkg/resources/iam/resource_role_test.go
+++ b/pkg/resources/iam/resource_role_test.go
@@ -7,12 +7,18 @@ import (
 
 	"github.com/exoscale/terraform-provider-exoscale/pkg/testutils"
 
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func testResourceRole(t *testing.T) {
-	fullResourceName := "exoscale_iam_role.test"
+	t.Parallel()
+
+	var (
+		roleName         string = acctest.RandomWithPrefix(testutils.Prefix + "-role")
+		fullResourceName string = "exoscale_iam_role.test"
+	)
 
 	tpl, err := template.ParseFiles("../../testutils/testdata/resource_iam_role.tmpl")
 	if err != nil {
@@ -21,7 +27,7 @@ func testResourceRole(t *testing.T) {
 
 	data := testutils.ResourceIAMRole{
 		ResourceName: "test",
-		Name:         "test",
+		Name:         roleName,
 		Description:  "foo bar",
 		Editable:     true,
 		Labels:       map[string]string{"foo": "bar"},
@@ -92,7 +98,7 @@ func testResourceRole(t *testing.T) {
 			{
 				Config: configCreate,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(fullResourceName, "name", "test"),
+					resource.TestCheckResourceAttr(fullResourceName, "name", roleName),
 					resource.TestCheckResourceAttr(fullResourceName, "description", "foo bar"),
 					resource.TestCheckResourceAttr(fullResourceName, "editable", "true"),
 					resource.TestCheckResourceAttr(fullResourceName, "labels.foo", "bar"),

--- a/pkg/resources/instance/datasource.go
+++ b/pkg/resources/instance/datasource.go
@@ -224,11 +224,21 @@ func dsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.
 		}(),
 	)
 	if err != nil {
+		if errors.Is(err, v3.ErrNotFound) {
+			// Instance no longer exists, remove from state.
+			d.SetId("")
+			return nil
+		}
 		return diag.Errorf("unable to retrieve instance: %s", err)
 	}
 
 	instance, err := client.GetInstance(ctx, instanceListResp.ID)
 	if err != nil {
+		if errors.Is(err, v3.ErrNotFound) {
+			// Instance no longer exists, remove from state.
+			d.SetId("")
+			return nil
+		}
 		return diag.Errorf("unable to retrieve instance: %s", err)
 	}
 

--- a/pkg/resources/instance/datasource_list_test.go
+++ b/pkg/resources/instance/datasource_list_test.go
@@ -19,7 +19,7 @@ var (
 	dsListDiskSize          int64 = 10
 	dsListName                    = acctest.RandomWithPrefix(testutils.Prefix)
 	dsListSSHKeyName              = acctest.RandomWithPrefix(testutils.Prefix)
-	dsListReverseDNS              = "tf-provider-rdns-test.exoscale.com"
+	dsListReverseDNS              = "tf-provider-rdns-list-test.exoscale.com"
 	dsListType                    = "standard.tiny"
 	dsListZone                    = "at-vie-2"
 
@@ -63,6 +63,8 @@ resource "exoscale_compute_instance" "test" {
 )
 
 func testListDataSource(t *testing.T) {
+	t.Parallel()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testutils.AccPreCheck(t) },
 		ProtoV6ProviderFactories: testutils.TestAccProtoV6ProviderFactories,

--- a/pkg/resources/instance/datasource_test.go
+++ b/pkg/resources/instance/datasource_test.go
@@ -101,6 +101,8 @@ resource "exoscale_compute_instance" "test" {
 )
 
 func testDataSource(t *testing.T) {
+	t.Parallel()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testutils.AccPreCheck(t) },
 		ProtoV6ProviderFactories: testutils.TestAccProtoV6ProviderFactories,

--- a/pkg/resources/instance/destroy_protection_test.go
+++ b/pkg/resources/instance/destroy_protection_test.go
@@ -94,6 +94,8 @@ func checkResourceDoesNotExist(name string) func(s *terraform.State) error {
 }
 
 func testExplicitDestroyProtection(t *testing.T) {
+	t.Parallel()
+
 	instanceName := acctest.RandomWithPrefix(testutils.Prefix)
 
 	resource.Test(t, resource.TestCase{
@@ -148,6 +150,8 @@ func testExplicitDestroyProtection(t *testing.T) {
 }
 
 func testDefaultDestroyProtection(t *testing.T) {
+	t.Parallel()
+
 	instanceName := acctest.RandomWithPrefix(testutils.Prefix)
 
 	resource.Test(t, resource.TestCase{

--- a/pkg/resources/instance/main_test.go
+++ b/pkg/resources/instance/main_test.go
@@ -3,6 +3,8 @@ package instance_test
 import "testing"
 
 func TestInstance(t *testing.T) {
+	t.Parallel()
+
 	t.Run("DataSource", testDataSource)
 	t.Run("DataSourceList", testListDataSource)
 	t.Run("Resource", testResource)

--- a/pkg/resources/instance/resource_test.go
+++ b/pkg/resources/instance/resource_test.go
@@ -494,6 +494,8 @@ resource "exoscale_compute_instance" "test" {
 )
 
 func testResource(t *testing.T) {
+	t.Parallel()
+
 	var (
 		r                     = "exoscale_compute_instance.test"
 		testInstance          v3.Instance

--- a/pkg/resources/instance_pool/datasource_list_test.go
+++ b/pkg/resources/instance_pool/datasource_list_test.go
@@ -56,6 +56,8 @@ resource "exoscale_instance_pool" "test2" {
 )
 
 func testListDataSource(t *testing.T) {
+	t.Parallel()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testutils.AccPreCheck(t) },
 		ProtoV6ProviderFactories: testutils.TestAccProtoV6ProviderFactories,

--- a/pkg/resources/instance_pool/datasource_test.go
+++ b/pkg/resources/instance_pool/datasource_test.go
@@ -31,6 +31,8 @@ var (
 )
 
 func testDataSource(t *testing.T) {
+	t.Parallel()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testutils.AccPreCheck(t) },
 		ProtoV6ProviderFactories: testutils.TestAccProtoV6ProviderFactories,

--- a/pkg/resources/instance_pool/main_test.go
+++ b/pkg/resources/instance_pool/main_test.go
@@ -3,6 +3,8 @@ package instance_pool_test
 import "testing"
 
 func TestInstancePool(t *testing.T) {
+	t.Parallel()
+
 	t.Run("DataSource", testDataSource)
 	t.Run("DataSourceList", testListDataSource)
 	t.Run("Resource", testResource)

--- a/pkg/resources/instance_pool/resource_test.go
+++ b/pkg/resources/instance_pool/resource_test.go
@@ -156,6 +156,8 @@ resource "exoscale_instance_pool" "test" {
 )
 
 func testResource(t *testing.T) {
+	t.Parallel()
+
 	var (
 		r            = "exoscale_instance_pool.test"
 		instancePool v3.InstancePool

--- a/pkg/resources/nlb_service/datasource_list_test.go
+++ b/pkg/resources/nlb_service/datasource_list_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func testListDataSource(t *testing.T) {
+	t.Parallel()
+
 	buf := &bytes.Buffer{}
 
 	// template testdata
@@ -113,39 +115,7 @@ func testListDataSource(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testutils.AccPreCheck(t) },
-		ProtoV6ProviderFactories: testutils.TestAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: configBase + buf.String(),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(fullResourceName, "zone", model.Zone),
-					resource.TestCheckResourceAttr(fullResourceName, "services.#", "1"),
-					resource.TestCheckResourceAttr(
-						fullResourceName,
-						"services.0.port",
-						fmt.Sprintf("%d", nlbServiceModel.Port),
-					),
-					resource.TestCheckResourceAttr(
-						fullResourceName,
-						"services.0.target_port",
-						fmt.Sprintf("%d", nlbServiceModel.TargetPort),
-					),
-					resource.TestCheckResourceAttr(
-						fullResourceName,
-						"services.0.name",
-						nlbServiceModel.Name,
-					),
-					resource.TestCheckResourceAttr(
-						fullResourceName,
-						"services.0.healthcheck.port",
-						fmt.Sprintf("%d", nlbServiceModel.HealthcheckPort),
-					),
-				),
-			},
-		},
-	})
+	configByName := configBase + buf.String()
 
 	// datasource by id
 	buf = &bytes.Buffer{}
@@ -155,36 +125,45 @@ func testListDataSource(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	configByID := configBase + buf.String()
+
+	checks := resource.ComposeAggregateTestCheckFunc(
+		resource.TestCheckResourceAttr(fullResourceName, "zone", model.Zone),
+		resource.TestCheckResourceAttr(fullResourceName, "services.#", "1"),
+		resource.TestCheckResourceAttr(
+			fullResourceName,
+			"services.0.port",
+			fmt.Sprintf("%d", nlbServiceModel.Port),
+		),
+		resource.TestCheckResourceAttr(
+			fullResourceName,
+			"services.0.target_port",
+			fmt.Sprintf("%d", nlbServiceModel.TargetPort),
+		),
+		resource.TestCheckResourceAttr(
+			fullResourceName,
+			"services.0.name",
+			nlbServiceModel.Name,
+		),
+		resource.TestCheckResourceAttr(
+			fullResourceName,
+			"services.0.healthcheck.port",
+			fmt.Sprintf("%d", nlbServiceModel.HealthcheckPort),
+		),
+	)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testutils.AccPreCheck(t) },
 		ProtoV6ProviderFactories: testutils.TestAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: configBase + buf.String(),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(fullResourceName, "zone", model.Zone),
-					resource.TestCheckResourceAttr(fullResourceName, "services.#", "1"),
-					resource.TestCheckResourceAttr(
-						fullResourceName,
-						"services.0.port",
-						fmt.Sprintf("%d", nlbServiceModel.Port),
-					),
-					resource.TestCheckResourceAttr(
-						fullResourceName,
-						"services.0.target_port",
-						fmt.Sprintf("%d", nlbServiceModel.TargetPort),
-					),
-					resource.TestCheckResourceAttr(
-						fullResourceName,
-						"services.0.name",
-						nlbServiceModel.Name,
-					),
-					resource.TestCheckResourceAttr(
-						fullResourceName,
-						"services.0.healthcheck.port",
-						fmt.Sprintf("%d", nlbServiceModel.HealthcheckPort),
-					),
-				),
+				Config: configByName,
+				Check:  checks,
+			},
+			{
+				Config: configByID,
+				Check:  checks,
 			},
 		},
 	})

--- a/pkg/resources/nlb_service/main_test.go
+++ b/pkg/resources/nlb_service/main_test.go
@@ -3,5 +3,7 @@ package nlb_service_test
 import "testing"
 
 func TestNlbService(t *testing.T) {
+	t.Parallel()
+
 	t.Run("DataSourceList", testListDataSource)
 }

--- a/pkg/resources/sos_bucket_policy/main_test.go
+++ b/pkg/resources/sos_bucket_policy/main_test.go
@@ -15,6 +15,8 @@ import (
 )
 
 func TestSOSBucketPolicy(t *testing.T) {
+	t.Parallel()
+
 	policyResourceName := "exoscale_sos_bucket_policy.test_policy"
 	policyDataSourceName := "data." + policyResourceName
 


### PR DESCRIPTION
# Description
* Allow parallel testing for the pkg package first
* Race condition are limited and usually induced by the test phase and is not encountered at run.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Acceptance tests OK
* [ ] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing

```
$> TF_ACC=1 go test -timeout=90m -tags=testacc -v -count=1 ./pkg/...
?   	github.com/exoscale/terraform-provider-exoscale/pkg/config	[no test files]
=== RUN   TestComputeInstanceListFilterString
=== PAUSE TestComputeInstanceListFilterString
=== RUN   TestComputeInstanceListFilterRegex
=== PAUSE TestComputeInstanceListFilterRegex
=== RUN   TestComputeInstanceListFilterLabelsExactly
=== PAUSE TestComputeInstanceListFilterLabelsExactly
=== RUN   TestComputeInstanceListFilterLabelsRegex
=== PAUSE TestComputeInstanceListFilterLabelsRegex
=== CONT  TestComputeInstanceListFilterString
--- PASS: TestComputeInstanceListFilterString (0.00s)
=== CONT  TestComputeInstanceListFilterLabelsRegex
--- PASS: TestComputeInstanceListFilterLabelsRegex (0.00s)
=== CONT  TestComputeInstanceListFilterLabelsExactly
--- PASS: TestComputeInstanceListFilterLabelsExactly (0.00s)
=== CONT  TestComputeInstanceListFilterRegex
--- PASS: TestComputeInstanceListFilterRegex (0.00s)
PASS
ok  	github.com/exoscale/terraform-provider-exoscale/pkg/filter	0.007s
?   	github.com/exoscale/terraform-provider-exoscale/pkg/general	[no test files]
=== RUN   TestFilterableListDataSource
=== PAUSE TestFilterableListDataSource
=== CONT  TestFilterableListDataSource
--- PASS: TestFilterableListDataSource (0.55s)
PASS
ok  	github.com/exoscale/terraform-provider-exoscale/pkg/list	0.594s
?   	github.com/exoscale/terraform-provider-exoscale/pkg/provider	[no test files]
?   	github.com/exoscale/terraform-provider-exoscale/pkg/provider/config	[no test files]
=== RUN   TestAntiAffinityGroup
=== PAUSE TestAntiAffinityGroup
=== CONT  TestAntiAffinityGroup
=== RUN   TestAntiAffinityGroup/DataSource
=== PAUSE TestAntiAffinityGroup/DataSource
=== RUN   TestAntiAffinityGroup/Resource
=== PAUSE TestAntiAffinityGroup/Resource
=== CONT  TestAntiAffinityGroup/DataSource
=== CONT  TestAntiAffinityGroup/Resource
--- PASS: TestAntiAffinityGroup (0.00s)
    --- PASS: TestAntiAffinityGroup/Resource (9.78s)
    --- PASS: TestAntiAffinityGroup/DataSource (67.98s)
PASS
ok  	github.com/exoscale/terraform-provider-exoscale/pkg/resources/anti_affinity_group	68.017s
=== RUN   TestBlockStorage
=== PAUSE TestBlockStorage
=== CONT  TestBlockStorage
--- PASS: TestBlockStorage (76.45s)
PASS
ok  	github.com/exoscale/terraform-provider-exoscale/pkg/resources/block_storage	76.475s
=== RUN   TestDatabase
=== PAUSE TestDatabase
=== RUN   TestPartialSettingsPatch
=== PAUSE TestPartialSettingsPatch
=== CONT  TestDatabase
=== RUN   TestDatabase/ResourcePg
=== PAUSE TestDatabase/ResourcePg
=== RUN   TestDatabase/ResourceMysql
=== PAUSE TestDatabase/ResourceMysql
=== RUN   TestDatabase/ResourceValkey
=== PAUSE TestDatabase/ResourceValkey
=== RUN   TestDatabase/ResourceKafka
=== PAUSE TestDatabase/ResourceKafka
=== RUN   TestDatabase/ResourceOpensearch
=== PAUSE TestDatabase/ResourceOpensearch
=== RUN   TestDatabase/ResourceGrafana
=== PAUSE TestDatabase/ResourceGrafana
=== RUN   TestDatabase/DataSourceURI
=== PAUSE TestDatabase/DataSourceURI
=== CONT  TestDatabase/ResourcePg
=== CONT  TestDatabase/ResourceOpensearch
=== CONT  TestPartialSettingsPatch
--- PASS: TestPartialSettingsPatch (0.00s)
=== CONT  TestDatabase/DataSourceURI
=== CONT  TestDatabase/ResourceGrafana
=== CONT  TestDatabase/ResourceValkey
=== CONT  TestDatabase/ResourceKafka
=== CONT  TestDatabase/ResourceMysql
--- PASS: TestDatabase (0.00s)
    --- PASS: TestDatabase/ResourceValkey (7.14s)
    --- PASS: TestDatabase/ResourceGrafana (164.07s)
    --- PASS: TestDatabase/ResourceMysql (247.93s)
    --- PASS: TestDatabase/ResourceOpensearch (266.89s)
    --- PASS: TestDatabase/ResourceKafka (286.15s)
    --- PASS: TestDatabase/ResourcePg (548.66s)
    --- PASS: TestDatabase/DataSourceURI (921.64s)
PASS
ok  	github.com/exoscale/terraform-provider-exoscale/pkg/resources/database	921.674s
=== RUN   TestIAM
=== PAUSE TestIAM
=== CONT  TestIAM
=== RUN   TestIAM/DataSourceOrgPolicy
=== PAUSE TestIAM/DataSourceOrgPolicy
=== RUN   TestIAM/ResourceOrgPolicy
=== PAUSE TestIAM/ResourceOrgPolicy
=== RUN   TestIAM/ResourceRole
=== PAUSE TestIAM/ResourceRole
=== RUN   TestIAM/DataSourceRole
=== PAUSE TestIAM/DataSourceRole
=== RUN   TestIAM/DataSourceAPIKey
=== PAUSE TestIAM/DataSourceAPIKey
=== RUN   TestIAM/ResourceAPIKey
=== PAUSE TestIAM/ResourceAPIKey
=== CONT  TestIAM/DataSourceOrgPolicy
=== CONT  TestIAM/DataSourceRole
=== CONT  TestIAM/ResourceAPIKey
=== CONT  TestIAM/ResourceRole
=== CONT  TestIAM/ResourceOrgPolicy
=== CONT  TestIAM/DataSourceAPIKey
--- PASS: TestIAM (0.00s)
    --- PASS: TestIAM/DataSourceOrgPolicy (1.44s)
    --- PASS: TestIAM/DataSourceRole (8.20s)
    --- PASS: TestIAM/ResourceOrgPolicy (8.27s)
    --- PASS: TestIAM/DataSourceAPIKey (11.21s)
    --- PASS: TestIAM/ResourceAPIKey (11.25s)
    --- PASS: TestIAM/ResourceRole (15.23s)
PASS
ok  	github.com/exoscale/terraform-provider-exoscale/pkg/resources/iam	15.260s
=== RUN   TestInstance
=== PAUSE TestInstance
=== CONT  TestInstance
=== RUN   TestInstance/DataSource
=== PAUSE TestInstance/DataSource
=== RUN   TestInstance/DataSourceList
=== PAUSE TestInstance/DataSourceList
=== RUN   TestInstance/Resource
=== PAUSE TestInstance/Resource
=== RUN   TestInstance/DestroyProtection/ExplicitValue
=== PAUSE TestInstance/DestroyProtection/ExplicitValue
=== RUN   TestInstance/DestroyProtection/DefaultValue
=== PAUSE TestInstance/DestroyProtection/DefaultValue
=== CONT  TestInstance/DataSource
=== CONT  TestInstance/DestroyProtection/ExplicitValue
=== CONT  TestInstance/Resource
=== CONT  TestInstance/DestroyProtection/DefaultValue
=== CONT  TestInstance/DataSourceList
--- PASS: TestInstance (0.00s)
    --- PASS: TestInstance/DataSourceList (36.57s)
    --- PASS: TestInstance/DataSource (63.55s)
    --- PASS: TestInstance/DestroyProtection/ExplicitValue (66.72s)
    --- PASS: TestInstance/DestroyProtection/DefaultValue (69.99s)
    --- PASS: TestInstance/Resource (540.21s)
PASS
ok  	github.com/exoscale/terraform-provider-exoscale/pkg/resources/instance	540.267s
=== RUN   TestInstancePool
=== PAUSE TestInstancePool
=== CONT  TestInstancePool
=== RUN   TestInstancePool/DataSource
=== PAUSE TestInstancePool/DataSource
=== RUN   TestInstancePool/DataSourceList
=== PAUSE TestInstancePool/DataSourceList
=== RUN   TestInstancePool/Resource
=== PAUSE TestInstancePool/Resource
=== CONT  TestInstancePool/DataSource
=== CONT  TestInstancePool/DataSourceList
=== CONT  TestInstancePool/Resource
--- PASS: TestInstancePool (0.00s)
    --- PASS: TestInstancePool/DataSourceList (41.95s)
    --- PASS: TestInstancePool/DataSource (81.35s)
    --- PASS: TestInstancePool/Resource (115.65s)
PASS
ok  	github.com/exoscale/terraform-provider-exoscale/pkg/resources/instance_pool	115.713s
=== RUN   TestNlbService
=== PAUSE TestNlbService
=== CONT  TestNlbService
=== RUN   TestNlbService/DataSourceList
=== PAUSE TestNlbService/DataSourceList
=== CONT  TestNlbService/DataSourceList
--- PASS: TestNlbService (0.00s)
    --- PASS: TestNlbService/DataSourceList (94.21s)
PASS
ok  	github.com/exoscale/terraform-provider-exoscale/pkg/resources/nlb_service	94.243s
=== RUN   TestSecurityGroup
=== PAUSE TestSecurityGroup
=== CONT  TestSecurityGroup
--- PASS: TestSecurityGroup (18.99s)
PASS
ok  	github.com/exoscale/terraform-provider-exoscale/pkg/resources/security_group	19.006s
=== RUN   TestSOSBucketPolicy
=== PAUSE TestSOSBucketPolicy
=== CONT  TestSOSBucketPolicy
--- PASS: TestSOSBucketPolicy (58.62s)
PASS
ok  	github.com/exoscale/terraform-provider-exoscale/pkg/resources/sos_bucket_policy	58.630s
?   	github.com/exoscale/terraform-provider-exoscale/pkg/resources/zones	[no test files]
?   	github.com/exoscale/terraform-provider-exoscale/pkg/sos	[no test files]
?   	github.com/exoscale/terraform-provider-exoscale/pkg/testutils	[no test files]
?   	github.com/exoscale/terraform-provider-exoscale/pkg/utils	[no test files]
?   	github.com/exoscale/terraform-provider-exoscale/pkg/validators	[no test files]
?   	github.com/exoscale/terraform-provider-exoscale/pkg/version	[no test files]
```
