### PR TITLE
feat: remove unused delay provider attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+IMPROVEMENTS:
+
+- Removed deprecated and unused `delay` provider attribute
+
 ## 0.69.2
 
 IMPROVEMENTS:

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,7 +47,6 @@ provider "exoscale" {
 
 ### Optional
 
-- `delay` (Number, Deprecated)
 - `environment` (String)
 - `key` (String) Exoscale API key
 - `secret` (String, Sensitive) Exoscale API secret

--- a/exoscale/provider.go
+++ b/exoscale/provider.go
@@ -76,11 +76,6 @@ func Provider() *schema.Provider {
 					"Timeout in seconds for waiting on compute resources to become available (by default: %.0f)",
 					config.DefaultTimeout.Seconds()),
 			},
-			"delay": {
-				Type:       schema.TypeInt,
-				Optional:   true,
-				Deprecated: "Does nothing",
-			},
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -41,7 +41,6 @@ const (
 	EnvironmentAttrName = "environment"
 	SOSEndpointAttrName = "sos_endpoint"
 	TimeoutAttrName     = "timeout"
-	DelayAttrName       = "delay"
 )
 
 var _ provider.Provider = &ExoscaleProvider{}
@@ -53,7 +52,6 @@ type ExoscaleProviderModel struct {
 	Secret      types.String  `tfsdk:"secret"`
 	Environment types.String  `tfsdk:"environment"`
 	Timeout     types.Float64 `tfsdk:"timeout"`
-	Delay       types.Int64   `tfsdk:"delay"`
 	SOSEndpoint types.String  `tfsdk:"sos_endpoint"`
 }
 
@@ -84,10 +82,6 @@ func (p *ExoscaleProvider) Schema(ctx context.Context, req provider.SchemaReques
 				MarkdownDescription: fmt.Sprintf(
 					"Timeout in seconds for waiting on compute resources to become available (by default: %.0f)",
 					config.DefaultTimeout.Seconds()),
-			},
-			DelayAttrName: schema.Int64Attribute{
-				Optional:           true,
-				DeprecationMessage: "Does nothing",
 			},
 		},
 	}


### PR DESCRIPTION
# Description
<!--
* Prefix: the title with the component name being changed. Add a short and self describing sentence to ease the review
* Please add a few lines providing context and describing the change
* Please self comment changes whenever applicable to help with the review process
* Please keep the checklist as part of the PR. Tick what applies to this change.
-->

This attribute was [deprecated in 2018][1].

[1]: https://github.com/exoscale/terraform-provider-exoscale/commit/9598dab209f77f0a6cbe84b9d0c62c165e0612c5

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [ ] Acceptance tests OK (see below) 
* [ ] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing

`make test` passed.

`make test-acc` fails due to quota limits on my account:
<details>
  <summary>Expand</summary>
  
