### PR TITLE
build: fix make build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ EXTRA_ARGS := -parallel=3 -count=1 -failfast
 go.mk/init.mk:
 include go.mk/init.mk
 
-GO_LD_FLAGS := "-s -w -X $(PACKAGE)/version.Version=${VERSION} \
+GO_LD_FLAGS := -ldflags "-s -w -X $(PACKAGE)/version.Version=${VERSION} \
 							-X $(PACKAGE)/version.Commit=${GIT_REVISION}"
 GO_BIN_OUTPUT_NAME = terraform-provider-exoscale_v$(VERSION)
 


### PR DESCRIPTION
Previously `make build` would fail with:
```sh
$ make build
mkdir -p '/home/ivan/Work/Exoscale/terraform-provider-exoscale/bin'
'/home/ivan/.local/share/mise/installs/go/1.26.2/bin/go' build \
  -v -trimpath \
  "-s -w -X github.com/exoscale/terraform-provider-exoscale/version.Version=dev -X github.com/exoscale/terraform-provider-exoscale/version.Commit=e550cce2" \
   \
  -o '/home/ivan/Work/Exoscale/terraform-provider-exoscale/bin/terraform-provider-exoscale_vdev' \
  '.'
flag provided but not defined: -s -w -X github.com/exoscale/terraform-provider-exoscale/version.Version
usage: go build [-o output] [build flags] [packages]
Run 'go help build' for details.
make: *** [/home/ivan/Work/Exoscale/terraform-provider-exoscale/go.mk/go.mk:75: build] Error 2
```

I.e. the `-ldflags` flag was not provided. This is with a fresh checkout of go.mk, so I'm not sure if this is a regression, or if it never worked. A [search][1] shows other projects passing `-ldflags`.

This seems like something go.mk should handle, since the var is already called `GO_LD_FLAGS`, but I'd rather not touch a shared project...

[1]: https://github.com/search?q=org%3Aexoscale%20GO_LD_FLAGS&type=code