### PR TITLE
Drop windows/arm target

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,6 +23,8 @@ builds:
     ignore:
       - goos: darwin
         goarch: '386'
+      - goos: windows
+        goarch: arm
 
 archives:
   - formats: [ 'zip' ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+BREAKING CHANGES:
+
+- Drop windows/arm target #524
+
 ## 0.69.0
 
 IMPROVEMENTS:


### PR DESCRIPTION
# Description

Go 1.26 [dropped](https://go.dev/doc/go1.26#windows) `windows/arm` target so we will drop it as well.

Fixes a broken release 0.69.0.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [ ] Acceptance tests OK
* [ ] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing

<!--
Describe the tests you did
-->
