### PR TITLE
Resource compute_instance: clearify the default state value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+IMPROVEMENTS:
+
+- Resource compute_instance: clearify the default state value #538
+
 ## 0.69.3
 
 IMPROVEMENTS:

--- a/docs/resources/compute_instance.md
+++ b/docs/resources/compute_instance.md
@@ -65,7 +65,7 @@ directory for complete configuration examples.
 - `security_group_ids` (Set of String) A list of [exoscale_security_group](./security_group.md) (IDs) to attach to the instance.
 - `ssh_key` (String, Deprecated) ❗ The [exoscale_ssh_key](./ssh_key.md) (name) to authorize in the instance (may only be set at creation time).
 - `ssh_keys` (Set of String) ❗ The list of [exoscale_ssh_key](./ssh_key.md) (name) to authorize in the instance (may only be set at creation time).
-- `state` (String) The instance state (`running` or `stopped`; default: `running`).
+- `state` (String) The instance state (`running` or `stopped`). If omitted, instance will start and reach `running` state.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 - `user_data` (String) [cloud-init](https://cloudinit.readthedocs.io/) configuration.
 

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ import (
 	"github.com/exoscale/terraform-provider-exoscale/pkg/provider"
 )
 
-//go:generate terraform fmt -recursive ./examples/
+//go:generate ./scripts/fmt.sh
 
 //go:generate go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs
 

--- a/pkg/resources/instance/resource.go
+++ b/pkg/resources/instance/resource.go
@@ -177,7 +177,7 @@ func Resource() *schema.Resource {
 			Elem:        &schema.Schema{Type: schema.TypeString},
 		},
 		AttrState: {
-			Description: "The instance state (`running` or `stopped`; default: `running`).",
+			Description: "The instance state (`running` or `stopped`). If omitted, instance will start and reach `running` state.",
 			Type:        schema.TypeString,
 			Optional:    true,
 			Computed:    true,

--- a/scripts/fmt.sh
+++ b/scripts/fmt.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+
+set -euo pipefail
+
+if command -v tofu &> /dev/null
+then
+    tofu fmt -recursive ./examples/
+else
+    terraform fmt -recursive ./examples/
+fi

--- a/scripts/fmt.sh
+++ b/scripts/fmt.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env sh
 
-set -euo pipefail
-
 if command -v tofu &> /dev/null
 then
     tofu fmt -recursive ./examples/

--- a/scripts/fmt.sh
+++ b/scripts/fmt.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 if command -v tofu &> /dev/null
 then


### PR DESCRIPTION
# Description

As stated in https://github.com/exoscale/terraform-provider-exoscale/pull/475, `state` has no default value, from terraform POV at least. However API does default to starting instance. We clarify this in the documentation.

Additionally makes doc generator work with opentofu.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [ ] Acceptance tests OK
* [ ] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing

<!--
Describe the tests you did
-->
