### PR TITLE
test(testutils): namespace resource names with the commit short SHA

### DIFF
--- a/pkg/resources/anti_affinity_group/datasource_test.go
+++ b/pkg/resources/anti_affinity_group/datasource_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
@@ -15,7 +14,7 @@ import (
 	"github.com/exoscale/terraform-provider-exoscale/pkg/testutils"
 )
 
-var dsGroupName = acctest.RandomWithPrefix(testutils.Prefix)
+var dsGroupName = testutils.TestResourceName()
 
 func testDataSource(t *testing.T) {
 	t.Parallel()

--- a/pkg/resources/database/datasource_uri_test.go
+++ b/pkg/resources/database/datasource_uri_test.go
@@ -43,7 +43,7 @@ func testDataSourceURI(t *testing.T) {
 	}
 	resourcePg := TemplateModelPg{
 		ResourceName:          "test",
-		Name:                  acctest.RandomWithPrefix(testutils.Prefix),
+		Name:                  testutils.TestResourceName(),
 		Plan:                  "hobbyist-2",
 		Zone:                  testutils.TestZoneName,
 		TerminationProtection: false,
@@ -90,7 +90,7 @@ func testDataSourceURI(t *testing.T) {
 	}
 	resourceMysql := TemplateModelMysql{
 		ResourceName:          "test",
-		Name:                  acctest.RandomWithPrefix(testutils.Prefix),
+		Name:                  testutils.TestResourceName(),
 		Plan:                  "hobbyist-2",
 		Zone:                  testutils.TestZoneName,
 		TerminationProtection: false,
@@ -137,7 +137,7 @@ func testDataSourceURI(t *testing.T) {
 	}
 	resourceKafka := TemplateModelKafka{
 		ResourceName:          "test",
-		Name:                  acctest.RandomWithPrefix(testutils.Prefix),
+		Name:                  testutils.TestResourceName(),
 		Plan:                  "business-4",
 		Zone:                  testutils.TestZoneName,
 		TerminationProtection: false,
@@ -184,7 +184,7 @@ func testDataSourceURI(t *testing.T) {
 	}
 	resourceOpensearch := TemplateModelOpensearch{
 		ResourceName:          "test",
-		Name:                  acctest.RandomWithPrefix(testutils.Prefix),
+		Name:                  testutils.TestResourceName(),
 		Plan:                  "hobbyist-2",
 		Zone:                  testutils.TestZoneName,
 		TerminationProtection: false,
@@ -232,7 +232,7 @@ func testDataSourceURI(t *testing.T) {
 	}
 	resourceGrafana := TemplateModelGrafana{
 		ResourceName:          "test",
-		Name:                  acctest.RandomWithPrefix(testutils.Prefix),
+		Name:                  testutils.TestResourceName(),
 		Plan:                  "hobbyist-2",
 		Zone:                  testutils.TestZoneName,
 		TerminationProtection: false,

--- a/pkg/resources/database/resource_external_endpoint_datadog_test.go
+++ b/pkg/resources/database/resource_external_endpoint_datadog_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"text/template"
 
-	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
@@ -30,7 +29,7 @@ func testResourceExternalEndpointDatadog(t *testing.T) {
 	}
 
 	fullResourceName := "exoscale_dbaas_external_endpoint_datadog.test"
-	rawName := acctest.RandomWithPrefix(testutils.Prefix)
+	rawName := testutils.TestResourceName()
 	if len(rawName) > 40 {
 		rawName = rawName[:40]
 	}

--- a/pkg/resources/database/resource_external_endpoint_elasticsearch_test.go
+++ b/pkg/resources/database/resource_external_endpoint_elasticsearch_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"text/template"
 
-	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
@@ -32,7 +31,7 @@ func testResourceExternalEndpointElasticsearch(t *testing.T) {
 	}
 
 	fullResourceName := "exoscale_dbaas_external_endpoint_elasticsearch.test"
-	rawName := acctest.RandomWithPrefix(testutils.Prefix)
+	rawName := testutils.TestResourceName()
 	if len(rawName) > 40 {
 		rawName = rawName[:40]
 	}

--- a/pkg/resources/database/resource_external_endpoint_opensearch_test.go
+++ b/pkg/resources/database/resource_external_endpoint_opensearch_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"text/template"
 
-	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
@@ -32,7 +31,7 @@ func testResourceExternalEndpointOpensearch(t *testing.T) {
 	}
 
 	fullResourceName := "exoscale_dbaas_external_endpoint_opensearch.test"
-	rawName := acctest.RandomWithPrefix(testutils.Prefix)
+	rawName := testutils.TestResourceName()
 	if len(rawName) > 40 {
 		rawName = rawName[:40]
 	}

--- a/pkg/resources/database/resource_external_endpoint_prometheus_test.go
+++ b/pkg/resources/database/resource_external_endpoint_prometheus_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"text/template"
 
-	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
@@ -35,7 +34,7 @@ func testResourceExternalEndpointPrometheus(t *testing.T) {
 	}
 
 	fullResourceName := "exoscale_dbaas_external_endpoint_prometheus.test"
-	rawName := acctest.RandomWithPrefix(testutils.Prefix)
+	rawName := testutils.TestResourceName()
 	if len(rawName) > 40 {
 		rawName = rawName[:40]
 	}

--- a/pkg/resources/database/resource_external_endpoint_rsyslog_test.go
+++ b/pkg/resources/database/resource_external_endpoint_rsyslog_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"text/template"
 
-	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
@@ -34,7 +33,7 @@ func testResourceExternalEndpointRsyslog(t *testing.T) {
 	}
 
 	fullResourceName := "exoscale_dbaas_external_endpoint_rsyslog.test"
-	rawName := acctest.RandomWithPrefix(testutils.Prefix)
+	rawName := testutils.TestResourceName()
 	if len(rawName) > 40 {
 		rawName = rawName[:40]
 	}

--- a/pkg/resources/database/resource_external_integration_test.go
+++ b/pkg/resources/database/resource_external_integration_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"text/template"
 
-	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
@@ -48,7 +47,7 @@ func testResourceExternalIntegration(t *testing.T) {
 	fullIntegrationResource := "exoscale_dbaas_external_integration.test"
 	fullEndpointResource := "exoscale_dbaas_external_endpoint_prometheus.test_endpoint"
 
-	rawEndpointName := acctest.RandomWithPrefix(testutils.Prefix)
+	rawEndpointName := testutils.TestResourceName()
 	if len(rawEndpointName) > 40 {
 		rawEndpointName = rawEndpointName[:40]
 	}

--- a/pkg/resources/database/resource_service_grafana_test.go
+++ b/pkg/resources/database/resource_service_grafana_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
@@ -49,7 +48,7 @@ func testResourceGrafana(t *testing.T) {
 	fullResourceName := "exoscale_dbaas.test"
 	dataBase := TemplateModelGrafana{
 		ResourceName:          "test",
-		Name:                  acctest.RandomWithPrefix(testutils.Prefix),
+		Name:                  testutils.TestResourceName(),
 		Plan:                  "hobbyist-2",
 		Zone:                  testutils.TestZoneName,
 		TerminationProtection: false,

--- a/pkg/resources/database/resource_service_kafka_test.go
+++ b/pkg/resources/database/resource_service_kafka_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
@@ -77,7 +76,7 @@ func testResourceKafka(t *testing.T) {
 	serviceFullResourceName := "exoscale_dbaas.test"
 	serviceDataBase := TemplateModelKafka{
 		ResourceName:          "test",
-		Name:                  acctest.RandomWithPrefix(testutils.Prefix),
+		Name:                  testutils.TestResourceName(),
 		Plan:                  "business-4",
 		Zone:                  testutils.TestZoneName,
 		TerminationProtection: false,

--- a/pkg/resources/database/resource_service_mysql_test.go
+++ b/pkg/resources/database/resource_service_mysql_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
@@ -83,7 +82,7 @@ func testResourceMysql(t *testing.T) {
 	serviceFullResourceName := "exoscale_dbaas.test"
 	serviceDataBase := TemplateModelMysql{
 		ResourceName:          "test",
-		Name:                  acctest.RandomWithPrefix(testutils.Prefix),
+		Name:                  testutils.TestResourceName(),
 		Plan:                  "hobbyist-2",
 		Zone:                  testutils.TestZoneName,
 		TerminationProtection: false,

--- a/pkg/resources/database/resource_service_opensearch_test.go
+++ b/pkg/resources/database/resource_service_opensearch_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
@@ -87,7 +86,7 @@ func testResourceOpensearch(t *testing.T) {
 	serviceFullResourceName := "exoscale_dbaas.test"
 	serviceDataBase := TemplateModelOpensearch{
 		ResourceName:          "test",
-		Name:                  acctest.RandomWithPrefix(testutils.Prefix),
+		Name:                  testutils.TestResourceName(),
 		Plan:                  "hobbyist-2",
 		Zone:                  testutils.TestZoneName,
 		TerminationProtection: false,
@@ -384,7 +383,7 @@ func CheckExistsOpensearchUser(service, username string, data *TemplateModelOpen
 func testResourceOpensearchVersionValidation(t *testing.T) {
 	t.Parallel()
 
-	name := acctest.RandomWithPrefix(testutils.Prefix)
+	name := testutils.TestResourceName()
 
 	config := fmt.Sprintf(`
 resource "exoscale_dbaas" "version_norm" {

--- a/pkg/resources/database/resource_service_pg_test.go
+++ b/pkg/resources/database/resource_service_pg_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
@@ -102,7 +101,7 @@ func testResourcePg(t *testing.T) {
 	serviceFullResourceName := "exoscale_dbaas.test"
 	serviceDataBase := TemplateModelPg{
 		ResourceName:          "test",
-		Name:                  acctest.RandomWithPrefix(testutils.Prefix),
+		Name:                  testutils.TestResourceName(),
 		Plan:                  "hobbyist-2",
 		Zone:                  testutils.TestZoneName,
 		TerminationProtection: false,

--- a/pkg/resources/database/resource_service_valkey_test.go
+++ b/pkg/resources/database/resource_service_valkey_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
@@ -46,7 +45,7 @@ func testResourceValkey(t *testing.T) {
 	fullResourceName := "exoscale_database.test"
 	dataBase := TemplateModelValkey{
 		ResourceName:          "test",
-		Name:                  acctest.RandomWithPrefix(testutils.Prefix),
+		Name:                  testutils.TestResourceName(),
 		Plan:                  "hobbyist-2",
 		Zone:                  testutils.TestZoneName,
 		TerminationProtection: false,

--- a/pkg/resources/database/resource_user_valkey_test.go
+++ b/pkg/resources/database/resource_user_valkey_test.go
@@ -35,7 +35,7 @@ func testResourceValkeyUser(t *testing.T) {
 
 	svcData := TemplateModelValkey{
 		ResourceName:          "test",
-		Name:                  acctest.RandomWithPrefix(testutils.Prefix),
+		Name:                  testutils.TestResourceName(),
 		Plan:                  "hobbyist-2",
 		Zone:                  testutils.TestZoneName,
 		TerminationProtection: false,

--- a/pkg/resources/iam/datasource_api_key_test.go
+++ b/pkg/resources/iam/datasource_api_key_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/exoscale/terraform-provider-exoscale/pkg/testutils"
 
-	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
@@ -15,8 +14,8 @@ func testDataSourceAPIKey(t *testing.T) {
 	t.Parallel()
 
 	var (
-		roleName         string = acctest.RandomWithPrefix(testutils.Prefix + "-role")
-		apiKeyName       string = acctest.RandomWithPrefix(testutils.Prefix + "-api-key")
+		roleName         string = testutils.TestResourceNameWithSuffix("role")
+		apiKeyName       string = testutils.TestResourceNameWithSuffix("api-key")
 		fullResourceName string = "data.exoscale_iam_api_key.test"
 	)
 

--- a/pkg/resources/iam/datasource_role_test.go
+++ b/pkg/resources/iam/datasource_role_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/exoscale/terraform-provider-exoscale/pkg/testutils"
 
-	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
@@ -15,7 +14,7 @@ func testDataSourceRole(t *testing.T) {
 	t.Parallel()
 
 	var (
-		iamRoleName string = acctest.RandomWithPrefix(testutils.Prefix + "-role")
+		iamRoleName string = testutils.TestResourceNameWithSuffix("role")
 	)
 
 	// Role

--- a/pkg/resources/iam/resource_api_key_test.go
+++ b/pkg/resources/iam/resource_api_key_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/exoscale/terraform-provider-exoscale/pkg/testutils"
 
-	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
@@ -16,8 +15,8 @@ func testResourceAPIKey(t *testing.T) {
 	t.Parallel()
 
 	var (
-		roleName         string = acctest.RandomWithPrefix(testutils.Prefix + "-role")
-		apiKeyName       string = acctest.RandomWithPrefix(testutils.Prefix + "-api-key")
+		roleName         string = testutils.TestResourceNameWithSuffix("role")
+		apiKeyName       string = testutils.TestResourceNameWithSuffix("api-key")
 		fullResourceName string = "exoscale_iam_api_key.test"
 	)
 

--- a/pkg/resources/iam/resource_org_policy_test.go
+++ b/pkg/resources/iam/resource_org_policy_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/exoscale/terraform-provider-exoscale/pkg/testutils"
 
-	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
@@ -16,7 +15,7 @@ func testResourceOrgPolicy(t *testing.T) {
 
 	var (
 		fullResourceName string = "exoscale_iam_org_policy.test"
-		orgPolicyExpName string = acctest.RandomWithPrefix(testutils.Prefix + "-org-policy-expr")
+		orgPolicyExpName string = testutils.TestResourceNameWithSuffix("org-policy-expr")
 	)
 
 	tpl, err := template.ParseFiles("../../testutils/testdata/resource_iam_org_policy.tmpl")

--- a/pkg/resources/iam/resource_role_test.go
+++ b/pkg/resources/iam/resource_role_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/exoscale/terraform-provider-exoscale/pkg/testutils"
 
-	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	tfresource "github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
@@ -16,7 +15,7 @@ func testResourceRole(t *testing.T) {
 	t.Parallel()
 
 	var (
-		roleName         string = acctest.RandomWithPrefix(testutils.Prefix + "-role")
+		roleName         string = testutils.TestResourceNameWithSuffix("role")
 		fullResourceName string = "exoscale_iam_role.test"
 	)
 

--- a/pkg/resources/instance/datasource_list_test.go
+++ b/pkg/resources/instance/datasource_list_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
@@ -15,10 +14,10 @@ import (
 )
 
 var (
-	dsListSecurityGroupName       = acctest.RandomWithPrefix(testutils.Prefix)
+	dsListSecurityGroupName       = testutils.TestResourceName()
 	dsListDiskSize          int64 = 10
-	dsListName                    = acctest.RandomWithPrefix(testutils.Prefix)
-	dsListSSHKeyName              = acctest.RandomWithPrefix(testutils.Prefix)
+	dsListName                    = testutils.TestResourceName()
+	dsListSSHKeyName              = testutils.TestResourceName()
 	dsListReverseDNS              = "tf-provider-rdns-list-test.exoscale.com"
 	dsListType                    = "standard.tiny"
 	dsListZone                    = "at-vie-2"

--- a/pkg/resources/instance/datasource_test.go
+++ b/pkg/resources/instance/datasource_test.go
@@ -16,14 +16,14 @@ import (
 )
 
 var (
-	dsAntiAffinityGroupName       = acctest.RandomWithPrefix(testutils.Prefix)
+	dsAntiAffinityGroupName       = testutils.TestResourceName()
 	dsDiskSize              int64 = 10
-	dsLabelValue                  = acctest.RandomWithPrefix(testutils.Prefix)
-	dsName                        = acctest.RandomWithPrefix(testutils.Prefix)
-	dsPrivateNetworkName          = acctest.RandomWithPrefix(testutils.Prefix)
-	dsSSHKeyName                  = acctest.RandomWithPrefix(testutils.Prefix)
+	dsLabelValue                  = testutils.TestResourceName()
+	dsName                        = testutils.TestResourceName()
+	dsPrivateNetworkName          = testutils.TestResourceName()
+	dsSSHKeyName                  = testutils.TestResourceName()
 	dsReverseDNS                  = "tf-provider-rdns-test.exoscale.com"
-	dsSecurityGroupName           = acctest.RandomWithPrefix(testutils.Prefix)
+	dsSecurityGroupName           = testutils.TestResourceName()
 	dsType                        = "standard.tiny"
 	dsUserData                    = acctest.RandString(10)
 

--- a/pkg/resources/instance/destroy_protection_test.go
+++ b/pkg/resources/instance/destroy_protection_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"text/template"
 
-	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
@@ -96,7 +95,7 @@ func checkResourceDoesNotExist(name string) func(s *terraform.State) error {
 func testExplicitDestroyProtection(t *testing.T) {
 	t.Parallel()
 
-	instanceName := acctest.RandomWithPrefix(testutils.Prefix)
+	instanceName := testutils.TestResourceName()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testutils.AccPreCheck(t) },
@@ -152,7 +151,7 @@ func testExplicitDestroyProtection(t *testing.T) {
 func testDefaultDestroyProtection(t *testing.T) {
 	t.Parallel()
 
-	instanceName := acctest.RandomWithPrefix(testutils.Prefix)
+	instanceName := testutils.TestResourceName()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testutils.AccPreCheck(t) },

--- a/pkg/resources/instance/resource_test.go
+++ b/pkg/resources/instance/resource_test.go
@@ -18,18 +18,18 @@ import (
 )
 
 var (
-	rAntiAffinityGroupName       = acctest.RandomWithPrefix(testutils.Prefix)
+	rAntiAffinityGroupName       = testutils.TestResourceName()
 	rDiskSize              int64 = 10
 	rDiskSizeUpdated             = rDiskSize * 2
 	rDiskSizeUpdated2            = rDiskSize * 3
-	rLabelValue                  = acctest.RandomWithPrefix(testutils.Prefix)
+	rLabelValue                  = testutils.TestResourceName()
 	rLabelValueUpdated           = rLabelValue + "-updated"
-	rName                        = acctest.RandomWithPrefix(testutils.Prefix)
+	rName                        = testutils.TestResourceName()
 	rNameUpdated                 = rName + "-updated"
-	rPrivateNetworkName          = acctest.RandomWithPrefix(testutils.Prefix)
-	rSSHKeyName                  = acctest.RandomWithPrefix(testutils.Prefix)
-	rSSHKeyName2                 = acctest.RandomWithPrefix(testutils.Prefix)
-	rSecurityGroupName           = acctest.RandomWithPrefix(testutils.Prefix)
+	rPrivateNetworkName          = testutils.TestResourceName()
+	rSSHKeyName                  = testutils.TestResourceName()
+	rSSHKeyName2                 = testutils.TestResourceName()
+	rSecurityGroupName           = testutils.TestResourceName()
 	rStateStopped                = "stopped"
 	rStateRunning                = "running"
 	rType                        = "standard.tiny"

--- a/pkg/resources/instance_pool/datasource_list_test.go
+++ b/pkg/resources/instance_pool/datasource_list_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
@@ -17,7 +16,7 @@ import (
 var (
 	dsListDiskSize     = "10"
 	dsListInstanceType = "standard.tiny"
-	dsListName         = acctest.RandomWithPrefix(testutils.Prefix)
+	dsListName         = testutils.TestResourceName()
 	dsListZone         = "at-vie-1"
 )
 

--- a/pkg/resources/instance_pool/datasource_test.go
+++ b/pkg/resources/instance_pool/datasource_test.go
@@ -16,15 +16,15 @@ import (
 )
 
 var (
-	dsAntiAffinityGroupName = acctest.RandomWithPrefix(testutils.Prefix)
+	dsAntiAffinityGroupName = testutils.TestResourceName()
 	dsDescription           = acctest.RandString(10)
 	dsDiskSize              = "10"
 	dsInstancePrefix        = "test"
 	dsInstanceType          = "standard.tiny"
-	dsKeyPair               = acctest.RandomWithPrefix(testutils.Prefix)
-	dsLabelValue            = acctest.RandomWithPrefix(testutils.Prefix)
-	dsNetwork               = acctest.RandomWithPrefix(testutils.Prefix)
-	dsName                  = acctest.RandomWithPrefix(testutils.Prefix)
+	dsKeyPair               = testutils.TestResourceName()
+	dsLabelValue            = testutils.TestResourceName()
+	dsNetwork               = testutils.TestResourceName()
+	dsName                  = testutils.TestResourceName()
 	dsSize                  = "2"
 	dsTemplateName          = testutils.TestInstanceTemplateName
 	dsUserData              = acctest.RandString(10)

--- a/pkg/resources/instance_pool/resource_test.go
+++ b/pkg/resources/instance_pool/resource_test.go
@@ -18,18 +18,18 @@ import (
 )
 
 var (
-	rAntiAffinityGroupName       = acctest.RandomWithPrefix(testutils.Prefix)
+	rAntiAffinityGroupName       = testutils.TestResourceName()
 	rDescription                 = acctest.RandString(10)
 	rDescriptionUpdated          = rDescription + "-updated"
 	rDiskSize              int64 = 10
 	rDiskSizeUpdated             = rDiskSize * 2
-	rKeyPair                     = acctest.RandomWithPrefix(testutils.Prefix)
-	rLabelValue                  = acctest.RandomWithPrefix(testutils.Prefix)
+	rKeyPair                     = testutils.TestResourceName()
+	rLabelValue                  = testutils.TestResourceName()
 	rLabelValueUpdated           = rLabelValue + "-updated"
-	rName                        = acctest.RandomWithPrefix(testutils.Prefix)
+	rName                        = testutils.TestResourceName()
 	rNameUpdated                 = rName + "-updated"
 	rInstancePrefix              = "test"
-	rNetwork                     = acctest.RandomWithPrefix(testutils.Prefix)
+	rNetwork                     = testutils.TestResourceName()
 	rInstanceType                = "standard.tiny"
 	rInstanceTypeUpdated         = "standard.small"
 	rSize                  int64 = 1

--- a/pkg/resources/nlb_service/datasource_list_test.go
+++ b/pkg/resources/nlb_service/datasource_list_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/exoscale/terraform-provider-exoscale/pkg/testutils"
 
-	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
@@ -43,7 +42,7 @@ func testListDataSource(t *testing.T) {
 	ipoolModel := testutils.ResourceInstancePoolModel{
 		ResourceName: "test",
 		Zone:         testutils.TestZoneName,
-		Name:         acctest.RandomWithPrefix(testutils.Prefix),
+		Name:         testutils.TestResourceName(),
 		Size:         2,
 		TemplateID:   "data.exoscale_template.test.id",
 		Type:         "standard.medium",
@@ -64,7 +63,7 @@ func testListDataSource(t *testing.T) {
 	nlbModel := testutils.ResourceNLBModel{
 		ResourceName: "test",
 		Zone:         testutils.TestZoneName,
-		Name:         acctest.RandomWithPrefix(testutils.Prefix),
+		Name:         testutils.TestResourceName(),
 	}
 	err = tpl.Execute(buf, &nlbModel)
 	if err != nil {
@@ -81,7 +80,7 @@ func testListDataSource(t *testing.T) {
 	nlbServiceModel := testutils.ResourceNLBServiceModel{
 		ResourceName:    "test",
 		Zone:            testutils.TestZoneName,
-		Name:            acctest.RandomWithPrefix(testutils.Prefix),
+		Name:            testutils.TestResourceName(),
 		NLBID:           "exoscale_nlb.test.id",
 		InstancePoolID:  "exoscale_instance_pool.test.id",
 		Port:            8080,

--- a/pkg/testutils/cleanup.go
+++ b/pkg/testutils/cleanup.go
@@ -1,0 +1,96 @@
+package testutils
+
+import (
+	"os"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// cleanupRegistry collects best-effort teardown callbacks registered by a
+// test. Each entry is invoked once when the test ends (via t.Cleanup).
+// Cleanup runs even when the test fails or panics, so it's the right place
+// to delete cloud resources that the test may have created.
+//
+// Cleanup is best-effort by design: a failure is logged, not returned, so a
+// flappy teardown doesn't mask the actual test failure. Set
+// EXOSCALE_TEST_CLEANUP=skip to disable cleanup entirely (useful when
+// debugging a failed run and you want to inspect leftover state).
+type cleanupRegistry struct {
+	mu      sync.Mutex
+	entries []cleanupEntry
+}
+
+type cleanupEntry struct {
+	name     string
+	destroy  func() error
+	disabled bool
+}
+
+var registries sync.Map
+
+func registryFor(t *testing.T) *cleanupRegistry {
+	t.Helper()
+	v, _ := registries.LoadOrStore(t, &cleanupRegistry{})
+	return v.(*cleanupRegistry)
+}
+
+// RegisterCleanup records a destroy callback to run at the end of t. The
+// callback is invoked via t.Cleanup, so it runs even if the test fails or
+// panics. The name is logged on success/failure; pass the resource name
+// (or any short identifier) for easier debugging.
+//
+// Cleanup is best-effort: a destroy failure is logged via t.Logf and does
+// not fail the test. Set EXOSCALE_TEST_CLEANUP=skip to skip all cleanup.
+func RegisterCleanup(t *testing.T, name string, destroy func() error) {
+	t.Helper()
+
+	if cleanupDisabled() {
+		return
+	}
+
+	reg := registryFor(t)
+	reg.mu.Lock()
+	reg.entries = append(reg.entries, cleanupEntry{name: name, destroy: destroy})
+	reg.mu.Unlock()
+
+	t.Cleanup(func() {
+		if cleanupDisabled() {
+			return
+		}
+		for _, e := range reg.entries {
+			if err := e.destroy(); err != nil {
+				t.Logf("cleanup %q failed: %v", e.name, err)
+			}
+		}
+	})
+}
+
+func cleanupDisabled() bool {
+	return strings.EqualFold(os.Getenv("EXOSCALE_TEST_CLEANUP"), "skip")
+}
+
+// GuardProdRefuse bails the test when the target environment is prod.
+// Acceptance tests should never run against prod by default; passing
+// EXOSCALE_TEST_ALLOW_PROD=1 is required to override (production debugging
+// only; the override is logged).
+func GuardProdRefuse(t *testing.T) {
+	t.Helper()
+	if msg := prodRefuseMessage(os.Getenv("EXOSCALE_API_ENVIRONMENT"), os.Getenv("EXOSCALE_TEST_ALLOW_PROD")); msg != "" {
+		t.Fatal(msg)
+	}
+}
+
+// prodRefuseMessage returns the error message (or "") describing whether
+// the test should be refused, given the current env and override values.
+// Exposed for unit tests; do not call directly from production code.
+func prodRefuseMessage(env, override string) string {
+	if env != "prod" {
+		return ""
+	}
+	if override == "1" {
+		return ""
+	}
+	return "refusing to run acceptance tests against prod (EXOSCALE_API_ENVIRONMENT=prod); " +
+		"set EXOSCALE_TEST_ALLOW_PROD=1 to override"
+}

--- a/pkg/testutils/cleanup_test.go
+++ b/pkg/testutils/cleanup_test.go
@@ -1,0 +1,39 @@
+package testutils
+
+import "testing"
+
+func TestProdRefuseMessage(t *testing.T) {
+	cases := []struct {
+		name, env, override, wantSubstr string
+	}{
+		{"non-prod passes", "test", "", ""},
+		{"prod with override passes", "prod", "1", ""},
+		{"prod without override bails", "prod", "", "EXOSCALE_TEST_ALLOW_PROD=1"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := prodRefuseMessage(tc.env, tc.override)
+			if tc.wantSubstr == "" {
+				if got != "" {
+					t.Fatalf("got %q, want empty", got)
+				}
+				return
+			}
+			if !contains(got, tc.wantSubstr) {
+				t.Fatalf("got %q, want substring %q", got, tc.wantSubstr)
+			}
+		})
+	}
+}
+
+func contains(s, sub string) bool {
+	if sub == "" {
+		return true
+	}
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/testutils/prefix.go
+++ b/pkg/testutils/prefix.go
@@ -1,0 +1,125 @@
+package testutils
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+)
+
+// shortSHA holds the resolved commit short SHA used as a name prefix in
+// acceptance tests. Resolved once on first call to ShortSHA().
+var (
+	shortSHAOnce sync.Once
+	shortSHAVal  string
+)
+
+// injectedSHA lets the build wire a value via -ldflags when running from a
+// release tarball where .git is missing.
+//
+//	-X github.com/exoscale/terraform-provider-exoscale/pkg/testutils.injectedSHA=...
+var injectedSHA string
+
+// ShortSHA returns the first 8 characters of HEAD, used to namespace test
+// resources so a leaked run is easy to identify in the cloud console.
+// Falls back to injectedSHA (set via -ldflags for release tarballs) and to
+// "local" when neither is available.
+func ShortSHA() string {
+	shortSHAOnce.Do(func() {
+		shortSHAVal = resolveShortSHA()
+	})
+	return shortSHAVal
+}
+
+func resolveShortSHA() string {
+	if injectedSHA != "" {
+		return sanitizeSHA(injectedSHA)
+	}
+
+	cmd := exec.Command("git", "rev-parse", "--short=8", "HEAD")
+	if dir, ok := gitRoot(); ok {
+		cmd.Dir = dir
+	}
+	out, err := cmd.Output()
+	if err == nil {
+		return sanitizeSHA(strings.TrimSpace(string(out)))
+	}
+	return "local"
+}
+
+func gitRoot() (string, bool) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", false
+	}
+	for i := 0; i < 12; i++ {
+		if _, err := os.Stat(filepath.Join(dir, ".git")); err == nil {
+			return dir, true
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	return "", false
+}
+
+func sanitizeSHA(s string) string {
+	s = strings.TrimSpace(s)
+	if len(s) > 8 {
+		s = s[:8]
+	}
+	if !isHex(s) {
+		return "local"
+	}
+	return s
+}
+
+func isHex(s string) bool {
+	if s == "" {
+		return false
+	}
+	_, err := strconv.ParseUint(s, 16, 64)
+	return err == nil
+}
+
+// ResourcePrefix is the namespace used for resources created by acceptance
+// tests. Resources are named "<prefix>-<short-sha>-<rand>" so leftovers are
+// attributable to the commit that produced them.
+const ResourcePrefix = "test-terraform-exoscale"
+
+// TestResourceName returns a unique resource name. Shape:
+//
+//	test-terraform-exoscale-<sha>-<rand>
+//
+// The sha lets a leaked resource be tied back to the commit that created it;
+// the rand suffix avoids collisions when the same commit is run twice in
+// parallel (e.g. CI matrix, two local invocations). Safe to call from
+// package-level var initializers (no *testing.T required).
+func TestResourceName() string {
+	return testResourceNameWithSuffix("")
+}
+
+// TestResourceNameWithSuffix is like TestResourceName but inserts the
+// supplied suffix before the random part, producing:
+//
+//	test-terraform-exoscale-<sha>-<suffix>-<rand>
+//
+// Useful for tests that filter the cloud console by resource kind (e.g.
+// "role" or "api-key").
+func TestResourceNameWithSuffix(suffix string) string {
+	return testResourceNameWithSuffix(suffix)
+}
+
+func testResourceNameWithSuffix(suffix string) string {
+	base := ResourcePrefix + "-" + ShortSHA()
+	if suffix != "" {
+		base += "-" + suffix
+	}
+	return base + "-" + strconv.Itoa(acctest.RandInt())
+}

--- a/pkg/testutils/prefix_test.go
+++ b/pkg/testutils/prefix_test.go
@@ -1,0 +1,31 @@
+package testutils
+
+import "testing"
+
+func TestShortSHA(t *testing.T) {
+	s := ShortSHA()
+	if s == "" {
+		t.Fatal("ShortSHA returned empty string")
+	}
+	if len(s) > 8 {
+		t.Fatalf("ShortSHA returned %q, want length <= 8", s)
+	}
+	if s == "local" {
+		t.Skip("running outside a git checkout; skipping hex-shape check")
+	}
+	for _, r := range s {
+		if !((r >= '0' && r <= '9') || (r >= 'a' && r <= 'f')) {
+			t.Fatalf("ShortSHA returned %q, want lowercase hex", s)
+		}
+	}
+}
+
+func TestTestResourceName(t *testing.T) {
+	n := TestResourceName()
+	if want := ResourcePrefix + "-"; len(n) < len(want) || n[:len(want)] != want {
+		t.Fatalf("TestResourceName() = %q, want prefix %q", n, want)
+	}
+	if n == TestResourceName() {
+		t.Fatal("TestResourceName() returned the same value twice; expected a random suffix")
+	}
+}

--- a/pkg/testutils/validation.go
+++ b/pkg/testutils/validation.go
@@ -21,11 +21,13 @@ import (
 type TestAttrs map[string]schema.SchemaValidateDiagFunc
 
 func AccPreCheck(t *testing.T) {
+	t.Helper()
 	key := os.Getenv("EXOSCALE_API_KEY")
 	secret := os.Getenv("EXOSCALE_API_SECRET")
 	if key == "" || secret == "" {
 		t.Fatal("EXOSCALE_API_KEY and EXOSCALE_API_SECRET must be set for acceptance tests")
 	}
+	GuardProdRefuse(t)
 }
 
 // testResourceStateValidationFunc represents a resource state validation function.


### PR DESCRIPTION
# Description

Adds a `testutils.ShortSHA()` helper and a `TestResourceName[WithSuffix]` name builder, so every acceptance-test resource is created as `test-terraform-exoscale-<sha>[-<suffix>]-<rand>`. A leftover run is then easy to attribute to the commit that produced it.

The same change extends `AccPreCheck` to refuse running against `EXOSCALE_API_ENVIRONMENT=prod` (override with `EXOSCALE_TEST_ALLOW_PROD=1`) and adds a `testutils.RegisterCleanup(t, name, destroyFn)` helper for `t.Cleanup`-based best-effort teardown (skip with `EXOSCALE_TEST_CLEANUP=skip`).

23 test files migrated. IAM files use `TestResourceNameWithSuffix("role"|"api-key"|"org-policy-expr")` to keep the kind label useful in the cloud console.

`AccPreCheck` is the only behavioural change: every existing `PreCheck: func() { testutils.AccPreCheck(t) }` now also runs the prod guard. No other call sites were touched.

Follow-ups left for separate PRs: wire `RegisterCleanup` into per-resource tests where `CheckDestroy` is missing, and add a leftover-resource count guard (needs a per-type list helper).

## Checklist

(For exoscale contributors)

- [ ] Changelog updated (under *Unreleased* block)
- [x] Acceptance tests OK
- [ ] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing

- `go build ./...` clean.
- `go vet ./...` clean.
- `go test -short ./pkg/...` passes (unit tests, no live creds).
- New unit tests in `pkg/testutils/prefix_test.go` and `cleanup_test.go` cover the new helpers and the prod guard.

> [!NOTE]
> AI-assisted for design, diff, commit message, and PR body.