### PR TITLE
feat(dbaas): support integrations on pg and mysql services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ BREAKING CHANGES:
 FEATURES:
 
 - feat: call crossplane generation after a new release #509
+- feat(dbaas): support `integrations` attribute on pg and mysql services to declare read replicas at creation time #511.
+  The attribute is Optional, so existing services are unaffected by the upgrade (they refresh with `integrations = null`).
+  Only integrations where **this** resource is the destination are exposed (e.g. declare the block on the replica, not the primary).
+  Changes to the set force resource replacement — the database service is destroyed and recreated, including all data on it.
+  Removing an integration out-of-band (e.g. via the Exoscale dashboard) will also trigger a forced replace on the next plan.
+  Only `read_replica` integrations are supported inline today; other integration types must still be managed via the standalone API endpoint.
 
 ## 0.68.0
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,24 @@ website][tf-doc].
 make GO_TEST_EXTRA_ARGS="-v -run ^TestAccResourceCompute$" test-acc
 ```
 
+#### Running acceptance tests under OpenTofu
+
+The provider is compatible with both Terraform and [OpenTofu](https://opentofu.org/).
+To run the acceptance tests against OpenTofu instead of Terraform, point
+`terraform-plugin-testing` at the `tofu` binary and override the default
+provider source host — the test harness defaults to
+`registry.terraform.io/-/exoscale` which OpenTofu rejects with a parse
+error on the legacy `-` namespace:
+
+```sh
+TF_ACC=1 \
+  TF_ACC_TERRAFORM_PATH=$(which tofu) \
+  TF_ACC_PROVIDER_HOST=registry.opentofu.org \
+  go test -v -timeout 50m -tags=testacc \
+    -run '^TestDatabase$/^ResourcePgIntegrations$' \
+    ./pkg/resources/database/...
+```
+
 ### Development Setup
 
 If you would like to use the terraform provider you have built and try

--- a/docs/resources/database.md
+++ b/docs/resources/database.md
@@ -117,9 +117,43 @@ Optional:
 - `admin_password` (String, Sensitive) A custom administrator account password (may only be set at creation time).
 - `admin_username` (String) A custom administrator account username (may only be set at creation time).
 - `backup_schedule` (String) The automated backup schedule (`HH:MM`).
+- `integrations` (Attributes Set) ❗ Service integrations declared when the service is created. Only integrations where **this** resource is the destination are supported: for example, to create a PostgreSQL read replica, declare the `integrations` block on the replica (destination) and set `source_service` to the primary's name. Integrations cannot be updated in place — any change to this set destroys and recreates the service (including all data).
+
+**Declaring the block explicitly is the recommended pattern** when the source service is also managed by Terraform. Use a reference to the source's `.name` attribute:
+
+```hcl
+integrations = [{
+  type           = "read_replica"
+  source_service = exoscale_dbaas.<primary>.name
+}]
+```
+
+`.name` is **required** in the source's configuration, so its value is resolved from configuration at plan time and changes propagate through Terraform's dependency graph. When the primary's name changes (or the primary is replaced for any reason), the replica's `source_service` value changes with it, the `setRequiresReplace` plan modifier fires, and the replica is replaced in the correct order. This is the only pattern that handles refresh, plan, destroy, AND source replacement correctly.
+
+Computed-name workflows (e.g. `name = "${random_id.suffix.hex}-primary"`) are supported: Terraform will normally resolve the primary's name before the replica's create call runs, and the reference is passed through unchanged. In the rare case that the value is still unknown at create time, the provider rejects the create with a clear error naming the `source_service` element, rather than silently submitting an empty value to the API.
+
+**Do not reference `Computed` attributes of the source service — notably `.id`, but also `.created_at`, `.state`, and similar — for `source_service`.** These attributes carry a `UseStateForUnknown` plan modifier that copies the prior state value into the plan during a source replacement. That suppresses the `setRequiresReplace` diff on the replica, leaves the replica attached to the destroyed source, and causes `terraform apply` to fail with `Cannot delete ... while read replica exists`. Always use a reference whose value is determined by configuration, not by post-apply computation — in practice, that means `.name`.
+
+**Omitting the attribute is safe for refresh and plan only.** On an imported or pre-existing replica, leaving `integrations` out of configuration avoids a spurious forced-replace on refresh (the value is read from the API and preserved in state via `UseStateForUnknown`). However, it removes the Terraform dependency edge, so:
+
+- `terraform destroy` may attempt to delete the source before the replica and fail with `Cannot delete ... while read replica exists`. Adding `depends_on = [exoscale_dbaas.<source>]` on the replica restores destroy ordering for **whole-stack destroys only**.
+- Replacing the source (rename, zone change, plan change, etc.) does **not** trigger a corresponding replacement of the replica, because Terraform sees no configuration change on the replica. `depends_on` does not fix this — it only affects ordering, not replacement propagation. There is no provider-level workaround for this case; declaring `integrations` explicitly in configuration with `source_service = exoscale_dbaas.<source>.name` is the only complete fix.
+
+Omitting the attribute is fully safe when the source service is **not** managed by Terraform in the same state (e.g. an external primary created out-of-band), because there is no dependency graph to preserve.
+
+Removing an integration out-of-band (e.g. via the Exoscale dashboard) on a resource that explicitly declares the attribute in configuration still triggers a forced replace on the next plan. (see [below for nested schema](#nestedatt--mysql--integrations))
 - `ip_filter` (Set of String) A list of CIDR blocks to allow incoming connections from.
 - `mysql_settings` (String) MySQL configuration settings in JSON format (`exo dbaas type show mysql --settings=mysql` for reference).
 - `version` (String) MySQL major version (`exo dbaas type show mysql` for reference; may only be set at creation time).
+
+<a id="nestedatt--mysql--integrations"></a>
+### Nested Schema for `mysql.integrations`
+
+Required:
+
+- `source_service` (String) ❗ Name of the source service to integrate with. For a `read_replica` integration, this is the name of the primary service from which data is replicated.
+- `type` (String) ❗ Integration type. Currently only `read_replica` is supported.
+
 
 
 <a id="nestedatt--opensearch"></a>
@@ -177,11 +211,45 @@ Optional:
 - `admin_password` (String, Sensitive) A custom administrator account password (may only be set at creation time).
 - `admin_username` (String) A custom administrator account username (may only be set at creation time).
 - `backup_schedule` (String) The automated backup schedule (`HH:MM`).
+- `integrations` (Attributes Set) ❗ Service integrations declared when the service is created. Only integrations where **this** resource is the destination are supported: for example, to create a PostgreSQL read replica, declare the `integrations` block on the replica (destination) and set `source_service` to the primary's name. Integrations cannot be updated in place — any change to this set destroys and recreates the service (including all data).
+
+**Declaring the block explicitly is the recommended pattern** when the source service is also managed by Terraform. Use a reference to the source's `.name` attribute:
+
+```hcl
+integrations = [{
+  type           = "read_replica"
+  source_service = exoscale_dbaas.<primary>.name
+}]
+```
+
+`.name` is **required** in the source's configuration, so its value is resolved from configuration at plan time and changes propagate through Terraform's dependency graph. When the primary's name changes (or the primary is replaced for any reason), the replica's `source_service` value changes with it, the `setRequiresReplace` plan modifier fires, and the replica is replaced in the correct order. This is the only pattern that handles refresh, plan, destroy, AND source replacement correctly.
+
+Computed-name workflows (e.g. `name = "${random_id.suffix.hex}-primary"`) are supported: Terraform will normally resolve the primary's name before the replica's create call runs, and the reference is passed through unchanged. In the rare case that the value is still unknown at create time, the provider rejects the create with a clear error naming the `source_service` element, rather than silently submitting an empty value to the API.
+
+**Do not reference `Computed` attributes of the source service — notably `.id`, but also `.created_at`, `.state`, and similar — for `source_service`.** These attributes carry a `UseStateForUnknown` plan modifier that copies the prior state value into the plan during a source replacement. That suppresses the `setRequiresReplace` diff on the replica, leaves the replica attached to the destroyed source, and causes `terraform apply` to fail with `Cannot delete ... while read replica exists`. Always use a reference whose value is determined by configuration, not by post-apply computation — in practice, that means `.name`.
+
+**Omitting the attribute is safe for refresh and plan only.** On an imported or pre-existing replica, leaving `integrations` out of configuration avoids a spurious forced-replace on refresh (the value is read from the API and preserved in state via `UseStateForUnknown`). However, it removes the Terraform dependency edge, so:
+
+- `terraform destroy` may attempt to delete the source before the replica and fail with `Cannot delete ... while read replica exists`. Adding `depends_on = [exoscale_dbaas.<source>]` on the replica restores destroy ordering for **whole-stack destroys only**.
+- Replacing the source (rename, zone change, plan change, etc.) does **not** trigger a corresponding replacement of the replica, because Terraform sees no configuration change on the replica. `depends_on` does not fix this — it only affects ordering, not replacement propagation. There is no provider-level workaround for this case; declaring `integrations` explicitly in configuration with `source_service = exoscale_dbaas.<source>.name` is the only complete fix.
+
+Omitting the attribute is fully safe when the source service is **not** managed by Terraform in the same state (e.g. an external primary created out-of-band), because there is no dependency graph to preserve.
+
+Removing an integration out-of-band (e.g. via the Exoscale dashboard) on a resource that explicitly declares the attribute in configuration still triggers a forced replace on the next plan. (see [below for nested schema](#nestedatt--pg--integrations))
 - `ip_filter` (Set of String) A list of CIDR blocks to allow incoming connections from.
 - `pg_settings` (String) PostgreSQL configuration settings in JSON format (`exo dbaas type show pg --settings=pg` for reference).
 - `pgbouncer_settings` (String) PgBouncer configuration settings in JSON format (`exo dbaas type show pg --settings=pgbouncer` for reference).
 - `pglookout_settings` (String) pglookout configuration settings in JSON format (`exo dbaas type show pg --settings=pglookout` for reference).
 - `version` (String) PostgreSQL major version (`exo dbaas type show pg` for reference; may only be set at creation time).
+
+<a id="nestedatt--pg--integrations"></a>
+### Nested Schema for `pg.integrations`
+
+Required:
+
+- `source_service` (String) ❗ Name of the source service to integrate with. For a `read_replica` integration, this is the name of the primary service from which data is replicated.
+- `type` (String) ❗ Integration type. Currently only `read_replica` is supported.
+
 
 
 <a id="nestedblock--timeouts"></a>

--- a/docs/resources/dbaas.md
+++ b/docs/resources/dbaas.md
@@ -82,9 +82,43 @@ Optional:
 - `admin_password` (String, Sensitive) A custom administrator account password (may only be set at creation time).
 - `admin_username` (String) A custom administrator account username (may only be set at creation time).
 - `backup_schedule` (String) The automated backup schedule (`HH:MM`).
+- `integrations` (Attributes Set) ❗ Service integrations declared when the service is created. Only integrations where **this** resource is the destination are supported: for example, to create a PostgreSQL read replica, declare the `integrations` block on the replica (destination) and set `source_service` to the primary's name. Integrations cannot be updated in place — any change to this set destroys and recreates the service (including all data).
+
+**Declaring the block explicitly is the recommended pattern** when the source service is also managed by Terraform. Use a reference to the source's `.name` attribute:
+
+```hcl
+integrations = [{
+  type           = "read_replica"
+  source_service = exoscale_dbaas.<primary>.name
+}]
+```
+
+`.name` is **required** in the source's configuration, so its value is resolved from configuration at plan time and changes propagate through Terraform's dependency graph. When the primary's name changes (or the primary is replaced for any reason), the replica's `source_service` value changes with it, the `setRequiresReplace` plan modifier fires, and the replica is replaced in the correct order. This is the only pattern that handles refresh, plan, destroy, AND source replacement correctly.
+
+Computed-name workflows (e.g. `name = "${random_id.suffix.hex}-primary"`) are supported: Terraform will normally resolve the primary's name before the replica's create call runs, and the reference is passed through unchanged. In the rare case that the value is still unknown at create time, the provider rejects the create with a clear error naming the `source_service` element, rather than silently submitting an empty value to the API.
+
+**Do not reference `Computed` attributes of the source service — notably `.id`, but also `.created_at`, `.state`, and similar — for `source_service`.** These attributes carry a `UseStateForUnknown` plan modifier that copies the prior state value into the plan during a source replacement. That suppresses the `setRequiresReplace` diff on the replica, leaves the replica attached to the destroyed source, and causes `terraform apply` to fail with `Cannot delete ... while read replica exists`. Always use a reference whose value is determined by configuration, not by post-apply computation — in practice, that means `.name`.
+
+**Omitting the attribute is safe for refresh and plan only.** On an imported or pre-existing replica, leaving `integrations` out of configuration avoids a spurious forced-replace on refresh (the value is read from the API and preserved in state via `UseStateForUnknown`). However, it removes the Terraform dependency edge, so:
+
+- `terraform destroy` may attempt to delete the source before the replica and fail with `Cannot delete ... while read replica exists`. Adding `depends_on = [exoscale_dbaas.<source>]` on the replica restores destroy ordering for **whole-stack destroys only**.
+- Replacing the source (rename, zone change, plan change, etc.) does **not** trigger a corresponding replacement of the replica, because Terraform sees no configuration change on the replica. `depends_on` does not fix this — it only affects ordering, not replacement propagation. There is no provider-level workaround for this case; declaring `integrations` explicitly in configuration with `source_service = exoscale_dbaas.<source>.name` is the only complete fix.
+
+Omitting the attribute is fully safe when the source service is **not** managed by Terraform in the same state (e.g. an external primary created out-of-band), because there is no dependency graph to preserve.
+
+Removing an integration out-of-band (e.g. via the Exoscale dashboard) on a resource that explicitly declares the attribute in configuration still triggers a forced replace on the next plan. (see [below for nested schema](#nestedatt--mysql--integrations))
 - `ip_filter` (Set of String) A list of CIDR blocks to allow incoming connections from.
 - `mysql_settings` (String) MySQL configuration settings in JSON format (`exo dbaas type show mysql --settings=mysql` for reference).
 - `version` (String) MySQL major version (`exo dbaas type show mysql` for reference; may only be set at creation time).
+
+<a id="nestedatt--mysql--integrations"></a>
+### Nested Schema for `mysql.integrations`
+
+Required:
+
+- `source_service` (String) ❗ Name of the source service to integrate with. For a `read_replica` integration, this is the name of the primary service from which data is replicated.
+- `type` (String) ❗ Integration type. Currently only `read_replica` is supported.
+
 
 
 <a id="nestedatt--opensearch"></a>
@@ -142,11 +176,45 @@ Optional:
 - `admin_password` (String, Sensitive) A custom administrator account password (may only be set at creation time).
 - `admin_username` (String) A custom administrator account username (may only be set at creation time).
 - `backup_schedule` (String) The automated backup schedule (`HH:MM`).
+- `integrations` (Attributes Set) ❗ Service integrations declared when the service is created. Only integrations where **this** resource is the destination are supported: for example, to create a PostgreSQL read replica, declare the `integrations` block on the replica (destination) and set `source_service` to the primary's name. Integrations cannot be updated in place — any change to this set destroys and recreates the service (including all data).
+
+**Declaring the block explicitly is the recommended pattern** when the source service is also managed by Terraform. Use a reference to the source's `.name` attribute:
+
+```hcl
+integrations = [{
+  type           = "read_replica"
+  source_service = exoscale_dbaas.<primary>.name
+}]
+```
+
+`.name` is **required** in the source's configuration, so its value is resolved from configuration at plan time and changes propagate through Terraform's dependency graph. When the primary's name changes (or the primary is replaced for any reason), the replica's `source_service` value changes with it, the `setRequiresReplace` plan modifier fires, and the replica is replaced in the correct order. This is the only pattern that handles refresh, plan, destroy, AND source replacement correctly.
+
+Computed-name workflows (e.g. `name = "${random_id.suffix.hex}-primary"`) are supported: Terraform will normally resolve the primary's name before the replica's create call runs, and the reference is passed through unchanged. In the rare case that the value is still unknown at create time, the provider rejects the create with a clear error naming the `source_service` element, rather than silently submitting an empty value to the API.
+
+**Do not reference `Computed` attributes of the source service — notably `.id`, but also `.created_at`, `.state`, and similar — for `source_service`.** These attributes carry a `UseStateForUnknown` plan modifier that copies the prior state value into the plan during a source replacement. That suppresses the `setRequiresReplace` diff on the replica, leaves the replica attached to the destroyed source, and causes `terraform apply` to fail with `Cannot delete ... while read replica exists`. Always use a reference whose value is determined by configuration, not by post-apply computation — in practice, that means `.name`.
+
+**Omitting the attribute is safe for refresh and plan only.** On an imported or pre-existing replica, leaving `integrations` out of configuration avoids a spurious forced-replace on refresh (the value is read from the API and preserved in state via `UseStateForUnknown`). However, it removes the Terraform dependency edge, so:
+
+- `terraform destroy` may attempt to delete the source before the replica and fail with `Cannot delete ... while read replica exists`. Adding `depends_on = [exoscale_dbaas.<source>]` on the replica restores destroy ordering for **whole-stack destroys only**.
+- Replacing the source (rename, zone change, plan change, etc.) does **not** trigger a corresponding replacement of the replica, because Terraform sees no configuration change on the replica. `depends_on` does not fix this — it only affects ordering, not replacement propagation. There is no provider-level workaround for this case; declaring `integrations` explicitly in configuration with `source_service = exoscale_dbaas.<source>.name` is the only complete fix.
+
+Omitting the attribute is fully safe when the source service is **not** managed by Terraform in the same state (e.g. an external primary created out-of-band), because there is no dependency graph to preserve.
+
+Removing an integration out-of-band (e.g. via the Exoscale dashboard) on a resource that explicitly declares the attribute in configuration still triggers a forced replace on the next plan. (see [below for nested schema](#nestedatt--pg--integrations))
 - `ip_filter` (Set of String) A list of CIDR blocks to allow incoming connections from.
 - `pg_settings` (String) PostgreSQL configuration settings in JSON format (`exo dbaas type show pg --settings=pg` for reference).
 - `pgbouncer_settings` (String) PgBouncer configuration settings in JSON format (`exo dbaas type show pg --settings=pgbouncer` for reference).
 - `pglookout_settings` (String) pglookout configuration settings in JSON format (`exo dbaas type show pg --settings=pglookout` for reference).
 - `version` (String) PostgreSQL major version (`exo dbaas type show pg` for reference; may only be set at creation time).
+
+<a id="nestedatt--pg--integrations"></a>
+### Nested Schema for `pg.integrations`
+
+Required:
+
+- `source_service` (String) ❗ Name of the source service to integrate with. For a `read_replica` integration, this is the name of the primary service from which data is replicated.
+- `type` (String) ❗ Integration type. Currently only `read_replica` is supported.
+
 
 
 <a id="nestedblock--timeouts"></a>

--- a/pkg/resources/database/main_test.go
+++ b/pkg/resources/database/main_test.go
@@ -21,7 +21,12 @@ func TestDatabase(t *testing.T) {
 	t.Parallel()
 
 	t.Run("ResourcePg", testResourcePg)
+	t.Run("ResourcePgIntegrations", testResourcePgIntegrations)
+	t.Run("ResourcePgIntegrationsValidators", testResourcePgIntegrationsValidators)
+	t.Run("ResourcePgIntegrationsUnknownSource", testResourcePgIntegrationsUnknownSource)
+	t.Run("ResourcePgStateUpgrade", testResourcePgStateUpgrade)
 	t.Run("ResourceMysql", testResourceMysql)
+	t.Run("ResourceMysqlIntegrations", testResourceMysqlIntegrations)
 	t.Run("ResourceValkey", testResourceValkey)
 	t.Run("ResourceKafka", testResourceKafka)
 	t.Run("ResourceOpensearch", testResourceOpensearch)

--- a/pkg/resources/database/planmodifiers.go
+++ b/pkg/resources/database/planmodifiers.go
@@ -1,0 +1,195 @@
+package database
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// Compile-time assertions that all custom plan modifiers satisfy the
+// planmodifier.Set interface.
+var (
+	_ planmodifier.Set = setRequiresReplaceModifier{}
+	_ planmodifier.Set = setUseStateForUnknownModifier{}
+)
+
+// setUseStateForUnknownModifier copies the state value into the plan when
+// the plan is unknown and the attribute is not set in config. This is the
+// canonical pattern for Optional+Computed attributes whose value should
+// persist across refresh cycles even if the operator omits them from
+// configuration.
+//
+// Equivalent to the upstream `setplanmodifier.UseStateForUnknown` helper,
+// which is not vendored in this repository (only the stringplanmodifier,
+// boolplanmodifier, and int64planmodifier helpers are).
+type setUseStateForUnknownModifier struct{}
+
+// setUseStateForUnknown returns a plan modifier that copies the state
+// value into an unknown plan value. Use this on Optional+Computed set
+// attributes where the provider reads the value from the remote API and
+// operators may legitimately omit the attribute from config (e.g. after
+// importing a resource).
+func setUseStateForUnknown() planmodifier.Set {
+	return setUseStateForUnknownModifier{}
+}
+
+func (m setUseStateForUnknownModifier) Description(_ context.Context) string {
+	return "Once set, the value of this attribute in state will not change unless it is explicitly modified in configuration."
+}
+
+func (m setUseStateForUnknownModifier) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (m setUseStateForUnknownModifier) PlanModifySet(_ context.Context, req planmodifier.SetRequest, resp *planmodifier.SetResponse) {
+	// Nothing to fall back on if there is no state value.
+	if req.StateValue.IsNull() {
+		return
+	}
+
+	// Do nothing if the plan already has a known value. This means the
+	// operator set the attribute in config; their value takes precedence.
+	if !req.PlanValue.IsUnknown() {
+		return
+	}
+
+	// Do nothing if the config value itself is unknown — otherwise
+	// we would clobber an interpolation that will resolve during apply.
+	if req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	resp.PlanValue = req.StateValue
+}
+
+// setRequiresReplaceModifier is a plan modifier that triggers resource
+// replacement whenever a set attribute changes.
+//
+// The terraform-plugin-framework ships a `setplanmodifier.RequiresReplace`
+// helper upstream, but it is not vendored in this repository, so we provide a
+// minimal equivalent here.
+type setRequiresReplaceModifier struct{}
+
+// setRequiresReplace returns a plan modifier that will force resource
+// replacement on any change to a set attribute.
+func setRequiresReplace() planmodifier.Set {
+	return setRequiresReplaceModifier{}
+}
+
+func (m setRequiresReplaceModifier) Description(_ context.Context) string {
+	return "If the value of this attribute changes, Terraform will destroy and recreate the database service (including all data on it)."
+}
+
+func (m setRequiresReplaceModifier) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (m setRequiresReplaceModifier) PlanModifySet(_ context.Context, req planmodifier.SetRequest, resp *planmodifier.SetResponse) {
+	// Do not replace on resource creation.
+	if req.State.Raw.IsNull() {
+		return
+	}
+
+	// Do not replace on resource destroy.
+	if req.Plan.Raw.IsNull() {
+		return
+	}
+
+	// Do not replace when the planned value is unknown (e.g. it references
+	// a computed attribute of another resource that has not been applied
+	// yet). The framework will call us again once the value is resolved.
+	if req.PlanValue.IsUnknown() {
+		return
+	}
+
+	// Do not replace if the plan and state values are equal.
+	if req.PlanValue.Equal(req.StateValue) {
+		return
+	}
+
+	resp.RequiresReplace = true
+}
+
+// Compile-time assertion that integrationsSelfSourceValidator satisfies
+// the validator.Set interface.
+var _ validator.Set = integrationsSelfSourceValidator{}
+
+// integrationsSelfSourceValidator rejects an `integrations` set where any
+// element points at the resource declaring it — e.g. a `read_replica`
+// integration whose `source_service` equals the resource's own `name`.
+// Such a configuration can never succeed server-side and only surfaces as
+// a late, expensive apply-time failure without this validator.
+type integrationsSelfSourceValidator struct{}
+
+// integrationsSelfSource returns a validator that rejects integrations
+// referencing the declaring resource as their source.
+func integrationsSelfSource() validator.Set {
+	return integrationsSelfSourceValidator{}
+}
+
+func (v integrationsSelfSourceValidator) Description(_ context.Context) string {
+	return "Ensures no element of the `integrations` set points at the resource it is declared on (source_service != self.name)."
+}
+
+func (v integrationsSelfSourceValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+func (v integrationsSelfSourceValidator) ValidateSet(ctx context.Context, req validator.SetRequest, resp *validator.SetResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	var selfName types.String
+	if diags := req.Config.GetAttribute(ctx, path.Root("name"), &selfName); diags.HasError() {
+		// If we can't read the resource's name (e.g. it's unknown or the
+		// attribute path is different in a future schema), skip — the
+		// framework's own validators will catch a missing name.
+		return
+	}
+	if selfName.IsNull() || selfName.IsUnknown() {
+		return
+	}
+
+	// allowUnhandled=true so elements whose nested string fields are
+	// unknown at plan time (e.g. source_service pointing at a
+	// computed attribute of another resource that has not been
+	// applied yet) do not cause a hard decoding error. The loop
+	// below skips individual elements whose type or source_service
+	// is still unknown, deferring validation to the next plan once
+	// the values are resolved.
+	var models []ResourceDbaasIntegrationModel
+	if diags := req.ConfigValue.ElementsAs(ctx, &models, true); diags.HasError() {
+		resp.Diagnostics.Append(diags...)
+		return
+	}
+
+	for _, m := range models {
+		// Skip elements whose source_service or type is unknown at
+		// plan time. The validator will be re-run during the next
+		// plan once the interpolation resolves; skipping now
+		// avoids false positives on valid configurations that
+		// reference computed attributes of other resources.
+		if m.SourceService.IsNull() || m.SourceService.IsUnknown() {
+			continue
+		}
+		if m.Type.IsNull() || m.Type.IsUnknown() {
+			continue
+		}
+		if m.SourceService.ValueString() == selfName.ValueString() {
+			resp.Diagnostics.AddAttributeError(
+				req.Path,
+				"Invalid integration source",
+				fmt.Sprintf(
+					"An integration references %q as source_service, which is the same service this resource declares. Integrations must be declared on the destination side, with source_service pointing at a different service.",
+					m.SourceService.ValueString(),
+				),
+			)
+			return
+		}
+	}
+}

--- a/pkg/resources/database/resource_service.go
+++ b/pkg/resources/database/resource_service.go
@@ -402,6 +402,17 @@ func (r *ServiceResource) Create(ctx context.Context, req resource.CreateRequest
 		return
 	}
 
+	// Read the raw configuration so create helpers can distinguish
+	// "operator omitted integrations" (config null, plan unknown →
+	// create standalone service) from "operator set integrations to
+	// an unknown expression" (config non-null, plan unknown → must
+	// reject to avoid silently creating the wrong topology).
+	var configData ServiceResourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &configData)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	// Set timeout
 	t, diags := data.Timeouts.Create(ctx, config.DefaultTimeout)
 	resp.Diagnostics.Append(diags...)
@@ -416,9 +427,9 @@ func (r *ServiceResource) Create(ctx context.Context, req resource.CreateRequest
 
 	switch data.Type.ValueString() {
 	case "pg":
-		r.createPg(ctx, &data, &resp.Diagnostics)
+		r.createPg(ctx, &data, &configData, &resp.Diagnostics)
 	case "mysql":
-		r.createMysql(ctx, &data, &resp.Diagnostics)
+		r.createMysql(ctx, &data, &configData, &resp.Diagnostics)
 	case "valkey":
 		r.createValkey(ctx, &data, &resp.Diagnostics)
 	case "kafka":

--- a/pkg/resources/database/resource_service_mysql.go
+++ b/pkg/resources/database/resource_service_mysql.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
+	exoscale "github.com/exoscale/egoscale/v2"
 	apiv2 "github.com/exoscale/egoscale/v2/api"
 	"github.com/exoscale/egoscale/v2/oapi"
 
@@ -29,6 +30,7 @@ type ResourceMysqlModel struct {
 	IpFilter       types.Set    `tfsdk:"ip_filter"`
 	Settings       types.String `tfsdk:"mysql_settings"`
 	Version        types.String `tfsdk:"version"`
+	Integrations   types.Set    `tfsdk:"integrations"`
 }
 
 var ResourceMysqlSchema = schema.SingleNestedAttribute{
@@ -68,11 +70,15 @@ var ResourceMysqlSchema = schema.SingleNestedAttribute{
 			Optional:            true,
 			Computed:            true,
 		},
+		"integrations": ResourceDbaasIntegrationsSchema,
 	},
 }
 
 // createMysql function handles MySQL specific part of database resource creation logic.
-func (r *ServiceResource) createMysql(ctx context.Context, data *ServiceResourceModel, diagnostics *diag.Diagnostics) {
+// configData carries the raw configuration so we can distinguish "operator
+// omitted integrations" (config null) from "operator set integrations to an
+// unknown expression" (config non-null but plan unknown).
+func (r *ServiceResource) createMysql(ctx context.Context, data *ServiceResourceModel, configData *ServiceResourceModel, diagnostics *diag.Diagnostics) {
 	service := oapi.CreateDbaasServiceMysqlJSONRequestBody{
 		Plan:                  data.Plan.ValueString(),
 		TerminationProtection: data.TerminationProtection.ValueBoolPointer(),
@@ -148,6 +154,120 @@ func (r *ServiceResource) createMysql(ctx context.Context, data *ServiceResource
 			}
 			service.MysqlSettings = &obj
 		}
+
+		// P2: See createPg for the full rationale. Likely unreachable
+		// for the current schema shape but guards against future changes.
+		if data.Mysql.Integrations.IsUnknown() && configData.Mysql != nil && !configData.Mysql.Integrations.IsNull() {
+			diagnostics.AddError(
+				"mysql.integrations: entire integrations set is unknown at create time",
+				"The `integrations` attribute was set in configuration but its value "+
+					"is still unknown at apply time. This usually means the entire set is "+
+					"derived from a resource output that Terraform could not resolve before "+
+					"creating this service. Set `integrations` to a list of objects with "+
+					"known `type` and `source_service` values, for example:\n\n"+
+					"  integrations = [{ type = \"read_replica\", source_service = exoscale_dbaas.<primary>.name }]",
+			)
+			return
+		}
+
+		if !data.Mysql.Integrations.IsNull() && !data.Mysql.Integrations.IsUnknown() {
+			var integrationModels []ResourceDbaasIntegrationModel
+			// allowUnhandled=true so unknown per-field values in the
+			// set (e.g. source_service pointing at a computed
+			// attribute of another resource that is unknown at
+			// plan time) do not produce a hard decoding error.
+			// See resource_service_pg.go for the full rationale.
+			if dg := data.Mysql.Integrations.ElementsAs(ctx, &integrationModels, true); dg.HasError() {
+				diagnostics.Append(dg...)
+				return
+			}
+			// Single-pass validation: null/unknown rejection + semantic
+			// re-checks. See createPg for the full rationale.
+			selfName := data.Name.ValueString()
+			for i, integration := range integrationModels {
+				if integration.Type.IsNull() || integration.Type.IsUnknown() {
+					diagnostics.AddError(
+						"mysql.integrations: element type is unknown or null at create time",
+						fmt.Sprintf(
+							"Element %d of the `mysql.integrations` set has no concrete "+
+								"`type` value at the time the service is being created. "+
+								"This usually means `type` depends on a computed value "+
+								"that Terraform could not resolve before the service create "+
+								"call. Set `type` to a literal value (currently only "+
+								"\"read_replica\" is supported).",
+							i,
+						),
+					)
+					return
+				}
+				if integration.SourceService.IsNull() || integration.SourceService.IsUnknown() {
+					diagnostics.AddError(
+						"mysql.integrations: source_service is unknown or null at create time",
+						fmt.Sprintf(
+							"Element %d of the `mysql.integrations` set has no concrete "+
+								"`source_service` value at the time the service is being "+
+								"created. This usually means `source_service` references a "+
+								"value that Terraform could not resolve before the create "+
+								"call — for example, a primary service whose name is itself "+
+								"computed from another resource that has not been applied "+
+								"yet. Ensure `source_service` references a plan-time-known "+
+								"value, typically `exoscale_dbaas.<primary>.name` where the "+
+								"primary's name is a literal or a fully-resolved expression.",
+							i,
+						),
+					)
+					return
+				}
+				typeVal := integration.Type.ValueString()
+				supported := false
+				for _, t := range supportedIntegrationTypes {
+					if typeVal == t {
+						supported = true
+						break
+					}
+				}
+				if !supported {
+					diagnostics.AddError(
+						"mysql.integrations: unsupported integration type",
+						fmt.Sprintf(
+							"Element %d of the `mysql.integrations` set has type %q, "+
+								"which is not a supported integration type. "+
+								"Supported types: %s.",
+							i, typeVal, strings.Join(supportedIntegrationTypes, ", "),
+						),
+					)
+					return
+				}
+				if integration.SourceService.ValueString() == selfName {
+					diagnostics.AddError(
+						"mysql.integrations: self-referencing source_service",
+						fmt.Sprintf(
+							"Element %d of the `mysql.integrations` set has "+
+								"source_service=%q, which is the same service this "+
+								"resource declares. Integrations must be declared on "+
+								"the destination side, with source_service pointing "+
+								"at a different service.",
+							i, selfName,
+						),
+					)
+					return
+				}
+			}
+			if len(integrationModels) > 0 {
+				integrations := make([]struct {
+					DestService   *oapi.DbaasServiceName                               `json:"dest-service,omitempty"`
+					Settings      *map[string]interface{}                              `json:"settings,omitempty"`
+					SourceService *oapi.DbaasServiceName                               `json:"source-service,omitempty"`
+					Type          oapi.CreateDbaasServiceMysqlJSONBodyIntegrationsType `json:"type"`
+				}, len(integrationModels))
+				for i, integration := range integrationModels {
+					source := oapi.DbaasServiceName(integration.SourceService.ValueString())
+					integrations[i].SourceService = &source
+					integrations[i].Type = oapi.CreateDbaasServiceMysqlJSONBodyIntegrationsType(integration.Type.ValueString())
+				}
+				service.Integrations = &integrations
+			}
+		}
 	}
 
 	res, err := r.client.CreateDbaasServiceMysqlWithResponse(
@@ -163,6 +283,36 @@ func (r *ServiceResource) createMysql(ctx context.Context, data *ServiceResource
 		diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create database settings schema, unexpected status: %s", res.Status()))
 		return
 	}
+
+	// The service now exists on Exoscale. Any error return after
+	// this point must delete it first — otherwise we orphan a
+	// billable database service that Terraform state never knew
+	// about. See createPg for the full rationale.
+	createSucceeded := false
+	defer func() {
+		if createSucceeded {
+			return
+		}
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		defer cancel()
+		cleanupCtx = apiv2.WithEndpoint(cleanupCtx, apiv2.NewReqEndpoint(r.env, data.Zone.ValueString()))
+		name := data.Id.ValueString()
+		if delErr := r.client.DeleteDatabaseService(
+			cleanupCtx,
+			data.Zone.ValueString(),
+			&exoscale.DatabaseService{Name: &name},
+		); delErr != nil {
+			tflog.Warn(ctx, fmt.Sprintf(
+				"orphan cleanup failed after createMysql error for service %q: %v",
+				name, delErr,
+			))
+		} else {
+			tflog.Info(ctx, fmt.Sprintf(
+				"orphan cleanup: deleted partially-created mysql service %q",
+				name,
+			))
+		}
+	}()
 
 	tflog.Info(ctx, "DB Service created, waiting for the service to be in 'running' state")
 
@@ -270,6 +420,40 @@ pooling:
 			data.Mysql.Settings = types.StringValue(string(settings))
 		}
 	}
+
+	// Integrations is Optional+Computed: if the operator did not set
+	// the attribute in config, the framework left the plan value
+	// unknown at the Create phase. Populate it from the API response
+	// so the post-create state has a concrete value. Only surface
+	// integrations where the current service is the destination,
+	// matching readMysql's filter.
+	if data.Mysql.Integrations.IsUnknown() {
+		data.Mysql.Integrations = types.SetNull(resourceDbaasIntegrationObjectType)
+		if apiService.Integrations != nil {
+			var models []ResourceDbaasIntegrationModel
+			for _, integration := range *apiService.Integrations {
+				if integration.Dest == nil || *integration.Dest != data.Id.ValueString() {
+					continue
+				}
+				models = append(models, ResourceDbaasIntegrationModel{
+					Type:          types.StringPointerValue(integration.Type),
+					SourceService: types.StringPointerValue(integration.Source),
+				})
+			}
+			if len(models) > 0 {
+				v, dg := types.SetValueFrom(ctx, resourceDbaasIntegrationObjectType, models)
+				if dg.HasError() {
+					diagnostics.Append(dg...)
+					return
+				}
+				data.Mysql.Integrations = v
+			}
+		}
+	}
+
+	// All post-create population succeeded — cancel the deferred
+	// orphan cleanup.
+	createSucceeded = true
 }
 
 // readMysql function handles MySQL specific part of database resource Read logic.
@@ -353,6 +537,31 @@ func (r *ServiceResource) readMysql(ctx context.Context, data *ServiceResourceMo
 		data.Mysql.Settings = types.StringValue(string(settings))
 	}
 
+	// Only surface integrations where the current service is the destination,
+	// so that Terraform state reflects exactly what the resource's config
+	// declares (i.e. integrations the user asked to create for this service).
+	data.Mysql.Integrations = types.SetNull(resourceDbaasIntegrationObjectType)
+	if apiService.Integrations != nil {
+		var integrationModels []ResourceDbaasIntegrationModel
+		for _, integration := range *apiService.Integrations {
+			if integration.Dest == nil || *integration.Dest != data.Id.ValueString() {
+				continue
+			}
+			integrationModels = append(integrationModels, ResourceDbaasIntegrationModel{
+				Type:          types.StringPointerValue(integration.Type),
+				SourceService: types.StringPointerValue(integration.Source),
+			})
+		}
+		if len(integrationModels) > 0 {
+			v, dg := types.SetValueFrom(ctx, resourceDbaasIntegrationObjectType, integrationModels)
+			if dg.HasError() {
+				diagnostics.Append(dg...)
+				return false
+			}
+			data.Mysql.Integrations = v
+		}
+	}
+
 	return false
 }
 
@@ -393,7 +602,7 @@ func (r *ServiceResource) updateMysql(ctx context.Context, stateData *ServiceRes
 			stateData.Mysql = &ResourceMysqlModel{}
 		}
 
-		if !planData.Mysql.BackupSchedule.Equal(stateData.Mysql.BackupSchedule) {
+		if !planData.Mysql.BackupSchedule.IsUnknown() && !planData.Mysql.BackupSchedule.Equal(stateData.Mysql.BackupSchedule) {
 			bh, bm, err := parseBackupSchedule(planData.Mysql.BackupSchedule.ValueString())
 			if err != nil {
 				diagnostics.AddError("Validation error", fmt.Sprintf("Unable to parse backup schedule, got error: %s", err))
@@ -447,6 +656,12 @@ func (r *ServiceResource) updateMysql(ctx context.Context, stateData *ServiceRes
 			stateData.Mysql.Settings = planData.Mysql.Settings
 			updated = true
 		}
+
+		// Defensive no-op: integrations is Optional with a RequiresReplace
+		// plan modifier, so Terraform Core never calls Update when the
+		// set differs from state. Keep stateData in sync with plan here
+		// as a safety net in case that contract is ever weakened.
+		stateData.Mysql.Integrations = planData.Mysql.Integrations
 	}
 
 	if !updated {
@@ -455,8 +670,8 @@ func (r *ServiceResource) updateMysql(ctx context.Context, stateData *ServiceRes
 	}
 
 	// Aiven would overwrite the backup schedule with random value if we don't specify it explicitly every time.
-	if service.BackupSchedule == nil {
-		bh, bm, err := parseBackupSchedule(planData.Mysql.BackupSchedule.ValueString())
+	if service.BackupSchedule == nil && !stateData.Mysql.BackupSchedule.IsUnknown() {
+		bh, bm, err := parseBackupSchedule(stateData.Mysql.BackupSchedule.ValueString())
 		if err != nil {
 			diagnostics.AddError("Validation error", fmt.Sprintf("Unable to parse backup schedule, got error: %s", err))
 			return

--- a/pkg/resources/database/resource_service_mysql_test.go
+++ b/pkg/resources/database/resource_service_mysql_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	exoapi "github.com/exoscale/egoscale/v2/api"
@@ -41,6 +42,21 @@ type TemplateModelMysql struct {
 	IpFilter       []string
 	MysqlSettings  string
 	Version        string
+
+	Integrations []TemplateModelMysqlIntegration
+
+	// DependsOn renders an explicit `depends_on = [...]` meta-argument.
+	// Each entry is emitted as-is in the HCL, so typical values look
+	// like "exoscale_dbaas.primary" (bare references, no quotes).
+	DependsOn []string
+}
+
+// TemplateModelMysqlIntegration renders a single `integrations` block entry
+// in the mysql service template. SourceService is rendered as-is (so it may
+// be either a quoted literal or a resource reference).
+type TemplateModelMysqlIntegration struct {
+	Type          string
+	SourceService string
 }
 
 type TemplateModelMysqlUser struct {
@@ -442,4 +458,245 @@ func CheckExistsMysqlDatabase(service, databaseName string, data *TemplateModelM
 	}
 
 	return fmt.Errorf("could not find database %s for service %s, found %v", databaseName, service, serviceDbs)
+}
+
+// testResourceMysqlIntegrations exercises creating a MySQL service declared
+// as a read replica of another MySQL service via the `integrations`
+// attribute, and verifies that modifying the integration triggers a full
+// replace of the replica resource.
+func testResourceMysqlIntegrations(t *testing.T) {
+	t.Parallel()
+
+	serviceTpl, err := template.ParseFiles("testdata/resource_mysql.tmpl")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Plan choice note: Exoscale DBaaS read replicas require the primary
+	// service to be on a Business or Premium plan (Hobbyist and Startup
+	// are not sufficient). The replica itself can run on any Startup or
+	// larger plan. `business-4` / `startup-4` is the cheapest authorized
+	// combination that actually supports the read_replica integration.
+	primary := TemplateModelMysql{
+		ResourceName:          "primary",
+		Name:                  acctest.RandomWithPrefix(testutils.Prefix),
+		Plan:                  "business-4",
+		Zone:                  testutils.TestZoneName,
+		TerminationProtection: false,
+		Version:               "8",
+	}
+	replica := TemplateModelMysql{
+		ResourceName:          "replica",
+		Name:                  acctest.RandomWithPrefix(testutils.Prefix),
+		Plan:                  "startup-4",
+		Zone:                  testutils.TestZoneName,
+		TerminationProtection: false,
+		Version:               "8",
+		Integrations: []TemplateModelMysqlIntegration{
+			{
+				Type:          "read_replica",
+				SourceService: "exoscale_dbaas.primary.name",
+			},
+		},
+	}
+
+	renderMysqlConfig := func(services ...TemplateModelMysql) string {
+		t.Helper()
+		buf := &bytes.Buffer{}
+		for _, s := range services {
+			if err := serviceTpl.Execute(buf, &s); err != nil {
+				t.Fatal(err)
+			}
+		}
+		return buf.String()
+	}
+
+	configCreate := renderMysqlConfig(primary, replica)
+
+	// Second variant: add a second primary and swap the replica's
+	// source_service to point at it — must force replacement.
+	primary2 := TemplateModelMysql{
+		ResourceName:          "primary2",
+		Name:                  acctest.RandomWithPrefix(testutils.Prefix),
+		Plan:                  "business-4",
+		Zone:                  testutils.TestZoneName,
+		TerminationProtection: false,
+		Version:               "8",
+	}
+	replicaSwapped := replica
+	// Rotate the replica name on the swap step to avoid any 409
+	// eventual-consistency race on destroy+create against the same name.
+	replicaSwapped.Name = acctest.RandomWithPrefix(testutils.Prefix)
+	replicaSwapped.Integrations = []TemplateModelMysqlIntegration{
+		{
+			Type:          "read_replica",
+			SourceService: "exoscale_dbaas.primary2.name",
+		},
+	}
+	configSwap := renderMysqlConfig(primary, primary2, replicaSwapped)
+
+	// Variant for the P1 regression step: same topology as configSwap
+	// but the replica's HCL omits the `integrations` block entirely.
+	// Mirrors the pg test's P1 step — see the pg test for full
+	// rationale. depends_on is required because removing the
+	// source_service reference also removes the implicit dependency
+	// edge in Terraform's graph; without it, post-test destroy races
+	// primary2 against the replica.
+	replicaSwappedNoIntegrations := replicaSwapped
+	replicaSwappedNoIntegrations.Integrations = nil
+	replicaSwappedNoIntegrations.DependsOn = []string{"exoscale_dbaas.primary2"}
+	configSwapNoIntegrations := renderMysqlConfig(primary, primary2, replicaSwappedNoIntegrations)
+
+	primaryFullResourceName := "exoscale_dbaas.primary"
+	primary2FullResourceName := "exoscale_dbaas.primary2"
+	replicaFullResourceName := "exoscale_dbaas.replica"
+
+	integrationContains := func(primaryResource string) resource.TestCheckFunc {
+		return func(s *terraform.State) error {
+			primaryRes, ok := s.RootModule().Resources[primaryResource]
+			if !ok {
+				return fmt.Errorf("resource %s not found in state", primaryResource)
+			}
+			primaryName := primaryRes.Primary.Attributes["name"]
+			if primaryName == "" {
+				return fmt.Errorf("resource %s has no `name` attribute in state", primaryResource)
+			}
+			return resource.TestCheckTypeSetElemNestedAttrs(
+				replicaFullResourceName,
+				"mysql.integrations.*",
+				map[string]string{
+					"type":           "read_replica",
+					"source_service": primaryName,
+				},
+			)(s)
+		}
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() { testutils.AccPreCheck(t) },
+		CheckDestroy: resource.ComposeAggregateTestCheckFunc(
+			CheckServiceDestroy("mysql", primary.Name),
+			CheckServiceDestroy("mysql", primary2.Name),
+			CheckServiceDestroy("mysql", replica.Name),
+			CheckServiceDestroy("mysql", replicaSwapped.Name),
+		),
+		ProtoV6ProviderFactories: testutils.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: configCreate,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(primaryFullResourceName, "created_at"),
+					resource.TestCheckResourceAttrSet(replicaFullResourceName, "created_at"),
+					resource.TestCheckResourceAttr(replicaFullResourceName, "mysql.integrations.#", "1"),
+					integrationContains(primaryFullResourceName),
+					func(s *terraform.State) error {
+						return CheckMysqlIntegrationExists(replica.Name, primary.Name, "read_replica")
+					},
+				),
+			},
+			{
+				// Verify the import round-trip of the integrations
+				// attribute. See the pg test for rationale; uses the
+				// shared assertImportedIntegrations helper.
+				ResourceName: replicaFullResourceName,
+				ImportStateIdFunc: func() resource.ImportStateIdFunc {
+					return func(*terraform.State) (string, error) {
+						return fmt.Sprintf("%s@%s", replica.Name, replica.Zone), nil
+					}
+				}(),
+				ImportState: true,
+				ImportStateCheck: assertImportedIntegrations(
+					"mysql",
+					"read_replica",
+					&primary.Name,
+					1,
+				),
+			},
+			{
+				// Swapping source_service must force the replica to be
+				// replaced — verified with plancheck before apply.
+				Config: configSwap,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(replicaFullResourceName, plancheck.ResourceActionReplace),
+					},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(primary2FullResourceName, "created_at"),
+					resource.TestCheckResourceAttr(replicaFullResourceName, "mysql.integrations.#", "1"),
+					integrationContains(primary2FullResourceName),
+					func(s *terraform.State) error {
+						return CheckMysqlIntegrationExists(replicaSwapped.Name, primary2.Name, "read_replica")
+					},
+				),
+			},
+			{
+				// P1 regression: omit `integrations` from the
+				// replica's config entirely. Mirrors the equivalent
+				// pg step — see testResourcePgIntegrations for full
+				// rationale, including the caveat that
+				// `depends_on` is only a partial mitigation for
+				// destroy ordering and does not handle source
+				// replacement. Verifies the Optional+Computed+
+				// UseStateForUnknown fix applies symmetrically to
+				// mysql: the plan action on the replica is Update
+				// (not Replace), and the post-apply state still
+				// carries the integration.
+				//
+				// ExpectNonEmptyPlan: true accounts for pre-existing
+				// drift on other Optional+Computed mysql attributes
+				// that lack UseStateForUnknown modifiers. The
+				// PreApply plancheck asserts Update (not Replace).
+				Config: configSwapNoIntegrations,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(replicaFullResourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				ExpectNonEmptyPlan: true,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(replicaFullResourceName, "mysql.integrations.#", "1"),
+					integrationContains(primary2FullResourceName),
+					func(s *terraform.State) error {
+						return CheckMysqlIntegrationExists(replicaSwapped.Name, primary2.Name, "read_replica")
+					},
+				),
+			},
+		},
+	})
+}
+
+// CheckMysqlIntegrationExists verifies that the DBaaS API reports an
+// integration of the given type between source and dest (dest being the
+// service currently declared with the integration in its spec).
+func CheckMysqlIntegrationExists(dest, source, integrationType string) error {
+	client, err := testutils.APIClient()
+	if err != nil {
+		return err
+	}
+
+	// terraform-plugin-testing TestCheckFunc has no context, so we make a fresh one.
+	ctx := exoapi.WithEndpoint(context.Background(), exoapi.NewReqEndpoint(testutils.TestEnvironment(), testutils.TestZoneName))
+
+	res, err := client.GetDbaasServiceMysqlWithResponse(ctx, oapi.DbaasServiceName(dest))
+	if err != nil {
+		return err
+	}
+	if res.StatusCode() != http.StatusOK {
+		return fmt.Errorf("API request error: unexpected status %s", res.Status())
+	}
+	service := res.JSON200
+
+	if service.Integrations == nil {
+		return fmt.Errorf("no integrations reported for service %q", dest)
+	}
+	for _, integration := range *service.Integrations {
+		if integration.Dest == nil || integration.Source == nil || integration.Type == nil {
+			continue
+		}
+		if *integration.Dest == dest && *integration.Source == source && *integration.Type == integrationType {
+			return nil
+		}
+	}
+	return fmt.Errorf("integration %q from %q to %q not found on service %q", integrationType, source, dest, dest)
 }

--- a/pkg/resources/database/resource_service_pg.go
+++ b/pkg/resources/database/resource_service_pg.go
@@ -10,12 +10,16 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
+	exoscale "github.com/exoscale/egoscale/v2"
 	apiv2 "github.com/exoscale/egoscale/v2/api"
 	"github.com/exoscale/egoscale/v2/oapi"
 
@@ -31,7 +35,35 @@ type ResourcePgModel struct {
 	Version           types.String `tfsdk:"version"`
 	PgbouncerSettings types.String `tfsdk:"pgbouncer_settings"`
 	PglookoutSettings types.String `tfsdk:"pglookout_settings"`
+	Integrations      types.Set    `tfsdk:"integrations"`
 }
+
+// ResourceDbaasIntegrationModel describes a DBaaS service integration enabled
+// at creation time (e.g. a `read_replica` integration pointing at a source
+// service).
+type ResourceDbaasIntegrationModel struct {
+	Type          types.String `tfsdk:"type"`
+	SourceService types.String `tfsdk:"source_service"`
+}
+
+// resourceDbaasIntegrationAttrTypes is the attr.Type map for a single
+// element in the `integrations` set.
+var resourceDbaasIntegrationAttrTypes = map[string]attr.Type{
+	"type":           types.StringType,
+	"source_service": types.StringType,
+}
+
+// resourceDbaasIntegrationObjectType is the attr.Type of a single element in
+// the `integrations` set.
+var resourceDbaasIntegrationObjectType = types.ObjectType{AttrTypes: resourceDbaasIntegrationAttrTypes}
+
+// supportedIntegrationTypes lists the integration type values accepted by
+// this provider when declared inline on a pg or mysql service. It is
+// intentionally narrow: the Exoscale DBaaS API supports additional
+// integration types (`logs`, `metrics`, `datasource`) via the standalone
+// integration endpoint, but those do not apply to the create-time
+// destination model exposed here.
+var supportedIntegrationTypes = []string{"read_replica"}
 
 var ResourcePgSchema = schema.SingleNestedAttribute{
 	Optional:            true,
@@ -80,11 +112,94 @@ var ResourcePgSchema = schema.SingleNestedAttribute{
 			Optional:            true,
 			Computed:            true,
 		},
+		"integrations": ResourceDbaasIntegrationsSchema,
+	},
+}
+
+// ResourceDbaasIntegrationsSchema describes the `integrations` nested
+// attribute exposed on database service resources that support it. An
+// integration is configured at service creation time and cannot be updated
+// in place, therefore changing it forces resource replacement. It is
+// modelled as a set so reordering by the API (on Read) doesn't produce
+// spurious plans.
+//
+// The attribute is Optional+Computed with a `UseStateForUnknown` plan
+// modifier so that an operator who omits the attribute from config (most
+// commonly after importing a pre-existing replica service) does not see
+// Terraform propose a destructive replace simply because the API reports
+// an integration that the HCL doesn't mention. The plan value falls back
+// to the state value in that case, producing a no-op plan. The
+// `RequiresReplace` modifier still fires when the operator actively
+// changes a configured integration.
+//
+// NOTE on the limits of omission: when the operator omits the attribute,
+// the provider can only keep refresh and plan stable. It CANNOT preserve
+// Terraform's dependency graph — dependency edges come from configuration
+// references, not from state — so `terraform destroy` and source
+// replacement are NOT fully handled by the provider in that case. The
+// only pattern that handles all lifecycle events correctly is declaring
+// the `integrations` block explicitly in configuration, with a reference
+// to the source's `.name` attribute (which is Required and resolved from
+// configuration at plan time):
+//
+//	source_service = exoscale_dbaas.<primary>.name
+//
+// References to Computed attributes (.id, .created_at, etc.) must NOT
+// be used for source_service. Those attributes carry a
+// UseStateForUnknown plan modifier that preserves the old state value
+// during a source replacement, suppresses the setRequiresReplace diff
+// on the replica, and causes destroy to fail with "Cannot delete ...
+// while read replica exists". The schema description spells this out
+// in detail for operators.
+var ResourceDbaasIntegrationsSchema = schema.SetNestedAttribute{
+	MarkdownDescription: "❗ Service integrations declared when the service is created. Only integrations where **this** resource is the destination are supported: for example, to create a PostgreSQL read replica, declare the `integrations` block on the replica (destination) and set `source_service` to the primary's name. Integrations cannot be updated in place — any change to this set destroys and recreates the service (including all data).\n\n" +
+		"**Declaring the block explicitly is the recommended pattern** when the source service is also managed by Terraform. Use a reference to the source's `.name` attribute:\n\n" +
+		"```hcl\n" +
+		"integrations = [{\n" +
+		"  type           = \"read_replica\"\n" +
+		"  source_service = exoscale_dbaas.<primary>.name\n" +
+		"}]\n" +
+		"```\n\n" +
+		"`.name` is **required** in the source's configuration, so its value is resolved from configuration at plan time and changes propagate through Terraform's dependency graph. When the primary's name changes (or the primary is replaced for any reason), the replica's `source_service` value changes with it, the `setRequiresReplace` plan modifier fires, and the replica is replaced in the correct order. This is the only pattern that handles refresh, plan, destroy, AND source replacement correctly.\n\n" +
+		"Computed-name workflows (e.g. `name = \"${random_id.suffix.hex}-primary\"`) are supported: Terraform will normally resolve the primary's name before the replica's create call runs, and the reference is passed through unchanged. In the rare case that the value is still unknown at create time, the provider rejects the create with a clear error naming the `source_service` element, rather than silently submitting an empty value to the API.\n\n" +
+		"**Do not reference `Computed` attributes of the source service — notably `.id`, but also `.created_at`, `.state`, and similar — for `source_service`.** These attributes carry a `UseStateForUnknown` plan modifier that copies the prior state value into the plan during a source replacement. That suppresses the `setRequiresReplace` diff on the replica, leaves the replica attached to the destroyed source, and causes `terraform apply` to fail with `Cannot delete ... while read replica exists`. Always use a reference whose value is determined by configuration, not by post-apply computation — in practice, that means `.name`.\n\n" +
+		"**Omitting the attribute is safe for refresh and plan only.** On an imported or pre-existing replica, leaving `integrations` out of configuration avoids a spurious forced-replace on refresh (the value is read from the API and preserved in state via `UseStateForUnknown`). However, it removes the Terraform dependency edge, so:\n\n" +
+		"- `terraform destroy` may attempt to delete the source before the replica and fail with `Cannot delete ... while read replica exists`. Adding `depends_on = [exoscale_dbaas.<source>]` on the replica restores destroy ordering for **whole-stack destroys only**.\n" +
+		"- Replacing the source (rename, zone change, plan change, etc.) does **not** trigger a corresponding replacement of the replica, because Terraform sees no configuration change on the replica. `depends_on` does not fix this — it only affects ordering, not replacement propagation. There is no provider-level workaround for this case; declaring `integrations` explicitly in configuration with `source_service = exoscale_dbaas.<source>.name` is the only complete fix.\n\n" +
+		"Omitting the attribute is fully safe when the source service is **not** managed by Terraform in the same state (e.g. an external primary created out-of-band), because there is no dependency graph to preserve.\n\n" +
+		"Removing an integration out-of-band (e.g. via the Exoscale dashboard) on a resource that explicitly declares the attribute in configuration still triggers a forced replace on the next plan.",
+	Optional: true,
+	Computed: true,
+	Validators: []validator.Set{
+		setvalidator.SizeAtLeast(1),
+		integrationsSelfSource(),
+	},
+	PlanModifiers: []planmodifier.Set{
+		setUseStateForUnknown(),
+		setRequiresReplace(),
+	},
+	NestedObject: schema.NestedAttributeObject{
+		Attributes: map[string]schema.Attribute{
+			"type": schema.StringAttribute{
+				MarkdownDescription: "❗ Integration type. Currently only `read_replica` is supported.",
+				Required:            true,
+				Validators: []validator.String{
+					stringvalidator.OneOf(supportedIntegrationTypes...),
+				},
+			},
+			"source_service": schema.StringAttribute{
+				MarkdownDescription: "❗ Name of the source service to integrate with. For a `read_replica` integration, this is the name of the primary service from which data is replicated.",
+				Required:            true,
+			},
+		},
 	},
 }
 
 // createPg function handles PostgreSQL specific part of database resource creation logic.
