### PR TITLE
fix(block_storage): handle BS volume deletion in instance update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ IMPROVEMENTS:
 
 - Removed deprecated and unused `delay` provider attribute #539
 
+BUG FIXES:
+
+- Block storage: handle BS volume deletion in instance update #546
+
 DEPENDENCIES:
 
 - upgraded `golang/x/net` and related dependencies #540

--- a/pkg/resources/block_storage/main_test.go
+++ b/pkg/resources/block_storage/main_test.go
@@ -1,6 +1,8 @@
 package block_storage_test
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -8,7 +10,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
+	egoscale "github.com/exoscale/egoscale/v3"
 	"github.com/exoscale/terraform-provider-exoscale/pkg/testutils"
+	"github.com/exoscale/terraform-provider-exoscale/pkg/utils"
 )
 
 func TestBlockStorage(t *testing.T) {
@@ -342,4 +346,99 @@ func TestBlockStorage(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestBlockStorageDeleteAndDetach(t *testing.T) {
+	t.Parallel()
+
+	volumeResourceName := "exoscale_block_storage_volume.test_volume"
+	volumeDataSourceName := "data." + volumeResourceName
+	var volumeID string
+
+	testdataSpec := testutils.TestdataSpec{
+		ID:   time.Now().UnixNano(),
+		Zone: testutils.TestZoneName,
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testutils.AccPreCheck(t) },
+		ProtoV6ProviderFactories: testutils.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckBlockStorageVolumeDestroy(testdataSpec.Zone, &volumeID),
+		Steps: []resource.TestStep{
+			// 1 Create instance
+			{
+				Config: testutils.ParseTestdataConfig("./testdata/001.instance_create.tf.tmpl", &testdataSpec),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"exoscale_compute_instance.test_instance",
+						"name",
+						fmt.Sprintf("terraform-provider-test-%d", testdataSpec.ID),
+					),
+				),
+			},
+			// 2 Create and attach volume
+			{
+				Config: testutils.ParseTestdataConfig("./testdata/002.volume_create_attach.tf.tmpl", &testdataSpec),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrWith(volumeResourceName, "id", func(v string) error {
+						volumeID = v
+						return nil
+					}),
+					resource.TestCheckResourceAttr(
+						volumeResourceName,
+						"name",
+						fmt.Sprintf("terraform-provider-test-%d", testdataSpec.ID),
+					),
+					resource.TestCheckResourceAttr("exoscale_compute_instance.test_instance", "block_storage_volume_ids.#", "1"),
+					resource.TestCheckResourceAttr(volumeDataSourceName, "instance.%", "1"),
+					resource.TestCheckResourceAttrSet(volumeResourceName, "created_at"),
+					resource.TestCheckResourceAttrSet(volumeResourceName, "blocksize"),
+					resource.TestCheckResourceAttr(volumeDataSourceName, "size", "20"),
+					resource.TestCheckResourceAttr(volumeResourceName, "labels.%", "1"),
+					resource.TestCheckResourceAttr(volumeResourceName, "labels.foo1", "bar1"),
+					resource.TestCheckResourceAttr(volumeDataSourceName, "labels.%", "1"),
+					resource.TestCheckResourceAttr(volumeDataSourceName, "labels.foo1", "bar1"),
+					resource.TestCheckResourceAttrSet(volumeDataSourceName, "created_at"),
+					resource.TestCheckResourceAttrSet(volumeDataSourceName, "blocksize"),
+					resource.TestCheckResourceAttr(volumeDataSourceName, "state", "attached"),
+				),
+			},
+			// 3 Detach and delete volume, crucially, in the same step
+			{
+				Config: testutils.ParseTestdataConfig("./testdata/003.volume_detach_delete.tf.tmpl", &testdataSpec),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("exoscale_compute_instance.test_instance", "block_storage_volume_ids.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckBlockStorageVolumeDestroy(zone string, volumeID *string) resource.TestCheckFunc {
+	return func(_ *terraform.State) error {
+		if volumeID == nil || *volumeID == "" {
+			return errors.New("volume ID was not captured during the test")
+		}
+
+		defaultClient, err := testutils.APIClientV3()
+		if err != nil {
+			return fmt.Errorf("unable to initialize Exoscale client: %w", err)
+		}
+
+		ctx := context.Background()
+		client, err := utils.SwitchClientZone(ctx, defaultClient, egoscale.ZoneName(zone))
+		if err != nil {
+			return fmt.Errorf("unable to initialize Exoscale client: %w", err)
+		}
+
+		_, err = client.GetBlockStorageVolume(ctx, egoscale.UUID(*volumeID))
+		if err != nil {
+			if errors.Is(err, egoscale.ErrNotFound) {
+				return nil
+			}
+			return err
+		}
+
+		return errors.New("block storage volume still exists")
+	}
 }

--- a/pkg/resources/block_storage/main_test.go
+++ b/pkg/resources/block_storage/main_test.go
@@ -22,7 +22,7 @@ func TestBlockStorage(t *testing.T) {
 
 	testdataSpec := testutils.TestdataSpec{
 		ID:   time.Now().UnixNano(),
-		Zone: "at-vie-1", // to be replaced by global testutils.TestZoneName when BS reaches GA.
+		Zone: testutils.TestZoneName,
 	}
 
 	resource.Test(t, resource.TestCase{

--- a/pkg/resources/block_storage/testdata/001.instance_create.tf.tmpl
+++ b/pkg/resources/block_storage/testdata/001.instance_create.tf.tmpl
@@ -1,0 +1,19 @@
+data "exoscale_template" "test_template" {
+  zone = "{{ .Zone }}"
+  name = "Linux Ubuntu 22.04 LTS 64-bit"
+}
+
+data "exoscale_security_group" "default" {
+  name = "default"
+}
+
+resource "exoscale_compute_instance" "test_instance" {
+  zone = "{{ .Zone }}"
+  name = "terraform-provider-test-{{ .ID }}"
+
+  template_id = data.exoscale_template.test_template.id
+  type        = "standard.small"
+  disk_size   = 10
+
+  security_group_ids = [data.exoscale_security_group.default.id]
+}

--- a/pkg/resources/block_storage/testdata/002.volume_create_attach.tf.tmpl
+++ b/pkg/resources/block_storage/testdata/002.volume_create_attach.tf.tmpl
@@ -1,0 +1,40 @@
+data "exoscale_template" "test_template" {
+  zone = "{{ .Zone }}"
+  name = "Linux Ubuntu 22.04 LTS 64-bit"
+}
+
+data "exoscale_security_group" "default" {
+  name = "default"
+}
+
+resource "exoscale_compute_instance" "test_instance" {
+  zone = "{{ .Zone }}"
+  name = "terraform-provider-test-{{ .ID }}"
+
+  template_id = data.exoscale_template.test_template.id
+  type        = "standard.small"
+  disk_size   = 10
+
+  block_storage_volume_ids = [
+    exoscale_block_storage_volume.test_volume.id,
+  ]
+
+  security_group_ids = [data.exoscale_security_group.default.id]
+}
+
+resource "exoscale_block_storage_volume" "test_volume" {
+  name = "terraform-provider-test-{{ .ID }}"
+  labels = {
+    foo1 = "bar1"
+  }
+  size = 20
+  zone = "{{ .Zone }}"
+}
+
+data "exoscale_block_storage_volume" "test_volume" {
+  zone = "{{ .Zone }}"
+  id = exoscale_block_storage_volume.test_volume.id
+
+  # otherwise datasource will execute first and instance will be empty
+  depends_on = [exoscale_compute_instance.test_instance]
+}

--- a/pkg/resources/block_storage/testdata/003.volume_detach_delete.tf.tmpl
+++ b/pkg/resources/block_storage/testdata/003.volume_detach_delete.tf.tmpl
@@ -1,0 +1,21 @@
+data "exoscale_template" "test_template" {
+  zone = "{{ .Zone }}"
+  name = "Linux Ubuntu 22.04 LTS 64-bit"
+}
+
+data "exoscale_security_group" "default" {
+  name = "default"
+}
+
+resource "exoscale_compute_instance" "test_instance" {
+  zone = "{{ .Zone }}"
+  name = "terraform-provider-test-{{ .ID }}"
+
+  template_id = data.exoscale_template.test_template.id
+  type        = "standard.small"
+  disk_size   = 10
+
+  block_storage_volume_ids = []
+
+  security_group_ids = [data.exoscale_security_group.default.id]
+}

--- a/pkg/resources/instance/resource.go
+++ b/pkg/resources/instance/resource.go
@@ -656,6 +656,13 @@ func rUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag
 					bid,
 				)
 				if err != nil {
+					// The volume was likely already deleted as part of its regular
+					// deletion process.
+					if errors.Is(err, v3.ErrNotFound) {
+						tflog.Info(ctx, "volume not found")
+						continue
+					}
+
 					// Ideally we would have a custom error defined in OpenAPI spec & egoscale.
 					// For now we just check the error text.
 					if strings.HasSuffix(err.Error(), "Volume not attached") {


### PR DESCRIPTION
# Description
<!--
* Prefix: the title with the component name being changed. Add a short and self describing sentence to ease the review
* Please add a few lines providing context and describing the change
* Please self comment changes whenever applicable to help with the review process
* Please keep the checklist as part of the PR. Tick what applies to this change.
-->

Previously, if a block storage volume was deleted and detached at the same time, the detachment attempt during instance update would fail with:
```
Error: failed to detach block storage: DetachBlockStorageVolume: http response: Not Found: Blockstorage Volume not found
```

This is because the BS volume was already deleted in `ResourceVolume.Delete`.

The error was harmless since the volume would be deleted and detached anyways, and a subsequent `apply` would succeed, but it interrupted the process, and would cause confusion.

The fix simply checks for `v3.ErrNotFound`, allowing the instance update to continue.

Fixes internal support ticket 1167622

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [ ] Acceptance tests OK [test passes in isolation]
* [ ] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing

<!--
Describe the tests you did
-->

1. Run the new acceptance test without the fix: produces the error, and the test fails.

2. Apply the fix.

3. Run the new acceptance test with fix applied: no error, and the test passes.