### PR TITLE
feat(dbaas): support integrations on pg and mysql services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ BREAKING CHANGES:
 FEATURES:
 
 - feat: call crossplane generation after a new release #509
+- feat(dbaas): support `integrations` attribute on pg and mysql services to declare read replicas at creation time #511
 
 ## 0.68.0
 

--- a/docs/resources/database.md
+++ b/docs/resources/database.md
@@ -117,9 +117,19 @@ Optional:
 - `admin_password` (String, Sensitive) A custom administrator account password (may only be set at creation time).
 - `admin_username` (String) A custom administrator account username (may only be set at creation time).
 - `backup_schedule` (String) The automated backup schedule (`HH:MM`).
+- `integrations` (Attributes List) ❗ Service integrations enabled when the service is created. At the moment only integrations where the current service is the destination are supported (e.g. a `read_replica` integration pointing at a source service). Updating this list forces the service to be recreated. (see [below for nested schema](#nestedatt--mysql--integrations))
 - `ip_filter` (Set of String) A list of CIDR blocks to allow incoming connections from.
 - `mysql_settings` (String) MySQL configuration settings in JSON format (`exo dbaas type show mysql --settings=mysql` for reference).
 - `version` (String) MySQL major version (`exo dbaas type show mysql` for reference; may only be set at creation time).
+
+<a id="nestedatt--mysql--integrations"></a>
+### Nested Schema for `mysql.integrations`
+
+Required:
+
+- `source_service` (String) ❗ Name of the source service to integrate with.
+- `type` (String) ❗ Integration type (e.g. `read_replica`).
+
 
 
 <a id="nestedatt--opensearch"></a>
@@ -177,11 +187,21 @@ Optional:
 - `admin_password` (String, Sensitive) A custom administrator account password (may only be set at creation time).
 - `admin_username` (String) A custom administrator account username (may only be set at creation time).
 - `backup_schedule` (String) The automated backup schedule (`HH:MM`).
+- `integrations` (Attributes List) ❗ Service integrations enabled when the service is created. At the moment only integrations where the current service is the destination are supported (e.g. a `read_replica` integration pointing at a source service). Updating this list forces the service to be recreated. (see [below for nested schema](#nestedatt--pg--integrations))
 - `ip_filter` (Set of String) A list of CIDR blocks to allow incoming connections from.
 - `pg_settings` (String) PostgreSQL configuration settings in JSON format (`exo dbaas type show pg --settings=pg` for reference).
 - `pgbouncer_settings` (String) PgBouncer configuration settings in JSON format (`exo dbaas type show pg --settings=pgbouncer` for reference).
 - `pglookout_settings` (String) pglookout configuration settings in JSON format (`exo dbaas type show pg --settings=pglookout` for reference).
 - `version` (String) PostgreSQL major version (`exo dbaas type show pg` for reference; may only be set at creation time).
+
+<a id="nestedatt--pg--integrations"></a>
+### Nested Schema for `pg.integrations`
+
+Required:
+
+- `source_service` (String) ❗ Name of the source service to integrate with.
+- `type` (String) ❗ Integration type (e.g. `read_replica`).
+
 
 
 <a id="nestedblock--timeouts"></a>

--- a/docs/resources/dbaas.md
+++ b/docs/resources/dbaas.md
@@ -82,9 +82,19 @@ Optional:
 - `admin_password` (String, Sensitive) A custom administrator account password (may only be set at creation time).
 - `admin_username` (String) A custom administrator account username (may only be set at creation time).
 - `backup_schedule` (String) The automated backup schedule (`HH:MM`).
+- `integrations` (Attributes List) ❗ Service integrations enabled when the service is created. At the moment only integrations where the current service is the destination are supported (e.g. a `read_replica` integration pointing at a source service). Updating this list forces the service to be recreated. (see [below for nested schema](#nestedatt--mysql--integrations))
 - `ip_filter` (Set of String) A list of CIDR blocks to allow incoming connections from.
 - `mysql_settings` (String) MySQL configuration settings in JSON format (`exo dbaas type show mysql --settings=mysql` for reference).
 - `version` (String) MySQL major version (`exo dbaas type show mysql` for reference; may only be set at creation time).
+
+<a id="nestedatt--mysql--integrations"></a>
+### Nested Schema for `mysql.integrations`
+
+Required:
+
+- `source_service` (String) ❗ Name of the source service to integrate with.
+- `type` (String) ❗ Integration type (e.g. `read_replica`).
+
 
 
 <a id="nestedatt--opensearch"></a>
@@ -142,11 +152,21 @@ Optional:
 - `admin_password` (String, Sensitive) A custom administrator account password (may only be set at creation time).
 - `admin_username` (String) A custom administrator account username (may only be set at creation time).
 - `backup_schedule` (String) The automated backup schedule (`HH:MM`).
+- `integrations` (Attributes List) ❗ Service integrations enabled when the service is created. At the moment only integrations where the current service is the destination are supported (e.g. a `read_replica` integration pointing at a source service). Updating this list forces the service to be recreated. (see [below for nested schema](#nestedatt--pg--integrations))
 - `ip_filter` (Set of String) A list of CIDR blocks to allow incoming connections from.
 - `pg_settings` (String) PostgreSQL configuration settings in JSON format (`exo dbaas type show pg --settings=pg` for reference).
 - `pgbouncer_settings` (String) PgBouncer configuration settings in JSON format (`exo dbaas type show pg --settings=pgbouncer` for reference).
 - `pglookout_settings` (String) pglookout configuration settings in JSON format (`exo dbaas type show pg --settings=pglookout` for reference).
 - `version` (String) PostgreSQL major version (`exo dbaas type show pg` for reference; may only be set at creation time).
+
+<a id="nestedatt--pg--integrations"></a>
+### Nested Schema for `pg.integrations`
+
+Required:
+
+- `source_service` (String) ❗ Name of the source service to integrate with.
+- `type` (String) ❗ Integration type (e.g. `read_replica`).
+
 
 
 <a id="nestedblock--timeouts"></a>

--- a/pkg/resources/database/main_test.go
+++ b/pkg/resources/database/main_test.go
@@ -21,6 +21,7 @@ func TestDatabase(t *testing.T) {
 	t.Parallel()
 
 	t.Run("ResourcePg", testResourcePg)
+	t.Run("ResourcePgIntegrations", testResourcePgIntegrations)
 	t.Run("ResourceMysql", testResourceMysql)
 	t.Run("ResourceValkey", testResourceValkey)
 	t.Run("ResourceKafka", testResourceKafka)

--- a/pkg/resources/database/planmodifiers.go
+++ b/pkg/resources/database/planmodifiers.go
@@ -1,0 +1,48 @@
+package database
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+// listRequiresReplaceModifier is a plan modifier that triggers resource
+// replacement whenever a list attribute changes.
+//
+// The terraform-plugin-framework ships a `listplanmodifier.RequiresReplace`
+// helper upstream, but it is not vendored in this repository, so we provide a
+// minimal equivalent here.
+type listRequiresReplaceModifier struct{}
+
+// listRequiresReplace returns a plan modifier that will force resource
+// replacement on any change to a list attribute.
+func listRequiresReplace() planmodifier.List {
+	return listRequiresReplaceModifier{}
+}
+
+func (m listRequiresReplaceModifier) Description(_ context.Context) string {
+	return "If the value of this attribute changes, Terraform will destroy and recreate the resource."
+}
+
+func (m listRequiresReplaceModifier) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (m listRequiresReplaceModifier) PlanModifyList(_ context.Context, req planmodifier.ListRequest, resp *planmodifier.ListResponse) {
+	// Do not replace on resource creation.
+	if req.State.Raw.IsNull() {
+		return
+	}
+
+	// Do not replace on resource destroy.
+	if req.Plan.Raw.IsNull() {
+		return
+	}
+
+	// Do not replace if the plan and state values are equal.
+	if req.PlanValue.Equal(req.StateValue) {
+		return
+	}
+
+	resp.RequiresReplace = true
+}

--- a/pkg/resources/database/resource_service_mysql.go
+++ b/pkg/resources/database/resource_service_mysql.go
@@ -23,12 +23,13 @@ import (
 )
 
 type ResourceMysqlModel struct {
-	AdminPassword  types.String `tfsdk:"admin_password"`
-	AdminUsername  types.String `tfsdk:"admin_username"`
-	BackupSchedule types.String `tfsdk:"backup_schedule"`
-	IpFilter       types.Set    `tfsdk:"ip_filter"`
-	Settings       types.String `tfsdk:"mysql_settings"`
-	Version        types.String `tfsdk:"version"`
+	AdminPassword  types.String                    `tfsdk:"admin_password"`
+	AdminUsername  types.String                    `tfsdk:"admin_username"`
+	BackupSchedule types.String                    `tfsdk:"backup_schedule"`
+	IpFilter       types.Set                       `tfsdk:"ip_filter"`
+	Settings       types.String                    `tfsdk:"mysql_settings"`
+	Version        types.String                    `tfsdk:"version"`
+	Integrations   []ResourceDbaasIntegrationModel `tfsdk:"integrations"`
 }
 
 var ResourceMysqlSchema = schema.SingleNestedAttribute{
@@ -68,6 +69,7 @@ var ResourceMysqlSchema = schema.SingleNestedAttribute{
 			Optional:            true,
 			Computed:            true,
 		},
+		"integrations": ResourceDbaasIntegrationsSchema,
 	},
 }
 
@@ -147,6 +149,28 @@ func (r *ServiceResource) createMysql(ctx context.Context, data *ServiceResource
 				return
 			}
 			service.MysqlSettings = &obj
+		}
+
+		if len(data.Mysql.Integrations) > 0 {
+			integrations := make([]struct {
+				DestService   *oapi.DbaasServiceName                               `json:"dest-service,omitempty"`
+				Settings      *map[string]interface{}                              `json:"settings,omitempty"`
+				SourceService *oapi.DbaasServiceName                               `json:"source-service,omitempty"`
+				Type          oapi.CreateDbaasServiceMysqlJSONBodyIntegrationsType `json:"type"`
+			}, 0, len(data.Mysql.Integrations))
+			for _, integration := range data.Mysql.Integrations {
+				source := oapi.DbaasServiceName(integration.SourceService.ValueString())
+				integrations = append(integrations, struct {
+					DestService   *oapi.DbaasServiceName                               `json:"dest-service,omitempty"`
+					Settings      *map[string]interface{}                              `json:"settings,omitempty"`
+					SourceService *oapi.DbaasServiceName                               `json:"source-service,omitempty"`
+					Type          oapi.CreateDbaasServiceMysqlJSONBodyIntegrationsType `json:"type"`
+				}{
+					SourceService: &source,
+					Type:          oapi.CreateDbaasServiceMysqlJSONBodyIntegrationsType(integration.Type.ValueString()),
+				})
+			}
+			service.Integrations = &integrations
 		}
 	}
 
@@ -351,6 +375,22 @@ func (r *ServiceResource) readMysql(ctx context.Context, data *ServiceResourceMo
 			return false
 		}
 		data.Mysql.Settings = types.StringValue(string(settings))
+	}
+
+	// Only surface integrations where the current service is the destination,
+	// so that Terraform state reflects exactly what the resource's config
+	// declares (i.e. integrations the user asked to create for this service).
+	data.Mysql.Integrations = nil
+	if apiService.Integrations != nil {
+		for _, integration := range *apiService.Integrations {
+			if integration.Dest == nil || *integration.Dest != data.Id.ValueString() {
+				continue
+			}
+			data.Mysql.Integrations = append(data.Mysql.Integrations, ResourceDbaasIntegrationModel{
+				Type:          types.StringPointerValue(integration.Type),
+				SourceService: types.StringPointerValue(integration.Source),
+			})
+		}
 	}
 
 	return false

--- a/pkg/resources/database/resource_service_pg.go
+++ b/pkg/resources/database/resource_service_pg.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -23,14 +24,23 @@ import (
 )
 
 type ResourcePgModel struct {
-	AdminPassword     types.String `tfsdk:"admin_password"`
-	AdminUsername     types.String `tfsdk:"admin_username"`
-	BackupSchedule    types.String `tfsdk:"backup_schedule"`
-	IpFilter          types.Set    `tfsdk:"ip_filter"`
-	Settings          types.String `tfsdk:"pg_settings"`
-	Version           types.String `tfsdk:"version"`
-	PgbouncerSettings types.String `tfsdk:"pgbouncer_settings"`
-	PglookoutSettings types.String `tfsdk:"pglookout_settings"`
+	AdminPassword     types.String                    `tfsdk:"admin_password"`
+	AdminUsername     types.String                    `tfsdk:"admin_username"`
+	BackupSchedule    types.String                    `tfsdk:"backup_schedule"`
+	IpFilter          types.Set                       `tfsdk:"ip_filter"`
+	Settings          types.String                    `tfsdk:"pg_settings"`
+	Version           types.String                    `tfsdk:"version"`
+	PgbouncerSettings types.String                    `tfsdk:"pgbouncer_settings"`
+	PglookoutSettings types.String                    `tfsdk:"pglookout_settings"`
+	Integrations      []ResourceDbaasIntegrationModel `tfsdk:"integrations"`
+}
+
+// ResourceDbaasIntegrationModel describes a DBaaS service integration enabled
+// at creation time (e.g. a `read_replica` integration pointing at a source
+// service).
+type ResourceDbaasIntegrationModel struct {
+	Type          types.String `tfsdk:"type"`
+	SourceService types.String `tfsdk:"source_service"`
 }
 
 var ResourcePgSchema = schema.SingleNestedAttribute{
@@ -79,6 +89,31 @@ var ResourcePgSchema = schema.SingleNestedAttribute{
 			MarkdownDescription: "pglookout configuration settings in JSON format (`exo dbaas type show pg --settings=pglookout` for reference).",
 			Optional:            true,
 			Computed:            true,
+		},
+		"integrations": ResourceDbaasIntegrationsSchema,
+	},
+}
+
+// ResourceDbaasIntegrationsSchema describes the `integrations` nested
+// attribute exposed on database service resources that support it. An
+// integration is configured at service creation time and cannot be updated
+// in place, therefore changing it forces resource replacement.
+var ResourceDbaasIntegrationsSchema = schema.ListNestedAttribute{
+	MarkdownDescription: "❗ Service integrations enabled when the service is created. At the moment only integrations where the current service is the destination are supported (e.g. a `read_replica` integration pointing at a source service). Updating this list forces the service to be recreated.",
+	Optional:            true,
+	PlanModifiers: []planmodifier.List{
+		listRequiresReplace(),
+	},
+	NestedObject: schema.NestedAttributeObject{
+		Attributes: map[string]schema.Attribute{
+			"type": schema.StringAttribute{
+				MarkdownDescription: "❗ Integration type (e.g. `read_replica`).",
+				Required:            true,
+			},
+			"source_service": schema.StringAttribute{
+				MarkdownDescription: "❗ Name of the source service to integrate with.",
+				Required:            true,
+			},
 		},
 	},
 }
@@ -176,6 +211,28 @@ func (r *ServiceResource) createPg(ctx context.Context, data *ServiceResourceMod
 				return
 			}
 			service.PglookoutSettings = &obj
+		}
+
+		if len(data.Pg.Integrations) > 0 {
+			integrations := make([]struct {
+				DestService   *oapi.DbaasServiceName                            `json:"dest-service,omitempty"`
+				Settings      *map[string]interface{}                           `json:"settings,omitempty"`
+				SourceService *oapi.DbaasServiceName                            `json:"source-service,omitempty"`
+				Type          oapi.CreateDbaasServicePgJSONBodyIntegrationsType `json:"type"`
+			}, 0, len(data.Pg.Integrations))
+			for _, integration := range data.Pg.Integrations {
+				source := oapi.DbaasServiceName(integration.SourceService.ValueString())
+				integrations = append(integrations, struct {
+					DestService   *oapi.DbaasServiceName                            `json:"dest-service,omitempty"`
+					Settings      *map[string]interface{}                           `json:"settings,omitempty"`
+					SourceService *oapi.DbaasServiceName                            `json:"source-service,omitempty"`
+					Type          oapi.CreateDbaasServicePgJSONBodyIntegrationsType `json:"type"`
+				}{
+					SourceService: &source,
+					Type:          oapi.CreateDbaasServicePgJSONBodyIntegrationsType(integration.Type.ValueString()),
+				})
+			}
+			service.Integrations = &integrations
 		}
 	}
 
@@ -485,6 +542,22 @@ func (r *ServiceResource) readPg(ctx context.Context, data *ServiceResourceModel
 			return false
 		}
 		data.Pg.PglookoutSettings = types.StringValue(string(settings))
+	}
+
+	// Only surface integrations where the current service is the destination,
+	// so that Terraform state reflects exactly what the resource's config
+	// declares (i.e. integrations the user asked to create for this service).
+	data.Pg.Integrations = nil
+	if apiService.Integrations != nil {
+		for _, integration := range *apiService.Integrations {
+			if integration.Dest == nil || *integration.Dest != data.Id.ValueString() {
+				continue
+			}
+			data.Pg.Integrations = append(data.Pg.Integrations, ResourceDbaasIntegrationModel{
+				Type:          types.StringPointerValue(integration.Type),
+				SourceService: types.StringPointerValue(integration.Source),
+			})
+		}
 	}
 
 	return false

--- a/pkg/resources/database/resource_service_pg_test.go
+++ b/pkg/resources/database/resource_service_pg_test.go
@@ -42,6 +42,16 @@ type TemplateModelPg struct {
 	PgbouncerSettings string
 	PglookoutSettings string
 	Version           string
+
+	Integrations []TemplateModelPgIntegration
+}
+
+type TemplateModelPgIntegration struct {
+	Type string
+	// SourceService is rendered as-is into the terraform config, so it may be
+	// either a quoted string literal ("foo") or a resource reference
+	// (exoscale_dbaas.primary.name).
+	SourceService string
 }
 
 type TemplateModelPgUser struct {
@@ -452,4 +462,111 @@ func CheckExistsPgDatabase(service, databaseName string, data *TemplateModelPgDb
 	}
 
 	return fmt.Errorf("could not find database %s for service %s, found %v", databaseName, service, serviceDbs)
+}
+
+// testResourcePgIntegrations exercises creating a PG service that is declared
+// as a read replica of another PG service via the `integrations` attribute.
+func testResourcePgIntegrations(t *testing.T) {
+	t.Parallel()
+
+	serviceTpl, err := template.ParseFiles("testdata/resource_pg.tmpl")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	primary := TemplateModelPg{
+		ResourceName:          "primary",
+		Name:                  acctest.RandomWithPrefix(testutils.Prefix),
+		Plan:                  "hobbyist-2",
+		Zone:                  testutils.TestZoneName,
+		TerminationProtection: false,
+		Version:               "15",
+	}
+	replica := TemplateModelPg{
+		ResourceName:          "replica",
+		Name:                  acctest.RandomWithPrefix(testutils.Prefix),
+		Plan:                  "hobbyist-2",
+		Zone:                  testutils.TestZoneName,
+		TerminationProtection: false,
+		Version:               "15",
+		Integrations: []TemplateModelPgIntegration{
+			{
+				Type:          "read_replica",
+				SourceService: "exoscale_dbaas.primary.name",
+			},
+		},
+	}
+
+	buf := &bytes.Buffer{}
+	if err := serviceTpl.Execute(buf, &primary); err != nil {
+		t.Fatal(err)
+	}
+	if err := serviceTpl.Execute(buf, &replica); err != nil {
+		t.Fatal(err)
+	}
+	configCreate := buf.String()
+
+	primaryFullResourceName := "exoscale_dbaas.primary"
+	replicaFullResourceName := "exoscale_dbaas.replica"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() { testutils.AccPreCheck(t) },
+		CheckDestroy: resource.ComposeAggregateTestCheckFunc(
+			CheckServiceDestroy("pg", primary.Name),
+			CheckServiceDestroy("pg", replica.Name),
+		),
+		ProtoV6ProviderFactories: testutils.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: configCreate,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(primaryFullResourceName, "created_at"),
+					resource.TestCheckResourceAttrSet(replicaFullResourceName, "created_at"),
+					resource.TestCheckResourceAttr(replicaFullResourceName, "pg.integrations.#", "1"),
+					resource.TestCheckResourceAttr(replicaFullResourceName, "pg.integrations.0.type", "read_replica"),
+					resource.TestCheckResourceAttrPair(
+						replicaFullResourceName, "pg.integrations.0.source_service",
+						primaryFullResourceName, "name",
+					),
+					func(s *terraform.State) error {
+						return CheckPgIntegrationExists(replica.Name, primary.Name, "read_replica")
+					},
+				),
+			},
+		},
+	})
+}
+
+// CheckPgIntegrationExists verifies that the DBaaS API reports an integration
+// of the given type between source and dest (dest being the service currently
+// declared with the integration in its spec).
+func CheckPgIntegrationExists(dest, source, integrationType string) error {
+	client, err := testutils.APIClient()
+	if err != nil {
+		return err
+	}
+
+	ctx := exoapi.WithEndpoint(context.Background(), exoapi.NewReqEndpoint(testutils.TestEnvironment(), testutils.TestZoneName))
+
+	res, err := client.GetDbaasServicePgWithResponse(ctx, oapi.DbaasServiceName(dest))
+	if err != nil {
+		return err
+	}
+	if res.StatusCode() != http.StatusOK {
+		return fmt.Errorf("API request error: unexpected status %s", res.Status())
+	}
+	service := res.JSON200
+
+	if service.Integrations == nil {
+		return fmt.Errorf("no integrations reported for service %q", dest)
+	}
+	for _, integration := range *service.Integrations {
+		if integration.Dest == nil || integration.Source == nil || integration.Type == nil {
+			continue
+		}
+		if *integration.Dest == dest && *integration.Source == source && *integration.Type == integrationType {
+			return nil
+		}
+	}
+	return fmt.Errorf("integration %q from %q to %q not found on service %q", integrationType, source, dest, dest)
 }