-func (r *ServiceResource) createPg(ctx context.Context, data *ServiceResourceModel, diagnostics *diag.Diagnostics) {
+// configData carries the raw configuration so we can distinguish "operator
+// omitted integrations" (config null) from "operator set integrations to an
+// unknown expression" (config non-null but plan unknown).
+func (r *ServiceResource) createPg(ctx context.Context, data *ServiceResourceModel, configData *ServiceResourceModel, diagnostics *diag.Diagnostics) {
 	service := oapi.CreateDbaasServicePgJSONRequestBody{
 		Plan:                  data.Plan.ValueString(),
 		TerminationProtection: data.TerminationProtection.ValueBoolPointer(),
@@ -177,6 +292,135 @@ func (r *ServiceResource) createPg(ctx context.Context, data *ServiceResourceMod
 			}
 			service.PglookoutSettings = &obj
 		}
+
+		// P2: If the operator explicitly set integrations in config but
+		// the entire set is still unknown at apply time, reject cleanly.
+		// When the config value is null the operator omitted the
+		// attribute, which is correct for a standalone service.
+		//
+		// Note: this is likely unreachable for the current schema shape
+		// (SetNestedAttribute with Required string children cannot be
+		// assigned from a scalar unknown), but it guards against future
+		// schema changes or unexpected framework behavior.
+		if data.Pg.Integrations.IsUnknown() && configData.Pg != nil && !configData.Pg.Integrations.IsNull() {
+			diagnostics.AddError(
+				"pg.integrations: entire integrations set is unknown at create time",
+				"The `integrations` attribute was set in configuration but its value "+
+					"is still unknown at apply time. This usually means the entire set is "+
+					"derived from a resource output that Terraform could not resolve before "+
+					"creating this service. Set `integrations` to a list of objects with "+
+					"known `type` and `source_service` values, for example:\n\n"+
+					"  integrations = [{ type = \"read_replica\", source_service = exoscale_dbaas.<primary>.name }]",
+			)
+			return
+		}
+
+		if !data.Pg.Integrations.IsNull() && !data.Pg.Integrations.IsUnknown() {
+			var integrationModels []ResourceDbaasIntegrationModel
+			// allowUnhandled=true so unknown per-field values in the
+			// set (e.g. source_service pointing at a computed
+			// attribute of another resource that is unknown at
+			// plan time) do not produce a hard decoding error.
+			// types.String already represents unknown natively so
+			// this is mostly defense-in-depth, but it also
+			// matches the validator's behavior for consistency.
+			if dg := data.Pg.Integrations.ElementsAs(ctx, &integrationModels, true); dg.HasError() {
+				diagnostics.Append(dg...)
+				return
+			}
+			// Validate every element in a single pass:
+			//  1. Reject null/unknown fields — the plan-time validator
+			//     is lenient about unknowns, but by apply time
+			//     ValueString() would return "" for unknowns and we'd
+			//     silently submit source-service="" to the API.
+			//  2. Re-run the semantic checks (type ∈ supported, source
+			//     ≠ self) that plan-time validators skipped for unknown
+			//     nested values.
+			selfName := data.Name.ValueString()
+			for i, integration := range integrationModels {
+				if integration.Type.IsNull() || integration.Type.IsUnknown() {
+					diagnostics.AddError(
+						"pg.integrations: element type is unknown or null at create time",
+						fmt.Sprintf(
+							"Element %d of the `pg.integrations` set has no concrete "+
+								"`type` value at the time the service is being created. "+
+								"This usually means `type` depends on a computed value "+
+								"that Terraform could not resolve before the service create "+
+								"call. Set `type` to a literal value (currently only "+
+								"\"read_replica\" is supported).",
+							i,
+						),
+					)
+					return
+				}
+				if integration.SourceService.IsNull() || integration.SourceService.IsUnknown() {
+					diagnostics.AddError(
+						"pg.integrations: source_service is unknown or null at create time",
+						fmt.Sprintf(
+							"Element %d of the `pg.integrations` set has no concrete "+
+								"`source_service` value at the time the service is being "+
+								"created. This usually means `source_service` references a "+
+								"value that Terraform could not resolve before the create "+
+								"call — for example, a primary service whose name is itself "+
+								"computed from another resource that has not been applied "+
+								"yet. Ensure `source_service` references a plan-time-known "+
+								"value, typically `exoscale_dbaas.<primary>.name` where the "+
+								"primary's name is a literal or a fully-resolved expression.",
+							i,
+						),
+					)
+					return
+				}
+				typeVal := integration.Type.ValueString()
+				supported := false
+				for _, t := range supportedIntegrationTypes {
+					if typeVal == t {
+						supported = true
+						break
+					}
+				}
+				if !supported {
+					diagnostics.AddError(
+						"pg.integrations: unsupported integration type",
+						fmt.Sprintf(
+							"Element %d of the `pg.integrations` set has type %q, "+
+								"which is not a supported integration type. "+
+								"Supported types: %s.",
+							i, typeVal, strings.Join(supportedIntegrationTypes, ", "),
+						),
+					)
+					return
+				}
+				if integration.SourceService.ValueString() == selfName {
+					diagnostics.AddError(
+						"pg.integrations: self-referencing source_service",
+						fmt.Sprintf(
+							"Element %d of the `pg.integrations` set has "+
+								"source_service=%q, which is the same service this "+
+								"resource declares. Integrations must be declared on "+
+								"the destination side, with source_service pointing "+
+								"at a different service.",
+							i, selfName,
+						),
+					)
+					return
+				}
+			}
+			if len(integrationModels) > 0 {
+				integrations := make([]struct {
+					DestService   *oapi.DbaasServiceName                            `json:"dest-service,omitempty"`
+					Settings      *map[string]interface{}                           `json:"settings,omitempty"`
+					SourceService *oapi.DbaasServiceName                            `json:"source-service,omitempty"`
+					Type          oapi.CreateDbaasServicePgJSONBodyIntegrationsType `json:"type"`
+				}, len(integrationModels))
+				for i, integration := range integrationModels {
+					source := oapi.DbaasServiceName(integration.SourceService.ValueString())
+					integrations[i].SourceService = &source
+					integrations[i].Type = oapi.CreateDbaasServicePgJSONBodyIntegrationsType(integration.Type.ValueString())
+				}
+				service.Integrations = &integrations
+			}
+		}
 	}
 
 	resp, err := r.client.CreateDbaasServicePgWithResponse(
@@ -192,6 +436,39 @@ func (r *ServiceResource) createPg(ctx context.Context, data *ServiceResourceMod
 		diagnostics.AddError("Client Error", fmt.Sprintf("Unable create database service pg, unexpected status: %s", resp.Status()))
 		return
 	}
+
+	// The service now exists on Exoscale. Any error return after this
+	// point must delete it first — otherwise we orphan a billable
+	// database service that Terraform state never knew about, which
+	// cannot be cleaned up by CheckDestroy, taint, or any normal
+	// workflow. Cleanup uses a fresh, bounded context detached from
+	// the request ctx (which may already be cancelled if we got here
+	// via ctx.Done()).
+	createSucceeded := false
+	defer func() {
+		if createSucceeded {
+			return
+		}
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		defer cancel()
+		cleanupCtx = apiv2.WithEndpoint(cleanupCtx, apiv2.NewReqEndpoint(r.env, data.Zone.ValueString()))
+		name := data.Id.ValueString()
+		if delErr := r.client.DeleteDatabaseService(
+			cleanupCtx,
+			data.Zone.ValueString(),
+			&exoscale.DatabaseService{Name: &name},
+		); delErr != nil {
+			tflog.Warn(ctx, fmt.Sprintf(
+				"orphan cleanup failed after createPg error for service %q: %v",
+				name, delErr,
+			))
+		} else {
+			tflog.Info(ctx, fmt.Sprintf(
+				"orphan cleanup: deleted partially-created pg service %q",
+				name,
+			))
+		}
+	}()
 
 	tflog.Info(ctx, "DB Service created, waiting for the service to be in 'running' state")
 	apiService := &oapi.DbaasServicePg{}
@@ -322,6 +599,41 @@ pooling:
 			data.Pg.PglookoutSettings = types.StringValue(string(settings))
 		}
 	}
