### PR TITLE
Fix SG resource schema version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ IMPROVEMENTS:
 
 - sks: add Kubelet Image GC update support for nodepools #506
 
+BUG FIXES:
+
+- Fix SG resource schema version #526
+
 ## 0.69.1
 
 BREAKING CHANGES:

--- a/pkg/resources/security_group/resource.go
+++ b/pkg/resources/security_group/resource.go
@@ -82,6 +82,7 @@ func (r *Resource) Schema(
 	resp.Schema = schema.Schema{
 		Description:         "Manage Security Groups",
 		MarkdownDescription: ResourceDescription,
+		Version:             1, // TODO: Port schema upgrade from SDKv2 (for going from 0.32.0 or older to 0.69.0+).
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description:         "security group ID",


### PR DESCRIPTION
# Description

Adds the correct schema version of `exoscale_security_group` resource.
Fixes #525 

Schema was already at [version 1](https://github.com/exoscale/terraform-provider-exoscale/blob/a62fe93007d3b24a7057d8913eb67c27501b5351/exoscale/resource_exoscale_security_group.go#L70), but was not specified when I migrated resource to the new library (reverting to 0).
I did not port the schema upgrader yet, version bump was done 4+ years ago so unlikely to be the issue.
It should be ported for the sake of completion.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [ ] Acceptance tests OK
* [ ] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing

```
> tofu plan
╷
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI configuration:
│  - exoscale/exoscale in /home/predrag/Workspace/exoscale/terraform-provider-exoscale
│ 
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵

Planning failed. OpenTofu encountered an error while generating this plan.
```

After change:
```
> tofu plan
╷
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI configuration:
│  - exoscale/exoscale in /home/predrag/Workspace/exoscale/terraform-provider-exoscale
│ 
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
exoscale_security_group.my_security_group: Refreshing state... [id=c36988fc-550a-41e7-8f5f-f50db9b18c14]

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
```