--- a/pkg/resources/database/testdata/resource_pg.tmpl
+++ b/pkg/resources/database/testdata/resource_pg.tmpl
@@ -48,5 +48,16 @@ resource "exoscale_dbaas" {{ .ResourceName }} {
     {{- if .Version }}
     version = "{{ .Version }}"
     {{- end }}
+
+    {{- if .Integrations }}
+    integrations = [
+    {{- range $k, $v := .Integrations }}
+      {
+        type           = "{{ $v.Type }}"
+        source_service = {{ $v.SourceService }}
+      },
+    {{- end }}
+    ]
+    {{- end }}
   }
 }


### PR DESCRIPTION
## Summary

Adds an `integrations` nested attribute to the `pg` and `mysql` DBaaS service resources, so that services can be declared as read replicas of an existing service at creation time.

Closes #511.

Each integration has:
- `type` (e.g. `read_replica`)
- `source_service` (name of the primary to replicate from)

The list is wired into `CreateDbaasServicePg`/`CreateDbaasServiceMysql` and populated back in the Read path. Integrations cannot be updated in place, so the list uses `RequiresReplace` semantics — any change to it forces the service to be recreated, which matches the SDK / API constraint.

Example:

```hcl
resource "exoscale_dbaas" "primary" {
  name = "primary"
  type = "pg"
  plan = "hobbyist-2"
  zone = "ch-gva-2"
  pg   = {}
}

resource "exoscale_dbaas" "replica" {
  name = "replica"
  type = "pg"
  plan = "hobbyist-2"
  zone = "ch-gva-2"
  pg = {
    integrations = [{
      type           = "read_replica"
      source_service = exoscale_dbaas.primary.name
    }]
  }
}
```

### Implementation notes

- New shared `ResourceDbaasIntegrationModel` / `ResourceDbaasIntegrationsSchema` reused by both pg and mysql.
- The upstream `listplanmodifier.RequiresReplace` helper is not vendored in this repo, so a minimal equivalent lives in `pkg/resources/database/planmodifiers.go`.
- `readPg`/`readMysql` only surface integrations where `integration.Dest == current service name`, so a primary service doesn't pick up drift from replicas pointing at it.
- `updatePg`/`updateMysql` don't need to diff `Integrations` because schema-level `RequiresReplace` sends those changes through Create.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -run '^$' ./pkg/resources/database/...` (compile-only)
- [x] `go generate` — docs for `pg.integrations` / `mysql.integrations` regenerated via `tfplugindocs`
- [ ] Acceptance test `TestDatabase/ResourcePgIntegrations` against a live Exoscale account (requires `TF_ACC=1` and billable hobbyist-2 services — not executed in this branch; needs to be run by a reviewer with credentials)