### PR TITLE
chore(release): add unreleased changelog entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ DEPENDENCIES:
 
 FEATURES:
 
-- feat(dbaas): add exoscale_dbaas_valkey_user resource #528
+- `dbaas`: add exoscale_dbaas_valkey_user resource #528
 
 ## 0.69.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ IMPROVEMENTS:
 
 BUG FIXES:
 
-- Block storage: handle BS volume deletion in instance update #546
+- `block_storage_volume`: handle BS volume deletion in instance update #546
 - `compute_instance`: suppress user_data diffs for pre-encoded input #518
 - `security_group_rule`: allow portless protocols (ESP, AH, GRE, IPIP) #531
 - `template`: fall back to private visibility when name lookup returns not found #532

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@ IMPROVEMENTS:
 BUG FIXES:
 
 - Block storage: handle BS volume deletion in instance update #546
-- fix(compute_instance): suppress user_data diffs for pre-encoded input #518
-- fix(security-group-rule): allow portless protocols (ESP, AH, GRE, IPIP) #531
-- fix(template): fall back to private visibility when name lookup returns not found #532
+- `compute_instance`: suppress user_data diffs for pre-encoded input #518
+- `security_group_rule`: allow portless protocols (ESP, AH, GRE, IPIP) #531
+- `template`: fall back to private visibility when name lookup returns not found #532
 
 DEPENDENCIES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 IMPROVEMENTS:
 
 - Removed deprecated and unused `delay` provider attribute #539
-- test: local-creds helper for acceptance runs #545
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,22 @@
 IMPROVEMENTS:
 
 - Removed deprecated and unused `delay` provider attribute #539
+- test: local-creds helper for acceptance runs #545
 
 BUG FIXES:
 
 - Block storage: handle BS volume deletion in instance update #546
+- fix(compute_instance): suppress user_data diffs for pre-encoded input #518
+- fix(security-group-rule): allow portless protocols (ESP, AH, GRE, IPIP) #531
+- fix(template): fall back to private visibility when name lookup returns not found #532
 
 DEPENDENCIES:
 
 - upgraded `golang/x/net` and related dependencies #540
+
+FEATURES:
+
+- feat(dbaas): add exoscale_dbaas_valkey_user resource #528
 
 ## 0.69.2
 


### PR DESCRIPTION
## Summary

Backfill the `Unreleased` block in `CHANGELOG.md` with natalie's PRs merged since v0.69.2 (2026-05-05) that were missing.

## Related issue

None.

## Changes

Add the following to the existing `## Unreleased` block in `CHANGELOG.md`:

### IMPROVEMENTS
- test: local-creds helper for acceptance runs #545

### BUG FIXES
- fix(compute_instance): suppress user_data diffs for pre-encoded input #518
- fix(security-group-rule): allow portless protocols (ESP, AH, GRE, IPIP) #531
- fix(template): fall back to private visibility when name lookup returns not found #532

### FEATURES
- feat(dbaas): add exoscale_dbaas_valkey_user resource #528

## Checklist

* [x] Changelog updated (under *Unreleased* block)
* [ ] Acceptance tests OK (not applicable, docs only)

## Notes for reviewers

Entries for other merged PRs since 0.69.2 (#533 by @imiric) are missing. Not added here per scope; left for the relevant author or release manager.