### PR TITLE
doc(dbaas): update examples to use new syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ IMPROVEMENTS:
 
 BUG FIXES:
 
+- doc(dbaas): update examples to use new syntax #502
+
 BREAKING CHANGES:
 
 FEATURES:

--- a/docs/data-sources/database_uri.md
+++ b/docs/data-sources/database_uri.md
@@ -31,7 +31,7 @@ resource "exoscale_database" "my_database" {
 
   termination_protection = true
 
-  pg {
+  pg = {
     version = "13"
 
     backup_schedule = "04:00"

--- a/docs/resources/database.md
+++ b/docs/resources/database.md
@@ -27,7 +27,7 @@ resource "exoscale_database" "my_database" {
 
   termination_protection = true
 
-  pg {
+  pg = {
     version = "13"
 
     backup_schedule = "04:00"

--- a/examples/database/main.tf
+++ b/examples/database/main.tf
@@ -20,7 +20,7 @@ resource "exoscale_database" "my_database" {
 
   termination_protection = false
 
-  valkey {
+  valkey = {
     ip_filter = [
       "${data.http.myip.response_body}/32",
       "2.2.3.5/32"

--- a/examples/dbaas/main.tf
+++ b/examples/dbaas/main.tf
@@ -8,7 +8,7 @@ resource "exoscale_dbaas" "postgres" {
   plan = "hobbyist-2"
   type = "pg"
   zone = local.my_zone
-  pg {
+  pg = {
     admin_username = var.database_username
     admin_password = var.database_password
     ip_filter      = ["0.0.0.0/0"]

--- a/examples/resources/exoscale_database/resource.tf
+++ b/examples/resources/exoscale_database/resource.tf
@@ -10,7 +10,7 @@ resource "exoscale_database" "my_database" {
 
   termination_protection = true
 
-  pg {
+  pg = {
     version = "13"
 
     backup_schedule = "04:00"

--- a/go.mod
+++ b/go.mod
@@ -61,7 +61,7 @@ require (
 	github.com/bgentry/speakeasy v0.1.0 // indirect
 	github.com/bytedance/sonic v1.13.3 // indirect
 	github.com/bytedance/sonic/loader v0.2.4 // indirect
-	github.com/cloudflare/circl v1.6.1 // indirect
+	github.com/cloudflare/circl v1.6.3 // indirect
 	github.com/cloudwego/base64x v0.1.5 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/deepmap/oapi-codegen v1.16.3 // indirect

--- a/go.mod
+++ b/go.mod
@@ -174,4 +174,4 @@ require (
 	gopkg.in/ini.v1 v1.67.0 // indirect
 )
 
-go 1.25.7
+go 1.26

--- a/go.sum
+++ b/go.sum
@@ -87,8 +87,8 @@ github.com/bytedance/sonic v1.13.3/go.mod h1:o68xyaF9u2gvVBuGHPlUVCy+ZfmNNO5ETf1
 github.com/bytedance/sonic/loader v0.1.1/go.mod h1:ncP89zfokxS5LZrJxl5z0UJcsk4M4yY2JpfqGeCtNLU=
 github.com/bytedance/sonic/loader v0.2.4 h1:ZWCw4stuXUsn1/+zQDqeE7JKP+QO47tz7QCNan80NzY=
 github.com/bytedance/sonic/loader v0.2.4/go.mod h1:N8A3vUdtUebEY2/VQC0MyhYeKUFosQU6FxH2JmUe6VI=
-github.com/cloudflare/circl v1.6.1 h1:zqIqSPIndyBh1bjLVVDHMPpVKqp8Su/V+6MeDzzQBQ0=
-github.com/cloudflare/circl v1.6.1/go.mod h1:uddAzsPgqdMAYatqJ0lsjX1oECcQLIlRpzZh3pJrofs=
+github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
+github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
 github.com/cloudwego/base64x v0.1.5 h1:XPciSp1xaq2VCSt6lF0phncD4koWyULpl5bUxbfCyP4=
 github.com/cloudwego/base64x v0.1.5/go.mod h1:0zlkT4Wn5C6NdauXdJRhSKRlJvmclQ1hhJgA0rcu/8w=
 github.com/cloudwego/iasm v0.2.0/go.mod h1:8rXZaNYT2n95jn+zTI1sDr+IgcD2GVs0nlbbQPiEFhY=

--- a/templates/data-sources/database_uri.md.tmpl
+++ b/templates/data-sources/database_uri.md.tmpl
@@ -28,7 +28,7 @@ resource "exoscale_database" "my_database" {
 
   termination_protection = true
 
-  pg {
+  pg = {
     version = "13"
 
     backup_schedule = "04:00"

--- a/vendor/github.com/cloudflare/circl/internal/sha3/xor_unaligned.go
+++ b/vendor/github.com/cloudflare/circl/internal/sha3/xor_unaligned.go
@@ -14,14 +14,14 @@ import "unsafe"
 type storageBuf [maxRate / 8]uint64
 
 func (b *storageBuf) asBytes() *[maxRate]byte {
-	return (*[maxRate]byte)(unsafe.Pointer(b))
+	return (*[maxRate]byte)(unsafe.Pointer(b)) //nolint:gosec
 }
 
 // xorInuses unaligned reads and writes to update d.a to contain d.a
 // XOR buf.
 func xorIn(d *State, buf []byte) {
 	n := len(buf)
-	bw := (*[maxRate / 8]uint64)(unsafe.Pointer(&buf[0]))[: n/8 : n/8]
+	bw := (*[maxRate / 8]uint64)(unsafe.Pointer(&buf[0]))[: n/8 : n/8] //nolint:gosec
 	if n >= 72 {
 		d.a[0] ^= bw[0]
 		d.a[1] ^= bw[1]
@@ -56,6 +56,6 @@ func xorIn(d *State, buf []byte) {
 }
 
 func copyOut(d *State, buf []byte) {
-	ab := (*[maxRate]uint8)(unsafe.Pointer(&d.a[0]))
+	ab := (*[maxRate]uint8)(unsafe.Pointer(&d.a[0])) //nolint:gosec
 	copy(buf, ab[:])
 }

--- a/vendor/github.com/cloudflare/circl/sign/sign.go
+++ b/vendor/github.com/cloudflare/circl/sign/sign.go
@@ -38,6 +38,12 @@ type PrivateKey interface {
 	encoding.BinaryMarshaler
 }
 
+// A private key that retains the seed with which it was generated.
+type Seeded interface {
+	// returns the seed if retained, otherwise nil
+	Seed() []byte
+}
+
 // A Scheme represents a specific instance of a signature scheme.
 type Scheme interface {
 	// Name of the scheme.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -237,7 +237,7 @@ github.com/bytedance/sonic/loader/internal/abi
 github.com/bytedance/sonic/loader/internal/iasm/expr
 github.com/bytedance/sonic/loader/internal/iasm/x86_64
 github.com/bytedance/sonic/loader/internal/rt
-# github.com/cloudflare/circl v1.6.1
+# github.com/cloudflare/circl v1.6.3
 ## explicit; go 1.22.0
 github.com/cloudflare/circl/dh/x25519
 github.com/cloudflare/circl/dh/x448


### PR DESCRIPTION
# Description

In `v0.68.0` we introduced a breaking change for DBaaS resources ([here](https://github.com/exoscale/terraform-provider-exoscale/commit/9f04aeb4fc25e172dc9db2ecfef3a531790bc2a2)). However, there are still a few docs using the old syntax.

The migration guide is [here](https://github.com/exoscale/terraform-provider-exoscale/blob/master/docs/guides/migration-of-dbaas-from-v0_67_x-to-v0_68_x.md).
 
This PR updates all remaining docs and examples to use the new syntax.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [ ] Acceptance tests OK
* [ ] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing

N/A