+
+	// Integrations is Optional+Computed: if the operator did not set
+	// the attribute in config, the framework left the plan value
+	// unknown at the Create phase. Populate it from the API response
+	// so the post-create state has a concrete value. Only surface
+	// integrations where the current service is the destination,
+	// matching readPg's filter.
+	if data.Pg.Integrations.IsUnknown() {
+		data.Pg.Integrations = types.SetNull(resourceDbaasIntegrationObjectType)
+		if apiService.Integrations != nil {
+			var models []ResourceDbaasIntegrationModel
+			for _, integration := range *apiService.Integrations {
+				if integration.Dest == nil || *integration.Dest != data.Id.ValueString() {
+					continue
+				}
+				models = append(models, ResourceDbaasIntegrationModel{
+					Type:          types.StringPointerValue(integration.Type),
+					SourceService: types.StringPointerValue(integration.Source),
+				})
+			}
+			if len(models) > 0 {
+				v, dg := types.SetValueFrom(ctx, resourceDbaasIntegrationObjectType, models)
+				if dg.HasError() {
+					diagnostics.Append(dg...)
+					return
+				}
+				data.Pg.Integrations = v
+			}
+		}
+	}
+
+	// All post-create population succeeded — cancel the deferred
+	// orphan cleanup. Any panic between here and the return still
+	// allows the defer to run.
+	createSucceeded = true
 }
 
 // readPg function handles PostgreSQL specific part of database resource Read logic.
