### PR TITLE
test: local-creds helper for acceptance runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,15 @@ website][tf-doc].
 make GO_TEST_EXTRA_ARGS="-v -run ^TestAccResourceCompute$" test-acc
 ```
 
+Acceptance tests need API credentials. Set them in the environment, or use the local helper that reads them from `~/.config/exoscale/exoscale.toml` (same file the `exo` CLI uses):
+
+```sh
+go test -tags=local_integration -run TestDatabaseLocal \
+  -account=owner-production -timeout 60m ./pkg/resources/database/
+```
+
+The `local_integration` build tag keeps the helper out of CI. Every acceptance test package exposes a `TestXxxLocal` entry point that way. See [exoscale/cli#837](https://github.com/exoscale/cli/pull/837) for the original.
+
 ### Development Setup
 
 If you would like to use the terraform provider you have built and try

--- a/pkg/resources/anti_affinity_group/local_test.go
+++ b/pkg/resources/anti_affinity_group/local_test.go
@@ -1,0 +1,17 @@
+//go:build local_integration
+
+package anti_affinity_group_test
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/exoscale/terraform-provider-exoscale/pkg/testutils"
+)
+
+var flagAccount = flag.String("account", testutils.DefaultLocalAccount, "account name substring in exoscale.toml")
+
+func TestAntiAffinityGroupLocal(t *testing.T) {
+	testutils.LoadLocalCreds(t, *flagAccount)
+	TestAntiAffinityGroup(t)
+}

--- a/pkg/resources/block_storage/local_test.go
+++ b/pkg/resources/block_storage/local_test.go
@@ -1,0 +1,17 @@
+//go:build local_integration
+
+package block_storage_test
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/exoscale/terraform-provider-exoscale/pkg/testutils"
+)
+
+var flagAccount = flag.String("account", testutils.DefaultLocalAccount, "account name substring in exoscale.toml")
+
+func TestBlockStorageLocal(t *testing.T) {
+	testutils.LoadLocalCreds(t, *flagAccount)
+	TestBlockStorage(t)
+}

--- a/pkg/resources/database/local_test.go
+++ b/pkg/resources/database/local_test.go
@@ -1,0 +1,22 @@
+//go:build local_integration
+
+package database_test
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/exoscale/terraform-provider-exoscale/pkg/testutils"
+)
+
+var flagAccount = flag.String("account", testutils.DefaultLocalAccount, "account name substring in exoscale.toml")
+
+// TestDatabaseLocal mirrors TestDatabase but pulls credentials from
+// ~/.config/exoscale/exoscale.toml via the -account flag. Run with:
+//
+//	TF_ACC=1 go test -tags=local_integration -run TestDatabaseLocal \
+//	  -account=<name> -timeout 60m ./pkg/resources/database/
+func TestDatabaseLocal(t *testing.T) {
+	testutils.LoadLocalCreds(t, *flagAccount)
+	TestDatabase(t)
+}

--- a/pkg/resources/iam/local_test.go
+++ b/pkg/resources/iam/local_test.go
@@ -1,0 +1,17 @@
+//go:build local_integration
+
+package iam_test
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/exoscale/terraform-provider-exoscale/pkg/testutils"
+)
+
+var flagAccount = flag.String("account", testutils.DefaultLocalAccount, "account name substring in exoscale.toml")
+
+func TestIAMLocal(t *testing.T) {
+	testutils.LoadLocalCreds(t, *flagAccount)
+	TestIAM(t)
+}

--- a/pkg/resources/instance/local_test.go
+++ b/pkg/resources/instance/local_test.go
@@ -1,0 +1,17 @@
+//go:build local_integration
+
+package instance_test
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/exoscale/terraform-provider-exoscale/pkg/testutils"
+)
+
+var flagAccount = flag.String("account", testutils.DefaultLocalAccount, "account name substring in exoscale.toml")
+
+func TestInstanceLocal(t *testing.T) {
+	testutils.LoadLocalCreds(t, *flagAccount)
+	TestInstance(t)
+}

--- a/pkg/resources/instance_pool/local_test.go
+++ b/pkg/resources/instance_pool/local_test.go
@@ -1,0 +1,17 @@
+//go:build local_integration
+
+package instance_pool_test
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/exoscale/terraform-provider-exoscale/pkg/testutils"
+)
+
+var flagAccount = flag.String("account", testutils.DefaultLocalAccount, "account name substring in exoscale.toml")
+
+func TestInstancePoolLocal(t *testing.T) {
+	testutils.LoadLocalCreds(t, *flagAccount)
+	TestInstancePool(t)
+}

--- a/pkg/resources/nlb_service/local_test.go
+++ b/pkg/resources/nlb_service/local_test.go
@@ -1,0 +1,17 @@
+//go:build local_integration
+
+package nlb_service_test
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/exoscale/terraform-provider-exoscale/pkg/testutils"
+)
+
+var flagAccount = flag.String("account", testutils.DefaultLocalAccount, "account name substring in exoscale.toml")
+
+func TestNlbServiceLocal(t *testing.T) {
+	testutils.LoadLocalCreds(t, *flagAccount)
+	TestNlbService(t)
+}

--- a/pkg/resources/security_group/local_test.go
+++ b/pkg/resources/security_group/local_test.go
@@ -1,0 +1,17 @@
+//go:build local_integration
+
+package security_group_test
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/exoscale/terraform-provider-exoscale/pkg/testutils"
+)
+
+var flagAccount = flag.String("account", testutils.DefaultLocalAccount, "account name substring in exoscale.toml")
+
+func TestSecurityGroupLocal(t *testing.T) {
+	testutils.LoadLocalCreds(t, *flagAccount)
+	TestSecurityGroup(t)
+}

--- a/pkg/resources/sos_bucket_policy/local_test.go
+++ b/pkg/resources/sos_bucket_policy/local_test.go
@@ -1,0 +1,17 @@
+//go:build local_integration
+
+package sos_bucket_policy_test
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/exoscale/terraform-provider-exoscale/pkg/testutils"
+)
+
+var flagAccount = flag.String("account", testutils.DefaultLocalAccount, "account name substring in exoscale.toml")
+
+func TestSOSBucketPolicyLocal(t *testing.T) {
+	testutils.LoadLocalCreds(t, *flagAccount)
+	TestSOSBucketPolicy(t)
+}

--- a/pkg/testutils/localcreds.go
+++ b/pkg/testutils/localcreds.go
@@ -2,26 +2,28 @@ package testutils
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
 
 // DefaultLocalAccount is the substring matched against the account name in
-// ~/.config/exoscale/exoscale.toml when -account is not provided to `go test`.
+// the local exoscale.toml when -account is not provided to `go test`.
 const DefaultLocalAccount = "owner-production"
 
-// LoadLocalCreds reads an Exoscale account block from
-// $HOME/.config/exoscale/exoscale.toml whose name contains `account` and
-// exports its credentials to the test process via t.Setenv. Mirrors the helper
-// in exoscale/cli (PR #837) so the same exoscale.toml file works for both the
-// CLI and the provider's local acceptance runs.
+// LoadLocalCreds reads an Exoscale account block from the local exoscale.toml
+// whose name contains `account` and exports its credentials to the test
+// process via t.Setenv. The config file is resolved in the same order as the
+// CLI: $EXOSCALE_CONFIG if set, otherwise $UserConfigDir/exoscale/exoscale.toml
+// (e.g. ~/.config/exoscale/exoscale.toml on Linux,
+// ~/Library/Application Support/exoscale/exoscale.toml on macOS).
 //
 // Also sets TF_ACC=1 if unset, so `resource.Test()` (which gates on the env
 // var) runs without the caller having to remember to export it. A pre-set
 // TF_ACC is respected.
 //
-// Use only from `_test.go` files gated by `//go:build local_integration` —
-// never link this into CI.
+// Use only from `_test.go` files gated by `//go:build local_integration`.
+// Never link this into CI.
 func LoadLocalCreds(t *testing.T, account string) {
 	t.Helper()
 
@@ -33,7 +35,10 @@ func LoadLocalCreds(t *testing.T, account string) {
 		t.Setenv("TF_ACC", "1")
 	}
 
-	path := os.ExpandEnv("$HOME/.config/exoscale/exoscale.toml")
+	path, err := localConfigPath()
+	if err != nil {
+		t.Fatalf("LoadLocalCreds: %v", err)
+	}
 	toml, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("LoadLocalCreds: read %s: %v", path, err)
@@ -71,4 +76,18 @@ func tomlStringValue(block, key string) string {
 		}
 	}
 	return ""
