### PR TITLE
fix(dbaas_pg_database): wait for new database to appear in service list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+BUG FIXES:
+
+- `dbaas_pg_database`: wait for newly created database to appear in service list, fixing intermittent "Unable to find newly created database for the service" error on create
+
 IMPROVEMENTS:
 
 - Resource compute_instance: clearify the default state value #538

--- a/pkg/resources/database/resource_db_pg.go
+++ b/pkg/resources/database/resource_db_pg.go
@@ -240,18 +240,19 @@ func (data PGDatabaseResourceModel) CreateResource(ctx context.Context, client *
 		return
 	}
 
-	svc, err := client.GetDBAASServicePG(ctx, data.Service.ValueString())
-	if err != nil {
-		diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read database service pg, got error: %s", err))
-		return
-	}
-
-	for _, db := range svc.Databases {
-		if string(db) == data.DatabaseName.ValueString() {
-			return
+	// The service may take a moment to expose the new database in its
+	// Databases list once the create operation has completed. Poll the
+	// service until the new database appears, or the context times out.
+	if _, err := waitForDBAASServiceReadyForFn(ctx, client.GetDBAASServicePG, data.Service.ValueString(), func(t *v3.DBAASServicePG) bool {
+		for _, db := range t.Databases {
+			if string(db) == data.DatabaseName.ValueString() {
+				return true
+			}
 		}
+		return false
+	}); err != nil {
+		diagnostics.AddError("Client Error", fmt.Sprintf("Unable to find newly created database for the service: %s", err))
 	}
-	diagnostics.AddError("Client Error", "Unable to find newly created database for the service")
 }
 
 // DeleteResource deletes the resource


### PR DESCRIPTION
# Description

After `CreateDBAASPGDatabase` returns success, the service's `Databases` list can lag the operation by a few seconds. The previous code did a single `GetDBAASServicePG` call and bailed on the first miss with `"Unable to find newly created database for the service"`, which made `TestDatabase/ResourcePg` flake whenever the control plane was slow to propagate.

This swaps the single read for a poll using the existing `waitForDBAASServiceReadyForFn` helper, with a predicate that returns true once the new database appears in the service's `Databases` list. Same shape as the MySQL database resource, which already does this correctly.

## Checklist
(For exoscale contributors)

- [x] Changelog updated (under *Unreleased* block)
- [ ] Acceptance tests OK
- [ ] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing

- `go build ./pkg/resources/database/...` clean
- `go vet ./pkg/resources/database/...` clean
- Acceptance tests for `TestDatabase/ResourcePg` will be exercised by CI on this PR

> [!NOTE]
> AI-assisted for diagnosis of the read-after-create race and the diff itself.