### PR TITLE
fix(template): fall back to private visibility when name lookup returns not found

### DIFF
--- a/exoscale/datasource_exoscale_template.go
+++ b/exoscale/datasource_exoscale_template.go
@@ -2,6 +2,7 @@ package exoscale
 
 import (
 	"context"
+	"errors"
 	"regexp"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -92,10 +93,11 @@ func dataSourceTemplateRead(ctx context.Context, d *schema.ResourceData, meta in
 	var err error
 	if byTemplateID {
 		template, err = client.GetTemplate(ctx, zone, templateID.(string))
-
 	} else {
-
 		template, err = client.GetTemplateByName(ctx, zone, templateName.(string), visibility)
+		if err != nil && errors.Is(err, exoapi.ErrNotFound) && visibility == "public" {
+			template, err = client.GetTemplateByName(ctx, zone, templateName.(string), "private")
+		}
 	}
 
 	if err != nil {


### PR DESCRIPTION
## Summary

Fixes #523

When `visibility` defaults to `"public"`, the list API does not return user-registered (custom) templates even when those templates show `visibility = "public"` on the template object. Fetching by ID works fine since it bypasses the visibility filter.

When a name lookup under `"public"` returns not found, the datasource now falls back to searching `"private"` before returning an error.

## Tests

```
--- PASS: TestAccDataSourceTemplate (2.02s)
ok      github.com/exoscale/terraform-provider-exoscale/exoscale        2.038s
```