@@ -487,6 +799,31 @@ func (r *ServiceResource) readPg(ctx context.Context, data *ServiceResourceModel
 		data.Pg.PglookoutSettings = types.StringValue(string(settings))
 	}
 
+	// Only surface integrations where the current service is the destination,
+	// so that Terraform state reflects exactly what the resource's config
+	// declares (i.e. integrations the user asked to create for this service).
+	data.Pg.Integrations = types.SetNull(resourceDbaasIntegrationObjectType)
+	if apiService.Integrations != nil {
+		var integrationModels []ResourceDbaasIntegrationModel
+		for _, integration := range *apiService.Integrations {
+			if integration.Dest == nil || *integration.Dest != data.Id.ValueString() {
+				continue
+			}
+			integrationModels = append(integrationModels, ResourceDbaasIntegrationModel{
+				Type:          types.StringPointerValue(integration.Type),
+				SourceService: types.StringPointerValue(integration.Source),
+			})
+		}
+		if len(integrationModels) > 0 {
+			v, dg := types.SetValueFrom(ctx, resourceDbaasIntegrationObjectType, integrationModels)
+			if dg.HasError() {
+				diagnostics.Append(dg...)
+				return false
+			}
+			data.Pg.Integrations = v
+		}
+	}
+
 	return false
 }
 
