### PR TITLE
fix(security-group-rule): allow portless protocols (ESP, AH, GRE, IPIP)

### DIFF
--- a/pkg/resources/security_group/resource_rule.go
+++ b/pkg/resources/security_group/resource_rule.go
@@ -420,21 +420,29 @@ func (r *ResourceRule) Create(
 		return
 	}
 
-	switch {
-	case !plan.StartPort.IsUnknown() && !plan.EndPort.IsUnknown():
-		ruleReq.StartPort = plan.StartPort.ValueInt64()
-		ruleReq.EndPort = plan.EndPort.ValueInt64()
-	case !plan.ICMPType.IsUnknown() && !plan.ICMPCode.IsUnknown():
-		ruleReq.ICMP = &exoscale.AddRuleToSecurityGroupRequestICMP{
-			Type: plan.ICMPType.ValueInt64Pointer(),
-			Code: plan.ICMPCode.ValueInt64Pointer(),
+	portlessProtocols := map[exoscale.AddRuleToSecurityGroupRequestProtocol]bool{
+		exoscale.AddRuleToSecurityGroupRequestProtocolAh:   true,
+		exoscale.AddRuleToSecurityGroupRequestProtocolEsp:  true,
+		exoscale.AddRuleToSecurityGroupRequestProtocolGre:  true,
+		exoscale.AddRuleToSecurityGroupRequestProtocolIpip: true,
+	}
+	if !portlessProtocols[ruleReq.Protocol] {
+		switch {
+		case !plan.StartPort.IsUnknown() && !plan.EndPort.IsUnknown():
+			ruleReq.StartPort = plan.StartPort.ValueInt64()
+			ruleReq.EndPort = plan.EndPort.ValueInt64()
+		case !plan.ICMPType.IsUnknown() && !plan.ICMPCode.IsUnknown():
+			ruleReq.ICMP = &exoscale.AddRuleToSecurityGroupRequestICMP{
+				Type: plan.ICMPType.ValueInt64Pointer(),
+				Code: plan.ICMPCode.ValueInt64Pointer(),
+			}
+		default:
+			resp.Diagnostics.AddError(
+				"missing required field",
+				"requires start_port/end_port or icmp_type/icmp_code",
+			)
+			return
 		}
-	default: // validation must prevent reaching here
-		resp.Diagnostics.AddError(
-			"missing required field",
-			"requires start_port/end_port or icmp_type/icmp_code",
-		)
-		return
 	}
 
 	op, err := r.client.AddRuleToSecurityGroup(


### PR DESCRIPTION
## Summary

Fixes #529

`ESP`, `AH`, `GRE`, and `IPIP` protocols do not use ports or ICMP codes. The resource required `start_port`/`end_port` or `icmp_type`/`icmp_code` for all protocols, rejecting portless rules with a misleading error.

## Tests

```
--- PASS: TestSecurityGroup (29.07s)
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/security_group    29.085s
```