### PR TITLE
fix(compute_instance): correctly update state if instance is manually removed

### DIFF
--- a/pkg/resources/instance/resource.go
+++ b/pkg/resources/instance/resource.go
@@ -498,12 +498,12 @@ func rRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.D
 	}
 
 	instance, err := clientV3.GetInstance(ctx, v3.UUID(d.Id()))
+	if errors.Is(err, v3.ErrNotFound) || instance.ID == "" {
+		// Resource doesn't exist anymore, signaling the core to remove it from the state.
+		d.SetId("")
+		return nil
+	}
 	if err != nil {
-		if errors.Is(err, v3.ErrNotFound) {
-			// Resource doesn't exist anymore, signaling the core to remove it from the state.
-			d.SetId("")
-			return nil
-		}
 		return diag.FromErr(err)
 	}
 


### PR DESCRIPTION

# Description
<!--
* Prefix: the title with the component name being changed. Add a short and self describing sentence to ease the review
* Please add a few lines providing context and describing the change
* Please self comment changes whenever applicable to help with the review process
* Please keep the checklist as part of the PR. Tick what applies to this change.
-->

Quick hotfix for [#534][1].

This should probably have a lower level fix instead, so opening it up for discussion.

[1]: https://github.com/exoscale/terraform-provider-exoscale/issues/534

## Checklist
(For exoscale contributors)

* [ ] Changelog updated (under *Unreleased* block)
* [ ] Acceptance tests OK
* [ ] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing

<!--
Describe the tests you did
-->

Manually confirmed the panic no longer happens after running `terraform apply`.