### PR TITLE
feat(ci): enable Go test caching in GitHub Actions workflows

### DIFF
--- a/.github/workflows/test-acc.yml
+++ b/.github/workflows/test-acc.yml
@@ -51,4 +51,4 @@ jobs:
         env:
           EXOSCALE_API_KEY: ${{ secrets.EXOSCALE_API_KEY }}
           EXOSCALE_API_SECRET: ${{ secrets.EXOSCALE_API_SECRET }}
-          EXTRA_ARGS: ${{ github.event.inputs.test_run_pattern != '' && format('-parallel=3 -failfast -run={0}', github.event.inputs.test_run_pattern) || '' }}
+          EXTRA_ARGS: ${{ inputs.test_run_pattern != '' && format('-parallel=3 -count=1 -failfast -run={0}', inputs.test_run_pattern) || '' }}

--- a/.github/workflows/test-acc.yml
+++ b/.github/workflows/test-acc.yml
@@ -34,10 +34,12 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - run: make go.mk
-      - uses: ./go.mk/.github/actions/setup
+      - name: Set up Go
+        uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
-          cache: 'true'
+          cache: true
+          cache-dependency-path: 'go.sum'
       - uses: ./go.mk/.github/actions/pre-check
       - name: Run acceptance tests
         run: |
@@ -49,5 +51,4 @@ jobs:
         env:
           EXOSCALE_API_KEY: ${{ secrets.EXOSCALE_API_KEY }}
           EXOSCALE_API_SECRET: ${{ secrets.EXOSCALE_API_SECRET }}
-          EXTRA_ARGS: ${{ github.event.inputs.test_run_pattern != '' && format('-parallel=3 -count=1 -failfast -run={0}', github.event.inputs.test_run_pattern) || '' }}
-
+          EXTRA_ARGS: ${{ github.event.inputs.test_run_pattern != '' && format('-parallel=3 -failfast -run={0}', github.event.inputs.test_run_pattern) || '' }}

--- a/.github/workflows/test-acc.yml
+++ b/.github/workflows/test-acc.yml
@@ -49,4 +49,5 @@ jobs:
         env:
           EXOSCALE_API_KEY: ${{ secrets.EXOSCALE_API_KEY }}
           EXOSCALE_API_SECRET: ${{ secrets.EXOSCALE_API_SECRET }}
-          EXTRA_ARGS: ${{ github.event.inputs.test_run_pattern != '' && format('-parallel=3 -failfast -run={0}', github.event.inputs.test_run_pattern) || '' }}
+          EXTRA_ARGS: ${{ github.event.inputs.test_run_pattern != '' && format('-parallel=3 -count=1 -failfast -run={0}', github.event.inputs.test_run_pattern) || '' }}
+

--- a/.github/workflows/test-acc.yml
+++ b/.github/workflows/test-acc.yml
@@ -32,19 +32,13 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - run: make go.mk
       - uses: ./go.mk/.github/actions/setup
-      - uses: ./go.mk/.github/actions/pre-check
-      - uses: actions/cache@v4
         with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-${{ hashFiles('go.sum') }}-
-            ${{ runner.os }}-go-
+          go-version-file: 'go.mod'
+          cache: 'true'
+      - uses: ./go.mk/.github/actions/pre-check
       - name: Run acceptance tests
         run: |
           if [ -n "${EXTRA_ARGS}" ]; then
@@ -55,4 +49,4 @@ jobs:
         env:
           EXOSCALE_API_KEY: ${{ secrets.EXOSCALE_API_KEY }}
           EXOSCALE_API_SECRET: ${{ secrets.EXOSCALE_API_SECRET }}
-          EXTRA_ARGS: ${{ inputs.test_run_pattern != '' && format('-parallel=3 -failfast -run={0}', inputs.test_run_pattern) || '' }}
+          EXTRA_ARGS: ${{ github.event.inputs.test_run_pattern != '' && format('-parallel=3 -failfast -run={0}', github.event.inputs.test_run_pattern) || '' }}

--- a/.github/workflows/test-acc.yml
+++ b/.github/workflows/test-acc.yml
@@ -36,14 +36,23 @@ jobs:
       - run: make go.mk
       - uses: ./go.mk/.github/actions/setup
       - uses: ./go.mk/.github/actions/pre-check
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('go.sum') }}-${{ github.run_id }}
+          restore-keys: |
+            ${{ runner.os }}-go-${{ hashFiles('go.sum') }}-
+            ${{ runner.os }}-go-
       - name: Run acceptance tests
         run: |
           if [ -n "${EXTRA_ARGS}" ]; then
             make test-acc EXTRA_ARGS="${EXTRA_ARGS}"
           else
-            make test-acc
+            make test-acc EXTRA_ARGS="-parallel=3 -failfast"
           fi
         env:
           EXOSCALE_API_KEY: ${{ secrets.EXOSCALE_API_KEY }}
           EXOSCALE_API_SECRET: ${{ secrets.EXOSCALE_API_SECRET }}
-          EXTRA_ARGS: ${{ inputs.test_run_pattern != '' && format('-parallel=3 -count=1 -failfast -run={0}', inputs.test_run_pattern) || '' }}
+          EXTRA_ARGS: ${{ inputs.test_run_pattern != '' && format('-parallel=3 -failfast -run={0}', inputs.test_run_pattern) || '' }}

--- a/.github/workflows/test-acc.yml
+++ b/.github/workflows/test-acc.yml
@@ -41,7 +41,7 @@ jobs:
           path: |
             ~/.cache/go-build
             ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('go.sum') }}-${{ github.run_id }}
+          key: ${{ runner.os }}-go-${{ hashFiles('go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-${{ hashFiles('go.sum') }}-
             ${{ runner.os }}-go-
@@ -50,7 +50,7 @@ jobs:
           if [ -n "${EXTRA_ARGS}" ]; then
             make test-acc EXTRA_ARGS="${EXTRA_ARGS}"
           else
-            make test-acc EXTRA_ARGS="-parallel=3 -failfast"
+            make test-acc
           fi
         env:
           EXOSCALE_API_KEY: ${{ secrets.EXOSCALE_API_KEY }}

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -20,15 +20,6 @@ jobs:
       - run: make go.mk
       - uses: ./go.mk/.github/actions/setup
       - uses: ./go.mk/.github/actions/pre-check
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-${{ hashFiles('go.sum') }}-
-            ${{ runner.os }}-go-
       - name: Run unit tests
         run: |
-          make test-verbose EXTRA_ARGS="-parallel=3 -failfast"
+          make test-verbose

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -25,7 +25,7 @@ jobs:
           path: |
             ~/.cache/go-build
             ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('go.sum') }}-${{ github.run_id }}
+          key: ${{ runner.os }}-go-${{ hashFiles('go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-${{ hashFiles('go.sum') }}-
             ${{ runner.os }}-go-

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -20,6 +20,15 @@ jobs:
       - run: make go.mk
       - uses: ./go.mk/.github/actions/setup
       - uses: ./go.mk/.github/actions/pre-check
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('go.sum') }}-${{ github.run_id }}
+          restore-keys: |
+            ${{ runner.os }}-go-${{ hashFiles('go.sum') }}-
+            ${{ runner.os }}-go-
       - name: Run unit tests
         run: |
-          make test-verbose
+          make test-verbose EXTRA_ARGS="-parallel=3 -failfast"


### PR DESCRIPTION
Enable Go's built-in test result caching across CI runs by

This allows unchanged packages to skip re-execution on subsequent runs,
dramatically reducing acceptance test duration and avoiding flaky test
failures for code that has not changed.