### PR TITLE
feat: call crossplane generation after a new release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,3 +40,11 @@ jobs:
       - uses: ./go.mk/.github/actions/release
         with:
           release_github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  crossplane-provider:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.EXOSCALE_BUILD_GH_TOKEN }}
+    steps:
+      - name: Generate crossplane provider
+        run: gh workflow run generate-code.yaml -R exoscale/provider-exoscale -f terraform_provider_version=${GITHUB_REF_NAME#v}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ BREAKING CHANGES:
 
 FEATURES:
 
+- feat: call crossplane generation after a new release #509
+
 ## 0.68.0
 
 IMPROVEMENTS:


### PR DESCRIPTION
# Description
Call crossplane provider generation workflow after a terraform provider release

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [ ] Acceptance tests OK
* [ ] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing
will be tested after a new release