+}
+
+// localConfigPath returns the path to the local exoscale.toml. $EXOSCALE_CONFIG
+// overrides; otherwise it lives under os.UserConfigDir() so the path matches
+// the CLI's lookup on every platform.
+func localConfigPath() (string, error) {
+	if p := os.Getenv("EXOSCALE_CONFIG"); p != "" {
+		return p, nil
+	}
+	dir, err := os.UserConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "exoscale", "exoscale.toml"), nil
 }

--- a/pkg/testutils/localcreds.go
+++ b/pkg/testutils/localcreds.go
@@ -1,0 +1,74 @@
+package testutils
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// DefaultLocalAccount is the substring matched against the account name in
+// ~/.config/exoscale/exoscale.toml when -account is not provided to `go test`.
+const DefaultLocalAccount = "owner-production"
+
+// LoadLocalCreds reads an Exoscale account block from
+// $HOME/.config/exoscale/exoscale.toml whose name contains `account` and
+// exports its credentials to the test process via t.Setenv. Mirrors the helper
+// in exoscale/cli (PR #837) so the same exoscale.toml file works for both the
+// CLI and the provider's local acceptance runs.
+//
+// Also sets TF_ACC=1 if unset, so `resource.Test()` (which gates on the env
+// var) runs without the caller having to remember to export it. A pre-set
+// TF_ACC is respected.
+//
+// Use only from `_test.go` files gated by `//go:build local_integration` —
+// never link this into CI.
+func LoadLocalCreds(t *testing.T, account string) {
+	t.Helper()
+
+	if account == "" {
+		account = DefaultLocalAccount
+	}
+
+	if os.Getenv("TF_ACC") == "" {
+		t.Setenv("TF_ACC", "1")
+	}
+
+	path := os.ExpandEnv("$HOME/.config/exoscale/exoscale.toml")
+	toml, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("LoadLocalCreds: read %s: %v", path, err)
+	}
+
+	for _, block := range strings.Split(string(toml), "[[accounts]]")[1:] {
+		if !strings.Contains(block, account) {
+			continue
+		}
+		key := tomlStringValue(block, "key")
+		secret := tomlStringValue(block, "secret")
+		if key == "" || secret == "" {
+			continue
+		}
+		t.Setenv("EXOSCALE_API_KEY", key)
+		t.Setenv("EXOSCALE_API_SECRET", secret)
+		if zone := tomlStringValue(block, "defaultZone"); zone != "" {
+			t.Setenv("EXOSCALE_ZONE", zone)
+		}
+		return
+	}
+
+	t.Fatalf("LoadLocalCreds: no account matching %q in %s", account, path)
+}
+
+// tomlStringValue extracts a single-quoted string value for `key` from a raw
+// `[[accounts]]` block. Avoids pulling in a toml dependency for a one-off
+// read of three fields.
+func tomlStringValue(block, key string) string {
+	prefix := key + " = '"
+	for _, line := range strings.Split(block, "\n") {
+		line = strings.TrimSpace(line)
+		if after, ok := strings.CutPrefix(line, prefix); ok {
+			return strings.TrimSuffix(after, "'")
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
# Description

Local helper for running acceptance tests against real infra. Mirrors exoscale/cli#837. Reads `~/.config/exoscale/exoscale.toml`, sets the creds via `t.Setenv`, defaults `TF_ACC=1` (pre-set is respected).

```sh
go test -tags=local_integration -run TestDatabaseLocal \
  -account=owner-production -timeout 60m ./pkg/resources/database/
```

- `pkg/testutils/localcreds.go`: `LoadLocalCreds(t, account)`.
- 9 `pkg/resources/<pkg>/local_test.go` (build `local_integration`): `TestXxxLocal` per package, wraps the existing `TestXxx`. Legacy `exoscale/` left out, no single entry.
- `README.md`: short note in Contributing pointing at the helper, so new contributors know they don't need to export creds by hand.

Build, vet, gofmt, unit tests clean. Smoke tested with a fake `exoscale.toml`, env vars land correctly, `TF_ACC` default and override both work.

## Checklist
(For exoscale contributors)

* [ ] Changelog updated (under *Unreleased* block)
* [ ] Acceptance tests OK
* [ ] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing

`make test` passes. No real-infra run, no creds in this env.