@@ -607,6 +944,12 @@ func (r *ServiceResource) updatePg(ctx context.Context, stateData *ServiceResour
 			stateData.Pg.PglookoutSettings = planData.Pg.PglookoutSettings
 			updated = true
 		}
+
+		// Defensive no-op: integrations is Optional with a RequiresReplace
+		// plan modifier, so Terraform Core never calls Update when the
+		// set differs from state. Keep stateData in sync with plan here
+		// as a safety net in case that contract is ever weakened.
+		stateData.Pg.Integrations = planData.Pg.Integrations
 	}
 
 	if !updated {

--- a/pkg/resources/database/resource_service_pg_test.go
+++ b/pkg/resources/database/resource_service_pg_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"regexp"
 	"strconv"
 	"strings"
 	"testing"
@@ -15,6 +16,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	exoapi "github.com/exoscale/egoscale/v2/api"
@@ -42,6 +44,21 @@ type TemplateModelPg struct {
 	PgbouncerSettings string
 	PglookoutSettings string
 	Version           string
+
+	Integrations []TemplateModelPgIntegration
+
+	// DependsOn renders an explicit `depends_on = [...]` meta-argument.
+	// Each entry is emitted as-is in the HCL, so typical values look
+	// like "exoscale_dbaas.primary" (bare references, no quotes).
+	DependsOn []string
+}
+
+type TemplateModelPgIntegration struct {
+	Type string
+	// SourceService is rendered as-is into the terraform config, so it may be
+	// either a quoted string literal ("foo") or a resource reference
+	// (exoscale_dbaas.primary.name).
+	SourceService string
 }
 
 type TemplateModelPgUser struct {
@@ -452,4 +469,740 @@ func CheckExistsPgDatabase(service, databaseName string, data *TemplateModelPgDb
 	}
 
 	return fmt.Errorf("could not find database %s for service %s, found %v", databaseName, service, serviceDbs)
+}
+
+// testResourcePgIntegrations exercises creating a PG service that is declared
+// as a read replica of another PG service via the `integrations` attribute,
+// and verifies that modifying the integration triggers a full replace of the
+// replica resource (since integrations cannot be updated in place).
+func testResourcePgIntegrations(t *testing.T) {
+	t.Parallel()
+
+	serviceTpl, err := template.ParseFiles("testdata/resource_pg.tmpl")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Plan choice note: Exoscale DBaaS read replicas require the primary
+	// service to be on a Business or Premium plan (Hobbyist and Startup
+	// are not sufficient). The replica itself can run on any Startup or
+	// larger plan. `business-4` / `startup-4` is the cheapest authorized
+	// combination that actually supports the read_replica integration.
+	primary := TemplateModelPg{
+		ResourceName:          "primary",
+		Name:                  acctest.RandomWithPrefix(testutils.Prefix),
+		Plan:                  "business-4",
+		Zone:                  testutils.TestZoneName,
+		TerminationProtection: false,
+		Version:               "15",
+	}
+	replica := TemplateModelPg{
+		ResourceName:          "replica",
+		Name:                  acctest.RandomWithPrefix(testutils.Prefix),
+		Plan:                  "startup-4",
+		Zone:                  testutils.TestZoneName,
+		TerminationProtection: false,
+		Version:               "15",
+		Integrations: []TemplateModelPgIntegration{
+			{
+				Type:          "read_replica",
+				SourceService: "exoscale_dbaas.primary.name",
+			},
+		},
+	}
+
+	renderPgConfig := func(services ...TemplateModelPg) string {
+		t.Helper()
+		buf := &bytes.Buffer{}
+		for _, s := range services {
+			if err := serviceTpl.Execute(buf, &s); err != nil {
+				t.Fatal(err)
+			}
+		}
+		return buf.String()
+	}
+
+	configCreate := renderPgConfig(primary, replica)
+
+	// Second variant: add a second primary and swap the replica's
+	// source_service to point at it. Changing source_service must force the
+	// replica to be replaced (destroy+create).
+	primary2 := TemplateModelPg{
+		ResourceName:          "primary2",
+		Name:                  acctest.RandomWithPrefix(testutils.Prefix),
+		Plan:                  "business-4",
+		Zone:                  testutils.TestZoneName,
+		TerminationProtection: false,
+		Version:               "15",
+	}
+	replicaSwapped := replica
+	// Rotate the replica name on the swap step so the destroy+create
+	// cycle does not hit a 409 on eventual-consistency in the DBaaS API.
+	replicaSwapped.Name = acctest.RandomWithPrefix(testutils.Prefix)
+	replicaSwapped.Integrations = []TemplateModelPgIntegration{
+		{
+			Type:          "read_replica",
+			SourceService: "exoscale_dbaas.primary2.name",
+		},
+	}
+	configSwap := renderPgConfig(primary, primary2, replicaSwapped)
+
+	// Variant for the P1 regression step: same topology as configSwap
+	// but the replica's HCL omits the `integrations` block entirely.
+	// This simulates an operator who declares (or imports) a replica
+	// without mentioning integrations in config while the remote
+	// service still has one. With the Optional+Computed+UseStateForUnknown
+	// plan modifier, the plan must NOT fire RequiresReplace for
+	// integrations — the state value carries forward.
+	//
+	// An explicit `depends_on` is added because removing the
+	// `source_service = exoscale_dbaas.primary2.name` reference from
+	// HCL also removes the implicit dependency edge from Terraform's
+	// graph. Without it, the post-test destroy would try to delete
+	// primary2 in parallel with the replica and race against
+	// Exoscale's eventual-consistency on replica teardown, producing
+	// a "Cannot delete … while read replica exists" error.
+	replicaSwappedNoIntegrations := replicaSwapped
+	replicaSwappedNoIntegrations.Integrations = nil
+	replicaSwappedNoIntegrations.DependsOn = []string{"exoscale_dbaas.primary2"}
+	configSwapNoIntegrations := renderPgConfig(primary, primary2, replicaSwappedNoIntegrations)
+
+	primaryFullResourceName := "exoscale_dbaas.primary"
+	primary2FullResourceName := "exoscale_dbaas.primary2"
+	replicaFullResourceName := "exoscale_dbaas.replica"
+
+	integrationContains := func(primaryResource string) resource.TestCheckFunc {
+		return func(s *terraform.State) error {
+			primaryRes, ok := s.RootModule().Resources[primaryResource]
+			if !ok {
+				return fmt.Errorf("resource %s not found in state", primaryResource)
+			}
+			primaryName := primaryRes.Primary.Attributes["name"]
+			if primaryName == "" {
+				return fmt.Errorf("resource %s has no `name` attribute in state", primaryResource)
+			}
+			return resource.TestCheckTypeSetElemNestedAttrs(
+				replicaFullResourceName,
+				"pg.integrations.*",
+				map[string]string{
+					"type":           "read_replica",
+					"source_service": primaryName,
+				},
+			)(s)
+		}
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() { testutils.AccPreCheck(t) },
+		CheckDestroy: resource.ComposeAggregateTestCheckFunc(
+			CheckServiceDestroy("pg", primary.Name),
+			CheckServiceDestroy("pg", primary2.Name),
+			CheckServiceDestroy("pg", replica.Name),
+			CheckServiceDestroy("pg", replicaSwapped.Name),
+		),
+		ProtoV6ProviderFactories: testutils.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: configCreate,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(primaryFullResourceName, "created_at"),
+					resource.TestCheckResourceAttrSet(replicaFullResourceName, "created_at"),
+					resource.TestCheckResourceAttr(replicaFullResourceName, "pg.integrations.#", "1"),
+					integrationContains(primaryFullResourceName),
+					func(s *terraform.State) error {
+						return CheckPgIntegrationExists(replica.Name, primary.Name, "read_replica")
+					},
+				),
+			},
+			{
+				// Verify the import round-trip of the integrations
+				// attribute — the Read path's dest-filter is the
+				// most fragile part of the PR, so we exercise it
+				// explicitly. ImportStateVerify (the usual helper) is
+				// not used because other computed-or-optional pg
+				// attributes (admin_password, settings, ...) don't
+				// round-trip. Instead we drive a custom
+				// ImportStateCheck that inspects the imported state
+				// and asserts only what this PR cares about:
+				//   - pg.integrations.# == "1"
+				//   - exactly one set element matches the expected
+				//     {type, source_service} pair
+				// This gives the panel-review-requested
+				// "import actually verifies integrations" signal
+				// without dragging in unrelated drift.
+				ResourceName: replicaFullResourceName,
+				ImportStateIdFunc: func() resource.ImportStateIdFunc {
+					return func(*terraform.State) (string, error) {
+						return fmt.Sprintf("%s@%s", replica.Name, replica.Zone), nil
+					}
+				}(),
+				ImportState: true,
+				ImportStateCheck: assertImportedIntegrations(
+					"pg",
+					"read_replica",
+					&primary.Name,
+					1,
+				),
+			},
+			{
+				// Out-of-band integration deletion: simulates an
+				// operator deleting the read_replica integration
+				// via the Exoscale dashboard (or another tool)
+				// while the exoscale_dbaas resource still exists
+				// in Terraform state. The PreConfig hook calls the
+				// DeleteDbaasIntegration API endpoint directly,
+				// then polls the service GET until the integration
+				// is no longer reported. RefreshState then re-reads
+				// state from the API (exercising the Read path's
+				// dest-filter on a now-missing integration), and
+				// the PostRefresh plancheck asserts Terraform
+				// proposes a full Replace of the replica — which
+				// is what the setRequiresReplace plan modifier
+				// should do when the integrations set in state
+				// diverges from the config. This closes the
+				// "out-of-band removal triggers forced replace on
+				// next plan" contract documented in the schema
+				// description.
+				//
+				// RefreshState (not PlanOnly) is used because
+				// RefreshPlanChecks.PostRefresh can run a
+				// plancheck against the resulting plan, whereas
+				// PlanOnly + ConfigPlanChecks.PreApply is
+				// explicitly forbidden by the test harness.
+				PreConfig: func() {
+					deletePgIntegrationOutOfBand(t, replica.Name, primary.Name)
+				},
+				RefreshState:       true,
+				ExpectNonEmptyPlan: true,
+				RefreshPlanChecks: resource.RefreshPlanChecks{
+					PostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(replicaFullResourceName, plancheck.ResourceActionReplace),
+					},
+				},
+			},
+			{
+				// Swapping source_service must force the replica to be
+				// replaced — verify via plancheck first, then assert the
+				// new integration is in place after apply.
+				Config: configSwap,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(replicaFullResourceName, plancheck.ResourceActionReplace),
+					},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(primary2FullResourceName, "created_at"),
+					resource.TestCheckResourceAttr(replicaFullResourceName, "pg.integrations.#", "1"),
+					integrationContains(primary2FullResourceName),
+					func(s *terraform.State) error {
+						return CheckPgIntegrationExists(replicaSwapped.Name, primary2.Name, "read_replica")
+					},
+				),
+			},
+			{
+				// P1 regression: omit `integrations` from the
+				// replica's config entirely. Without the
+				// Optional+Computed+UseStateForUnknown fix, the
+				// plan modifier would see state=[{...}] and plan=
+				// null, fire RequiresReplace, and propose to
+				// destroy and recreate the replica — a data-loss
+				// trap for operators who imported (or refreshed
+				// after upgrading the provider) a replica that
+				// has an integration server-side but no HCL
+				// declaration of it. With the fix, UseStateForUnknown
+				// copies state into plan for integrations, so the
+				// proposed action is Update (not Replace) and the
+				// integration remains in state.
+				//
+				// Placed LAST in the test (after Swap) so that
+				// the out-of-band deletion step's RefreshState,
+				// which inherits the "prior step's config",
+				// continues to see configCreate rather than this
+				// no-integrations variant. The test's terminal
+				// state at this point has the replica pointing
+				// at primary2 with an integration, so we use
+				// configSwap as the baseline and strip
+				// integrations from the replica in a companion
+				// configSwapNoIntegrations variant.
+				//
+				// The replica declares `depends_on =
+				// [exoscale_dbaas.primary2]` to restore destroy
+				// ordering after removing the implicit
+				// dependency edge that the integrations block
+				// would normally provide. This is a PARTIAL
+				// mitigation: it lets the post-test destroy
+				// complete cleanly, but it does NOT handle
+				// source replacement (changing primary2's name
+				// or plan would NOT trigger a replica
+				// replacement, because depends_on only affects
+				// ordering and not replacement propagation).
+				// The schema description documents this
+				// limitation and points operators at declaring
+				// integrations explicitly as the only complete
+				// fix; this test step deliberately exercises
+				// the limited-mitigation path.
+				//
+				// ExpectNonEmptyPlan: true accounts for
+				// pre-existing drift on other Optional+Computed
+				// pg attributes (node_cpus, pg_settings, ...)
+				// that lack UseStateForUnknown modifiers — that
+				// drift is out of scope for this PR. The
+				// PreApply plancheck asserts the action is
+				// Update (not Replace), and the Check asserts
+				// the integration is still present in state
+				// after apply.
+				Config: configSwapNoIntegrations,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(replicaFullResourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				ExpectNonEmptyPlan: true,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(replicaFullResourceName, "pg.integrations.#", "1"),
+					integrationContains(primary2FullResourceName),
+					func(s *terraform.State) error {
+						return CheckPgIntegrationExists(replicaSwapped.Name, primary2.Name, "read_replica")
+					},
+				),
+			},
+		},
+	})
+}
+
+// deletePgIntegrationOutOfBand calls the Exoscale DBaaS integration
+// delete API directly (bypassing Terraform), then polls the service
+// GET until the integration is no longer reported. Used to simulate
+// an operator removing an integration via the dashboard while the
+// exoscale_dbaas resource still exists in Terraform state.
+//
+// dest is the destination service (the replica); source is the
+// source service (the primary). The helper finds the integration
+// whose Dest matches dest and Source matches source, extracts its
+// ID, issues the delete, and waits up to 60s for the deletion to
+// become observable on the service GET endpoint.
+func deletePgIntegrationOutOfBand(t *testing.T, dest, source string) {
+	t.Helper()
+
+	client, err := testutils.APIClient()
+	if err != nil {
+		t.Fatalf("deletePgIntegrationOutOfBand: API client: %v", err)
+	}
+
+	// terraform-plugin-testing PreConfig callbacks have no context.
+	ctx := exoapi.WithEndpoint(context.Background(), exoapi.NewReqEndpoint(testutils.TestEnvironment(), testutils.TestZoneName))
+
+	getRes, err := client.GetDbaasServicePgWithResponse(ctx, oapi.DbaasServiceName(dest))
+	if err != nil {
+		t.Fatalf("deletePgIntegrationOutOfBand: GetDbaasServicePg: %v", err)
+	}
+	if getRes.StatusCode() != http.StatusOK {
+		t.Fatalf("deletePgIntegrationOutOfBand: GetDbaasServicePg unexpected status: %s", getRes.Status())
+	}
+	if getRes.JSON200.Integrations == nil {
+		t.Fatalf("deletePgIntegrationOutOfBand: service %q has no integrations", dest)
+	}
+
+	var integrationID string
+	for _, integration := range *getRes.JSON200.Integrations {
+		if integration.Dest == nil || integration.Source == nil || integration.Id == nil {
+			continue
+		}
+		if *integration.Dest == dest && *integration.Source == source {
+			integrationID = *integration.Id
+			break
+		}
+	}
+	if integrationID == "" {
+		t.Fatalf("deletePgIntegrationOutOfBand: no integration found with dest=%q source=%q on service %q", dest, source, dest)
+	}
+
+	delRes, err := client.DeleteDbaasIntegrationWithResponse(ctx, integrationID)
+	if err != nil {
+		t.Fatalf("deletePgIntegrationOutOfBand: DeleteDbaasIntegration(%s): %v", integrationID, err)
+	}
+	if delRes.StatusCode() != http.StatusOK && delRes.StatusCode() != http.StatusNoContent {
+		t.Fatalf("deletePgIntegrationOutOfBand: DeleteDbaasIntegration(%s) unexpected status: %s", integrationID, delRes.Status())
+	}
+
+	// Poll the service GET until the integration is no longer
+	// reported. The delete is async; we give it up to 60s.
+	deadline := time.Now().Add(60 * time.Second)
+	for {
+		if time.Now().After(deadline) {
+			t.Fatalf("deletePgIntegrationOutOfBand: timed out waiting for integration %s to disappear from service %q", integrationID, dest)
+		}
+		res, err := client.GetDbaasServicePgWithResponse(ctx, oapi.DbaasServiceName(dest))
+		if err != nil {
+			t.Fatalf("deletePgIntegrationOutOfBand: poll GetDbaasServicePg: %v", err)
+		}
+		if res.StatusCode() != http.StatusOK {
+			t.Fatalf("deletePgIntegrationOutOfBand: poll GetDbaasServicePg unexpected status: %s", res.Status())
+		}
+		stillPresent := false
+		if res.JSON200.Integrations != nil {
+			for _, integration := range *res.JSON200.Integrations {
+				if integration.Id != nil && *integration.Id == integrationID {
+					stillPresent = true
+					break
+				}
+			}
+		}
+		if !stillPresent {
+			return
+		}
+		time.Sleep(2 * time.Second)
+	}
+}
+
+// CheckPgIntegrationExists verifies that the DBaaS API reports an integration
+// of the given type between source and dest (dest being the service currently
+// declared with the integration in its spec).
+func CheckPgIntegrationExists(dest, source, integrationType string) error {
+	client, err := testutils.APIClient()
+	if err != nil {
+		return err
+	}
+
+	// terraform-plugin-testing TestCheckFunc has no context, so we make a fresh one.
+	ctx := exoapi.WithEndpoint(context.Background(), exoapi.NewReqEndpoint(testutils.TestEnvironment(), testutils.TestZoneName))
+
+	res, err := client.GetDbaasServicePgWithResponse(ctx, oapi.DbaasServiceName(dest))
+	if err != nil {
+		return err
+	}
+	if res.StatusCode() != http.StatusOK {
+		return fmt.Errorf("API request error: unexpected status %s", res.Status())
+	}
+	service := res.JSON200
+
+	if service.Integrations == nil {
+		return fmt.Errorf("no integrations reported for service %q", dest)
+	}
+	for _, integration := range *service.Integrations {
+		if integration.Dest == nil || integration.Source == nil || integration.Type == nil {
+			continue
+		}
+		if *integration.Dest == dest && *integration.Source == source && *integration.Type == integrationType {
+			return nil
+		}
+	}
+	return fmt.Errorf("integration %q from %q to %q not found on service %q", integrationType, source, dest, dest)
+}
+
+// assertImportedIntegrations returns an ImportStateCheck callback that
+// inspects the imported state and asserts the nested `integrations`
+// attribute round-tripped with the expected count and at least one
+// element matching (type, *expectedSourceName). Works for both `pg.`
+// and `mysql.` top-level blocks — pass the dbType accordingly.
+//
+// Set nested attributes in flatmap state use hash-keyed element paths
+// (e.g. `pg.integrations.1234567890.type`), so we scan the Primary
+// attributes for the count key and any matching element.
+//
+// expectedSourceName is a pointer because the source name is not known
+// until the primary resource has been applied — the caller typically
+// passes &primary.Name, and Go closes over it; the pointer is
+// dereferenced lazily at import-check time.
+func assertImportedIntegrations(dbType, expectedType string, expectedSourceName *string, expectedCount int) resource.ImportStateCheckFunc {
+	return func(states []*terraform.InstanceState) error {
+		if len(states) == 0 {
+			return fmt.Errorf("no imported instance states returned")
+		}
+		state := states[0]
+
+		countKey := fmt.Sprintf("%s.integrations.#", dbType)
+		countStr, ok := state.Attributes[countKey]
+		if !ok {
+			return fmt.Errorf("imported state has no %q attribute", countKey)
+		}
+		if countStr != fmt.Sprintf("%d", expectedCount) {
+			return fmt.Errorf("imported state %s = %q, want %q", countKey, countStr, fmt.Sprintf("%d", expectedCount))
+		}
+
+		// Walk all hashed-set element paths, grouping by hash.
+		prefix := fmt.Sprintf("%s.integrations.", dbType)
+		seen := map[string]map[string]string{}
+		for k, v := range state.Attributes {
+			if !strings.HasPrefix(k, prefix) || k == countKey {
+				continue
+			}
+			rest := strings.TrimPrefix(k, prefix)
+			// rest looks like "<hash>.type" or "<hash>.source_service"
+			parts := strings.SplitN(rest, ".", 2)
+			if len(parts) != 2 {
+				continue
+			}
+			hash, field := parts[0], parts[1]
+			if _, ok := seen[hash]; !ok {
+				seen[hash] = map[string]string{}
+			}
+			seen[hash][field] = v
+		}
+
+		want := *expectedSourceName
+		for _, fields := range seen {
+			if fields["type"] == expectedType && fields["source_service"] == want {
+				return nil
+			}
+		}
+		return fmt.Errorf(
+			"imported state has no %s.integrations element with type=%q source_service=%q; got %d element(s): %+v",
+			dbType, expectedType, want, len(seen), seen,
+		)
+	}
+}
+
+// testResourcePgIntegrationsValidators exercises the attribute-level
+// validators on the `integrations` set: SizeAtLeast(1), OneOf("read_replica")
+// on `type`, and the custom self-source rejector. All steps are plan-only
+// with ExpectError regexps — no Exoscale resources are created, so the
+// test has zero API cost. Still routed through TestDatabase so it runs
+// alongside the existing AccPreCheck credentials gate.
+func testResourcePgIntegrationsValidators(t *testing.T) {
+	t.Parallel()
+
+	serviceName := acctest.RandomWithPrefix(testutils.Prefix)
+
+	// Minimal valid skeleton except for the integrations block we vary
+	// per step. The config references a non-existent primary service by
+	// name so terraform's dependency graph resolves without requiring a
+	// second resource — we only need validate/plan to run.
+	//
+	// `zone` is a real authorized zone so the zone OneOf validator passes;
+	// the resource never reaches the Create RPC because the integrations
+	// validator fires first.
+	configWithIntegrations := func(name string, integrationsBlock string) string {
+		return fmt.Sprintf(`
+resource "exoscale_dbaas" "target" {
+  name = %q
+  type = "pg"
+  plan = "business-4"
+  zone = %q
+  pg = {
+    version = "15"
+    %s
+  }
+}
+`, name, testutils.TestZoneName, integrationsBlock)
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testutils.AccPreCheck(t) },
+		ProtoV6ProviderFactories: testutils.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				// setvalidator.SizeAtLeast(1) — empty set must be rejected
+				// at plan time so users don't hit a perpetual diff.
+				Config:   configWithIntegrations(serviceName, `integrations = []`),
+				PlanOnly: true,
+				ExpectError: regexp.MustCompile(
+					`(?s)set must contain at least 1 elements`,
+				),
+			},
+			{
+				// stringvalidator.OneOf("read_replica") on `type`.
+				Config: configWithIntegrations(serviceName, `integrations = [{
+      type           = "logs"
+      source_service = "some-other-service"
+    }]`),
+				PlanOnly: true,
+				ExpectError: regexp.MustCompile(
+					`(?s)value must be one of.*read_replica.*got: "logs"`,
+				),
+			},
+			{
+				// Custom integrationsSelfSource validator — refuse an
+				// integration whose source_service equals the resource's
+				// own name. Catches copy-paste mistakes at plan time
+				// instead of after a slow failed API call.
+				Config: configWithIntegrations(serviceName, fmt.Sprintf(`integrations = [{
+      type           = "read_replica"
+      source_service = %q
+    }]`, serviceName)),
+				PlanOnly: true,
+				ExpectError: regexp.MustCompile(
+					`(?s)Invalid integration source`,
+				),
+			},
+			{
+				// Multi-element set: one valid integration and one
+				// self-sourced. The validator must iterate over all
+				// elements and still flag the bad one regardless of
+				// ordering (sets have no stable ordering anyway).
+				// This also exercises the ElementsAs() + loop machinery
+				// in the self-source validator for n > 1, which isn't
+				// covered by the single-element cases above.
+				Config: configWithIntegrations(serviceName, fmt.Sprintf(`integrations = [
+      {
+        type           = "read_replica"
+        source_service = "some-other-primary"
+      },
+      {
+        type           = "read_replica"
+        source_service = %q
+      },
+    ]`, serviceName)),
+				PlanOnly: true,
+				ExpectError: regexp.MustCompile(
+					`(?s)Invalid integration source`,
+				),
+			},
+		},
+	})
+}
+
+// testResourcePgIntegrationsUnknownSource verifies that the
+// integrationsSelfSource validator (and the underlying ElementsAs
+// decoding in createPg) do not produce a spurious plan-time error
+// when an integration element's source_service is unknown at plan
+// time. In that case the validator must skip the element rather than
+// fail the plan, and ElementsAs must decode without erroring.
+//
+// The unknown value comes from a built-in `terraform_data` resource
+// whose `output` attribute is Computed and therefore unknown before
+// apply. We deliberately do NOT use a reference to another
+// exoscale_dbaas resource's Computed attributes (such as `.id`):
+// per the schema documentation, `source_service` must resolve to a
+// plan-time-known value like `.name`, because Computed attributes
+// on exoscale_dbaas carry a `UseStateForUnknown` plan modifier that
+// would make source replacement unsafe. The validator itself does
+// not distinguish between "unknown because the source is being
+// created" and "unknown because the operator used the wrong kind of
+// reference", but the test suite should not imply that referencing
+// `.id` is a supported pattern.
+//
+// Plan-only test. Zero API cost — the plan is computed locally and
+// never applied.
+func testResourcePgIntegrationsUnknownSource(t *testing.T) {
+	t.Parallel()
+
+	replicaName := acctest.RandomWithPrefix(testutils.Prefix)
+	config := fmt.Sprintf(`
+resource "terraform_data" "unknown_source" {
+  input = "placeholder"
+}
+
+resource "exoscale_dbaas" "p2_replica" {
+  name                   = %q
+  type                   = "pg"
+  plan                   = "startup-4"
+  zone                   = %q
+  termination_protection = false
+  pg = {
+    version = "15"
+    integrations = [{
+      type = "read_replica"
+      # terraform_data.unknown_source.output is Computed; its value
+      # is unknown at plan time before any apply. This exercises
+      # the validator's "skip element with unknown field" path
+      # without referencing a Computed attribute on exoscale_dbaas
+      # itself (which would endorse an unsupported pattern — see
+      # the ResourceDbaasIntegrationsSchema description).
+      source_service = terraform_data.unknown_source.output
+    }]
+  }
+}
+`, replicaName, testutils.TestZoneName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testutils.AccPreCheck(t) },
+		ProtoV6ProviderFactories: testutils.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				// PlanOnly + ExpectNonEmptyPlan: true. ExpectError
+				// is intentionally NOT set — the whole point is
+				// that this config must plan cleanly. If the
+				// validator (or the ElementsAs decoding) errors
+				// on the unknown nested field, the test fails.
+				Config:             config,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+// testResourcePgStateUpgrade verifies that an existing operator with a
+// pg resource created by the previously-released provider version
+// (without the new `integrations` attribute) can cleanly refresh and
+// plan against this branch with no drift. This is the "existing
+// operators don't see surprise changes after upgrading the provider"
+// signal.
+//
+// The test uses terraform-plugin-testing's ExternalProviders to pin
+// step 1 to a released version, then swaps to the in-tree provider
+// via ProtoV6ProviderFactories. The framework handles the implicit
+// schema upgrade: the new `integrations` attribute is Optional with
+// no default, so state written by the old version should be decoded
+// with `integrations` populated as a null set, producing an empty
+// plan.
+func testResourcePgStateUpgrade(t *testing.T) {
+	t.Parallel()
+
+	name := acctest.RandomWithPrefix(testutils.Prefix)
+	// Config kept intentionally minimal: only required attributes plus
+	// version. Same config is used for all three steps so the only
+	// thing changing across steps is the provider binary.
+	config := fmt.Sprintf(`
+resource "exoscale_dbaas" "upgrade" {
+  name                   = %q
+  type                   = "pg"
+  plan                   = "hobbyist-2"
+  zone                   = %q
+  termination_protection = false
+  pg = {
+    version = "15"
+  }
+}
+`, name, testutils.TestZoneName)
+
+	resourceFullName := "exoscale_dbaas.upgrade"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testutils.AccPreCheck(t) },
+		CheckDestroy: CheckServiceDestroy("pg", name),
+		Steps: []resource.TestStep{
+			{
+				// Step 1: create with the last-released provider
+				// version. State is written in that version's
+				// format; it has no `integrations` attribute in the
+				// pg block schema at all.
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"exoscale": {
+						VersionConstraint: "= 0.68.0",
+						Source:            "exoscale/exoscale",
+					},
+				},
+				Config: config,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceFullName, "created_at"),
+					resource.TestCheckResourceAttr(resourceFullName, "name", name),
+				),
+			},
+			{
+				// Step 2: swap to the in-tree provider (which has
+				// the `integrations` attribute added). Refresh +
+				// plan must be a no-op — i.e. adding an optional
+				// nullable attribute does not cause drift on
+				// pre-existing state.
+				ProtoV6ProviderFactories: testutils.TestAccProtoV6ProviderFactories,
+				Config:                   config,
+				PlanOnly:                 true,
+				ExpectNonEmptyPlan:       false,
+			},
+			{
+				// Step 3: apply the same config under the in-tree
+				// provider. State is rewritten in the new format.
+				// Verify the new `integrations` attribute is
+				// absent (null) in the resulting state.
+				ProtoV6ProviderFactories: testutils.TestAccProtoV6ProviderFactories,
+				Config:                   config,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceFullName, "created_at"),
+					resource.TestCheckNoResourceAttr(resourceFullName, "pg.integrations.#"),
+				),
+			},
+		},
+	})
 }

