### PR TITLE
fix(instance): don't panic reading an instance destroyed out-of-band

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ IMPROVEMENTS:
 BUG FIXES:
 
 - Fix SG resource schema version #526
+- instance: don't panic when reading an instance destroyed out-of-band #534
 
 ## 0.69.1
 

--- a/pkg/resources/instance/resource.go
+++ b/pkg/resources/instance/resource.go
@@ -507,6 +507,16 @@ func rRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.D
 		return diag.FromErr(err)
 	}
 
+	// An instance deleted out-of-band keeps being returned by the API for a
+	// while in a terminal state before it starts answering 404. In that
+	// window most of its details (instance-type, template, ...) come back
+	// empty, so rApply would panic dereferencing them. Treat it as gone.
+	switch instance.State {
+	case v3.InstanceStateDestroying, v3.InstanceStateExpunging, v3.InstanceStateDestroyed:
+		d.SetId("")
+		return nil
+	}
+
 	tflog.Debug(ctx, "read finished successfully", map[string]interface{}{
 		"id": utils.IDString(d, Name),
 	})


### PR DESCRIPTION
## Summary

Fixes #534

When a compute instance gets deleted outside Terraform (CLI, portal, etc.) and you run `terraform apply` again, the provider panics with a nil pointer dereference in `rApply`:

```
panic: runtime error: invalid memory address or nil pointer dereference
	pkg/resources/instance/resource.go:1193
	pkg/resources/instance/resource.go:515 (rRead)
```

The API doesn't immediately 404 a deleted instance. For a while it keeps returning it in a terminal state (`destroying`, `expunging`, `destroyed`), and in that window `instance-type` and most other details come back empty. `rRead` only checks for `ErrNotFound`, so it falls through to `rApply`, which dereferences `instance.InstanceType.ID` and crashes.

`rRead` already does the right thing for a real 404 (clears the ID so core removes the resource from state). This just extends that to terminal-state instances, which are effectively gone too. After the fix the deleted instance is dropped from state and the next plan recreates it, no panic.

## Tests

The instance resource only has acceptance tests, and this path needs an instance to be deleted out-of-band mid-run, which isn't something the acceptance harness can set up. Verified the build and `go vet` locally. Happy to add coverage if you can point me at a good way to exercise it.