```
...
=== CONT  TestAccDataSourceDomain
    datasource_exoscale_domain_test.go:18: Step 1/1 error: Error running apply: exit status 1

        Error: unable to create domain: CreateDNSDomain: http response: Bad Request: DNS subscription limit reached

          with exoscale_domain.exo,
          on terraform_plugin_test.tf line 12, in resource "exoscale_domain" "exo":
          12: resource "exoscale_domain" "exo" {

--- FAIL: TestAccDataSourceDomain (0.74s)
=== CONT  TestAccResourceDomain
    resource_exoscale_domain_test.go:98: Step 1/2 error: Error running apply: exit status 1

        Error: unable to create domain: CreateDNSDomain: http response: Bad Request: DNS subscription limit reached

          with exoscale_domain.exo,
          on terraform_plugin_test.tf line 12, in resource "exoscale_domain" "exo":
          12: resource "exoscale_domain" "exo" {

--- FAIL: TestAccResourceDomain (0.76s)
=== CONT  TestAccResourceDomainIDN
    resource_exoscale_domain_test.go:138: Step 1/2 error: Error running apply: exit status 1

        Error: unable to create domain: CreateDNSDomain: http response: Bad Request: DNS subscription limit reached

          with exoscale_domain.idn,
          on terraform_plugin_test.tf line 12, in resource "exoscale_domain" "idn":
          12: resource "exoscale_domain" "idn" {

--- FAIL: TestAccResourceDomainIDN (0.73s)

...

=== NAME  TestAntiAffinityGroup/DataSource
    datasource_test.go:23: Step 4/4 error: Error running apply: exit status 1

        Error: CreateInstance: http response: Conflict: Usage of resource 'instance' has been exceeded.

          with exoscale_compute_instance.test,
          on terraform_plugin_test.tf line 25, in resource "exoscale_compute_instance" "test":
          25: resource "exoscale_compute_instance" "test" {

--- FAIL: TestAntiAffinityGroup (0.00s)
    --- PASS: TestAntiAffinityGroup/Resource (11.15s)
    --- FAIL: TestAntiAffinityGroup/DataSource (14.34s)
FAIL
FAIL	github.com/exoscale/terraform-provider-exoscale/pkg/resources/anti_affinity_group	14.373s
=== RUN   TestBlockStorage
=== PAUSE TestBlockStorage
=== CONT  TestBlockStorage
    main_test.go:28: Step 8/17 error: Error running apply: exit status 1

        Error: CreateInstance: http response: Conflict: Usage of resource 'instance' has been exceeded.

          with exoscale_compute_instance.test_instance,
          on terraform_plugin_test.tf line 20, in resource "exoscale_compute_instance" "test_instance":
          20: resource "exoscale_compute_instance" "test_instance" {

--- FAIL: TestBlockStorage (26.11s)

...

=== CONT  TestInstancePool/Resource
    resource_test.go:166: Step 1/3 error: Error running apply: exit status 1

        Error: CreateInstancePool: http response: Conflict: Usage of resource 'instance' has been exceeded.

          with exoscale_instance_pool.test,
          on terraform_plugin_test.tf line 29, in resource "exoscale_instance_pool" "test":
          29: resource "exoscale_instance_pool" "test" {

=== NAME  TestInstancePool/DataSource
    datasource_test.go:36: Step 2/2 error: Error running apply: exit status 1

        Error: CreateInstancePool: http response: Conflict: Usage of resource 'instance' has been exceeded.

          with exoscale_instance_pool.test,
          on terraform_plugin_test.tf line 35, in resource "exoscale_instance_pool" "test":
          35: resource "exoscale_instance_pool" "test" {

--- FAIL: TestInstancePool (0.00s)
    --- FAIL: TestInstancePool/DataSource (10.38s)
    --- FAIL: TestInstancePool/Resource (10.55s)
    --- PASS: TestInstancePool/DataSourceList (63.60s)
FAIL
FAIL	github.com/exoscale/terraform-provider-exoscale/pkg/resources/instance_pool	63.630s
=== RUN   TestNlbService
=== PAUSE TestNlbService
=== CONT  TestNlbService
=== RUN   TestNlbService/DataSourceList
=== PAUSE TestNlbService/DataSourceList
=== CONT  TestNlbService/DataSourceList
    datasource_list_test.go:156: Step 1/2 error: Error running apply: exit status 1

        Error: CreateInstancePool: http response: Conflict: Usage of resource 'instance' has been exceeded.

          with exoscale_instance_pool.test,
          on terraform_plugin_test.tf line 17, in resource "exoscale_instance_pool" "test":
          17: resource "exoscale_instance_pool" "test" {

    panic.go:694: Error running post-test destroy, there may be dangling resources: exit status 1

        Error: job failed

--- FAIL: TestNlbService (0.00s)
    --- FAIL: TestNlbService/DataSourceList (9.04s)
FAIL
FAIL	github.com/exoscale/terraform-provider-exoscale/pkg/resources/nlb_service	9.096s
FAIL
make: *** [Makefile:51: test-acc] Error 1
```

</details>