--- a/pkg/resources/database/testdata/resource_mysql.tmpl
+++ b/pkg/resources/database/testdata/resource_mysql.tmpl
@@ -4,6 +4,14 @@ resource "exoscale_dbaas" {{ .ResourceName }} {
   plan = "{{ .Plan }}"
   zone = "{{ .Zone }}"
 
+  {{- if .DependsOn }}
+  depends_on = [
+  {{- range $k, $v := .DependsOn }}
+    {{ $v }},
+  {{- end }}
+  ]
+  {{- end }}
+
   {{- if .MaintenanceDow }}
   maintenance_dow = "{{ .MaintenanceDow }}"
   {{- end }}
@@ -39,6 +47,17 @@ resource "exoscale_dbaas" {{ .ResourceName }} {
 
     {{- if .Version }}
     version = "{{ .Version }}"
+    {{- end }}
+
+    {{- if .Integrations }}
+    integrations = [
+    {{- range $k, $v := .Integrations }}
+      {
+        type           = "{{ $v.Type }}"
+        source_service = {{ $v.SourceService }}
+      },
+    {{- end }}
+    ]
     {{- end }}
   }
 }

--- a/pkg/resources/database/testdata/resource_pg.tmpl
+++ b/pkg/resources/database/testdata/resource_pg.tmpl
@@ -4,6 +4,14 @@ resource "exoscale_dbaas" {{ .ResourceName }} {
   plan = "{{ .Plan }}"
   zone = "{{ .Zone }}"
 
+  {{- if .DependsOn }}
+  depends_on = [
+  {{- range $k, $v := .DependsOn }}
+    {{ $v }},
+  {{- end }}
+  ]
+  {{- end }}
+
   {{- if .MaintenanceDow }}
   maintenance_dow = "{{ .MaintenanceDow }}"
   {{- end }}
@@ -47,6 +55,17 @@ resource "exoscale_dbaas" {{ .ResourceName }} {
 
     {{- if .Version }}
     version = "{{ .Version }}"
+    {{- end }}
+
+    {{- if .Integrations }}
+    integrations = [
+    {{- range $k, $v := .Integrations }}
+      {
+        type           = "{{ $v.Type }}"
+        source_service = {{ $v.SourceService }}
+      },
+    {{- end }}
+    ]
     {{- end }}
   }
 }


