### PR TITLE
fix: tolerate missing instance during detach

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ BUG FIXES:
 - `compute_instance`: suppress user_data diffs for pre-encoded input #518
 - `security_group_rule`: allow portless protocols (ESP, AH, GRE, IPIP) #531
 - `template`: fall back to private visibility when name lookup returns not found #532
+- `elastic_ip`: tolerate missing instance during detach #549
 
 DEPENDENCIES:
 

--- a/exoscale/util.go
+++ b/exoscale/util.go
@@ -2,6 +2,7 @@ package exoscale
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"regexp"
@@ -192,7 +193,6 @@ func detachMatchingResource(
 	match func(*v3.Instance, v3.UUID) bool,
 	detach func(ctx context.Context, client *v3.Client, id v3.UUID, instance *v3.Instance) (*v3.Operation, error),
 ) diag.Diagnostics {
-
 	listInstancesResponse, err := client.ListInstances(ctx)
 	if err != nil {
 		return diag.FromErr(err)
@@ -201,6 +201,11 @@ func detachMatchingResource(
 	for _, listInst := range listInstancesResponse.Instances {
 		inst, err := client.GetInstance(ctx, listInst.ID)
 		if err != nil {
+			if errors.Is(err, v3.ErrNotFound) {
+				// The instance was removed between the ListInstance and GetInstance
+				// calls, so we can consider any resources to be detached.
+				continue
+			}
 			return diag.FromErr(err)
 		}
 


### PR DESCRIPTION
# Description
<!--
* Prefix: the title with the component name being changed. Add a short and self describing sentence to ease the review
* Please add a few lines providing context and describing the change
* Please self comment changes whenever applicable to help with the review process
* Please keep the checklist as part of the PR. Tick what applies to this change.
-->

`detachMatchingResource` lists instances and then fetches each one to check for a matching attachment before deleting a resource. If an instance is deleted between the `ListInstances` and `GetInstance` calls (e.g. by a concurrent operation), `GetInstance` returns `ErrNotFound` which previously aborted the entire detach operation and left dangling resources.

A vanished instance can no longer hold the attachment, so skip it instead of failing. Other `GetInstance` errors are still propagated.

This is an attempt at fixing the [flaky failure of `TestAccDataSourceElasticIP`][1]:
```
datasource_exoscale_elastic_ip_test.go:125: Error running post-test destroy, there may be dangling resources: exit status 1

    Error: GetInstance: http response: Not Found: Instance not found.
```

I wasn't able to reproduce this locally (running the acceptance tests against my prod account), but this is the only scenario I can think of where this could happen.

Note that `detachMatchingResource` is also called by `resourcePrivateNetworkDelete`, but I think the same logic applies in that case as well.

[1]: https://github.com/exoscale/terraform-provider-exoscale/actions/runs/27135434233/job/80352641300


## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [ ] Acceptance tests OK
* [ ] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing

<!--
Describe the tests you did
-->

I think it's fixed :tada: Or, at least, `TestAccDataSourceElasticIP` didn't fail in [this run](https://github.com/exoscale/terraform-provider-exoscale/actions/runs/27278126311/job/80569409971).

There are still two failures left: `TestAccResourceSKSClusterSKSClusterWithAudit` and `TestInstance/Resource`.

We could run it a few more times before merging, if you'd like to have more confidence. Though we can also easily revert it if it fails on `master`.