### PR TITLE
fix(instance): check instance state before stop/start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ BUG FIXES:
 - `security_group_rule`: allow portless protocols (ESP, AH, GRE, IPIP) #531
 - `template`: fall back to private visibility when name lookup returns not found #532
 - `elastic_ip`: tolerate missing instance during detach #549
+- `instance`: check instance state before stop/start #551
 
 DEPENDENCIES:
 

--- a/pkg/resources/instance/resource.go
+++ b/pkg/resources/instance/resource.go
@@ -860,11 +860,21 @@ func rUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnos
 			return diag.Errorf("unable to scale down the disk size, use size > %v", instance.DiskSize)
 		}
 
-		// Compute instance scaling/disk resizing/TPM enabling API operations requires the instance to be stopped.
-		if d.Get(AttrState) == "stopped" ||
-			d.HasChange(AttrDiskSize) ||
-			d.HasChange(AttrType) ||
-			(d.HasChange(AttrEnableTPM) && d.Get(AttrEnableTPM).(bool)) {
+		// Refresh instance state, since it could have changed since when we
+		// first requested it above.
+		instance, err = client.GetInstance(ctx, v3.UUID(d.Id()))
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		// Compute instance scaling/disk resizing/TPM enabling API operations
+		// requires the instance to be stopped.
+		shouldStop := instance.State == v3.InstanceStateRunning &&
+			(d.Get(AttrState) == string(v3.InstanceStateStopped) ||
+				d.HasChange(AttrDiskSize) ||
+				d.HasChange(AttrType) ||
+				(d.HasChange(AttrEnableTPM) && d.Get(AttrEnableTPM).(bool)))
+		if shouldStop {
 			op, err := client.StopInstance(ctx, instance.ID)
 			if err != nil {
 				return diag.Errorf("unable to stop instance: %s", err)
@@ -872,7 +882,6 @@ func rUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnos
 			if _, err = client.Wait(ctx, op, v3.OperationStateSuccess); err != nil {
 				return diag.Errorf("unable to stop instance: %s", err)
 			}
-
 		}
 
 		if d.HasChange(AttrDiskSize) {
@@ -918,7 +927,9 @@ func rUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnos
 			}
 		}
 
-		if d.Get(AttrState) == "running" {
+		shouldStart := d.Get(AttrState) == string(v3.InstanceStateRunning) &&
+			(shouldStop || instance.State != v3.InstanceStateRunning)
+		if shouldStart {
 			op, err := client.StartInstance(ctx, instance.ID, v3.StartInstanceRequest{})
 			if err != nil {
 				return diag.Errorf("unable to start instance: %s", err)
@@ -926,7 +937,6 @@ func rUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnos
 			if _, err = client.Wait(ctx, op, v3.OperationStateSuccess); err != nil {
 				return diag.Errorf("unable to start instance: %s", err)
 			}
-
 		}
 	}
 


### PR DESCRIPTION
# Description
<!--
* Prefix: the title with the component name being changed. Add a short and self describing sentence to ease the review
* Please add a few lines providing context and describing the change
* Please self comment changes whenever applicable to help with the review process
* Please keep the checklist as part of the PR. Tick what applies to this change.
-->

Previously `instance.rUpdate` would attempt to stop an instance regardless of its current state, causing errors like:
```
StopInstance: http response: Bad Request: Only running instances can be stopped.
```

This was reproducible by our [`TestInstance/Resource` acceptance test][1].

The fix checks that the instance is actually running before attempting to stop it. And, for good measure, does the same when attempting to start it later, even though we haven't run into any issues with that call.

The second `GetInstance` to refresh the state isn't technically required (I've observed the instance is stopped after the first call), but I added it for additional safety in case of drift, since there are many intermediate operations.

Sidenote: this function should really be refactored, since it's very long and difficult to follow. The `nolint:gocyclo` is a hint. But I left that for later.

[1]: https://github.com/exoscale/terraform-provider-exoscale/actions/runs/27335561537/job/80763036826#logs

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Acceptance tests OK
* [ ] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing

`TF_ACC=1 go test -v -count=1 -timeout 15m ./pkg/resources/instance` passes locally, whereas it didn't before this change.