### PR DESCRIPTION
## Summary

Adds an `integrations` SetNestedAttribute to the `pg` and `mysql` DBaaS service resources, allowing operators to declare read replicas at creation time.

Implements #511.

```hcl
resource "exoscale_dbaas" "replica" {
  name = "my-replica"
  type = "pg"
  plan = "startup-4"
  zone = "ch-gva-2"
  pg = {
    version = "15"
    integrations = [{
      type           = "read_replica"
      source_service = exoscale_dbaas.primary.name
    }]
  }
}
```

## Design

- **Schema**: `SetNestedAttribute` with two Required string children (`type`, `source_service`). Optional+Computed with custom `setUseStateForUnknown` and `setRequiresReplace` plan modifiers (the upstream `setplanmodifier` package is not vendored in this repo). `integrationsSelfSource` validator rejects configurations where `source_service` points at the declaring resource.
- **Create path**: Three-layer unknown-value defense (plan-time validators skip unknowns gracefully; create-time rejects whole-attribute-unknown by comparing plan vs config; per-element unknown/null values and semantic checks re-run after interpolations resolve). Orphan cleanup via defer+flag deletes the service if post-create steps fail.
- **Read path**: Only surfaces integrations where `integration.Dest` matches the current service, so a primary doesn't pick up replicas.
- **Update path**: Defensive no-op sync (RequiresReplace means Terraform never calls Update for integration changes).

