### PR TITLE
fix: typo in security group rule import doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ IMPROVEMENTS:
 - Change zone for sks acceptance tests
 - Migrate Private Network resource/datasource to framework #542
 
+BUG FIXES:
+- fix: typo in security group rule import doc #559
+
 ## 0.69.3
 
 IMPROVEMENTS:

--- a/docs/resources/security_group_rule.md
+++ b/docs/resources/security_group_rule.md
@@ -73,9 +73,9 @@ Optional:
 ## Import
 
 ```shell
-# An existing security group rule may be imported by `<security-group-ID>/<security-group-rule-ID>`:
+# An existing security group rule may be imported by `<security-group-ID>@<security-group-rule-ID>`:
 
 terraform import \
   exoscale_security_group_rule.my_security_group_rule \
-  f81d4fae-7dec-11d0-a765-00a0c91e6bf6/9ecc6b8b-73d4-4211-8ced-f7f29bb79524
+  f81d4fae-7dec-11d0-a765-00a0c91e6bf6@9ecc6b8b-73d4-4211-8ced-f7f29bb79524
 ```

--- a/examples/resources/exoscale_security_group_rule/import.sh
+++ b/examples/resources/exoscale_security_group_rule/import.sh
@@ -1,5 +1,5 @@
-# An existing security group rule may be imported by `<security-group-ID>/<security-group-rule-ID>`:
+# An existing security group rule may be imported by `<security-group-ID>@<security-group-rule-ID>`:
 
 terraform import \
   exoscale_security_group_rule.my_security_group_rule \
-  f81d4fae-7dec-11d0-a765-00a0c91e6bf6/9ecc6b8b-73d4-4211-8ced-f7f29bb79524
+  f81d4fae-7dec-11d0-a765-00a0c91e6bf6@9ecc6b8b-73d4-4211-8ced-f7f29bb79524


### PR DESCRIPTION
# Description

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Acceptance tests OK
* [ ] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing

```Bash
$> terraform import exoscale_security_group_rule.my_security_group_rule <security-group-ID>/<security-group-rule-ID>
[...]
Import successful!

The resources that were imported are shown above. These resources are now in
your Terraform state and will henceforth be managed by Terraform.
```