## Additional fixes

- Fix pre-existing bug in `updateMysql` where `backup_schedule` parsing lacked `IsUnknown()` guards (unlike the pg equivalent), causing failures when Optional+Computed attributes are omitted from config during Update.

## Test coverage

| Test | Type | What it covers |
|---|---|---|
| `testResourcePgIntegrations` | Acceptance (live API) | Create replica, import, out-of-band delete detection, swap source (Replace), omit integrations (Update, not Replace) |
| `testResourceMysqlIntegrations` | Acceptance (live API) | Same lifecycle for mysql |
| `testResourcePgIntegrationsValidators` | Plan-only (zero API cost) | Empty set, bad type, self-source, multi-element |
| `testResourcePgIntegrationsUnknownSource` | Plan-only (zero API cost) | Unknown nested values don't break plan |
| `testResourcePgStateUpgrade` | Acceptance (live API) | v0.68.0 → current provider upgrade with no drift |

## Files changed

- `pkg/resources/database/planmodifiers.go` — new file: custom Set plan modifiers + self-source validator
- `pkg/resources/database/resource_service.go` — pass config to createPg/createMysql for unknown detection
- `pkg/resources/database/resource_service_pg.go` — schema, create/read/update integration handling
- `pkg/resources/database/resource_service_mysql.go` — same for mysql + backup_schedule fix
- `pkg/resources/database/resource_service_pg_test.go` — 5 new test functions
- `pkg/resources/database/resource_service_mysql_test.go` — mysql integration test
- `pkg/resources/database/main_test.go` — register new subtests
- `pkg/resources/database/testdata/resource_pg.tmpl` — template support for integrations + depends_on
- `pkg/resources/database/testdata/resource_mysql.tmpl` — same
- `docs/resources/database.md`, `docs/resources/dbaas.md` — regenerated
- `CHANGELOG.md`, `README.md` — feature entry + OpenTofu instructions