### PR TITLE
Add nvidia_mig_profiles support to sks_nodepool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ BUG FIXES:
 - dbaas: allows services with minor/patch version #563
 - improve acc test #563
 
+FEATURES:
+
+- `sks_nodepool`: add `nvidia_mig_profile` attribute to enable NVIDIA Multi-Instance GPU (MIG) partitioning on GPU nodepools (resource + data sources) #564
+
+DEPENDENCIES:
+
+- Bump `egoscale/v3` to v3.1.41
+
 ## 0.69.3
 
 IMPROVEMENTS:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ FEATURES:
 
 DEPENDENCIES:
 
-- Bump `egoscale/v3` to v3.1.41
+- Bump `egoscale/v3` to v3.1.42
 
 ## 0.69.3
 

--- a/docs/data-sources/sks_nodepool.md
+++ b/docs/data-sources/sks_nodepool.md
@@ -34,6 +34,7 @@ description: |-
 - `kubelet_image_gc` (Block Set) Configuration for this nodepool's kubelet image garbage collector (see [below for nested schema](#nestedblock--kubelet_image_gc))
 - `labels` (Map of String) A map of key/value labels.
 - `name` (String)
+- `nvidia_mig_profile` (String) The NVIDIA [Multi-Instance GPU (MIG)](https://docs.nvidia.com/datacenter/tesla/mig-user-guide/) profile to enable on the managed GPUs. The GPU family is inferred from `instance_type`: `gpua30.*` accepts `2g.12gb`, `1g.6gb+me`, `1g.6gb`, `2g.12gb+me`, `4g.24gb`; `gpurtx6000pro.*` accepts `1g.24gb-me`, `1g.24gb`, `2g.48gb-me`, `2g.48gb`, `4g.96gb+gfx`, `1g.24gb+me`, `2g.48gb+me.all`, `1g.24gb+gfx`, `1g.24gb+me.all`, `4g.96gb`, `2g.48gb+gfx`.
 - `private_network_ids` (Set of String) A list of [exoscale_private_network](./private_network.md) (IDs) to be attached to the managed instances.
 - `security_group_ids` (Set of String) A list of [exoscale_security_group](./security_group.md) (IDs) to be attached to the managed instances.
 - `size` (Number)

--- a/docs/data-sources/sks_nodepool_list.md
+++ b/docs/data-sources/sks_nodepool_list.md
@@ -33,6 +33,7 @@ description: |-
 - `ipv6` (Boolean) Match against this bool
 - `labels` (Map of String) Match against key/values. Keys are matched exactly, while values may be matched as a regex if you supply a string that begins and ends with "/"
 - `name` (String) Match against this string. If you supply a string that begins and ends with a "/" it will be matched as a regex.
+- `nvidia_mig_profile` (String) Match against this string. If you supply a string that begins and ends with a "/" it will be matched as a regex.
 - `size` (Number) Match against this int
 - `state` (String) Match against this string. If you supply a string that begins and ends with a "/" it will be matched as a regex.
 - `storage_lvm` (Boolean) Match against this bool
@@ -63,6 +64,7 @@ Read-Only:
 - `kubelet_image_gc` (Set of Object) (see [below for nested schema](#nestedobjatt--nodepools--kubelet_image_gc))
 - `labels` (Map of String)
 - `name` (String)
+- `nvidia_mig_profile` (String)
 - `private_network_ids` (Set of String)
 - `security_group_ids` (Set of String)
 - `size` (Number)

--- a/docs/resources/sks_nodepool.md
+++ b/docs/resources/sks_nodepool.md
@@ -51,6 +51,7 @@ directory for complete configuration examples.
 - `ipv6` (Boolean) Enable IPV6 for the nodepool nodes
 - `kubelet_image_gc` (Block Set) Configuration for this nodepool's kubelet image garbage collector (see [below for nested schema](#nestedblock--kubelet_image_gc))
 - `labels` (Map of String) A map of key/value labels.
+- `nvidia_mig_profile` (String) The NVIDIA [Multi-Instance GPU (MIG)](https://docs.nvidia.com/datacenter/tesla/mig-user-guide/) profile to enable on the managed GPUs. The GPU family is inferred from `instance_type`: `gpua30.*` accepts `2g.12gb`, `1g.6gb+me`, `1g.6gb`, `2g.12gb+me`, `4g.24gb`; `gpurtx6000pro.*` accepts `1g.24gb-me`, `1g.24gb`, `2g.48gb-me`, `2g.48gb`, `4g.96gb+gfx`, `1g.24gb+me`, `2g.48gb+me.all`, `1g.24gb+gfx`, `1g.24gb+me.all`, `4g.96gb`, `2g.48gb+gfx`.
 - `private_network_ids` (Set of String) A list of [exoscale_private_network](./private_network.md) (IDs) to be attached to the managed instances.
 - `security_group_ids` (Set of String) A list of [exoscale_security_group](./security_group.md) (IDs) to be attached to the managed instances.
 - `storage_lvm` (Boolean) Create nodes with non-standard partitioning for persistent storage (requires min 100G of disk space) (may only be set at creation time).

--- a/exoscale/datasource_exoscale_sks_nodepool.go
+++ b/exoscale/datasource_exoscale_sks_nodepool.go
@@ -78,6 +78,9 @@ func nodepoolToDataMap(nodepool *v3.SKSNodepool) general.TerraformObject {
 	if nodepool.InstanceType != nil {
 		ret[resSKSNodepoolAttrInstanceType] = nodepool.InstanceType.ID.String()
 	}
+	if profile := sksNodepoolMIGProfile(nodepool.NvidiaMigProfiles); profile != "" {
+		ret[resSKSNodepoolAttrNvidiaMigProfile] = profile
+	}
 	if len(nodepool.PrivateNetworks) > 0 {
 		ret[resSKSNodepoolAttrPrivateNetworkIDs] = utils.PrivateNetworksToPrivateNetworkIDs(nodepool.PrivateNetworks)
 	}

--- a/exoscale/resource_exoscale_sks_nodepool.go
+++ b/exoscale/resource_exoscale_sks_nodepool.go
@@ -39,6 +39,7 @@ const (
 	resSKSNodepoolAttrLabels                 = "labels"
 	resSKSNodepoolAttrID                     = "id"
 	resSKSNodepoolAttrName                   = "name"
+	resSKSNodepoolAttrNvidiaMigProfile       = "nvidia_mig_profile"
 	resSKSNOdepoolAttrIPV6Enabled            = "ipv6"
 	resSKSNodepoolAttrPrivateNetworkIDs      = "private_network_ids"
 	resSKSNodepoolAttrSecurityGroupIDs       = "security_group_ids"
@@ -149,6 +150,13 @@ func resourceSKSNodepool() *schema.Resource {
 			Type:        schema.TypeString,
 			Required:    true,
 			Description: "The SKS node pool name.",
+		},
+		resSKSNodepoolAttrNvidiaMigProfile: {
+			Type:     schema.TypeString,
+			Optional: true,
+			Description: "The NVIDIA [Multi-Instance GPU (MIG)](https://docs.nvidia.com/datacenter/tesla/mig-user-guide/) profile to enable on the managed GPUs. " +
+				"The GPU family is inferred from `instance_type`: `gpua30.*` accepts `2g.12gb`, `1g.6gb+me`, `1g.6gb`, `2g.12gb+me`, `4g.24gb`; " +
+				"`gpurtx6000pro.*` accepts `1g.24gb-me`, `1g.24gb`, `2g.48gb-me`, `2g.48gb`, `4g.96gb+gfx`, `1g.24gb+me`, `2g.48gb+me.all`, `1g.24gb+gfx`, `1g.24gb+me.all`, `4g.96gb`, `2g.48gb+gfx`.",
 		},
 		resSKSNOdepoolAttrIPV6Enabled: {
 			Type:        schema.TypeBool,
@@ -360,6 +368,14 @@ func resourceSKSNodepoolCreate(ctx context.Context, d *schema.ResourceData, meta
 		sksNodepoolCreate.Name = s
 	}
 
+	if v, ok := d.GetOk(resSKSNodepoolAttrNvidiaMigProfile); ok {
+		profiles, err := sksNodepoolMIGProfiles(sksNodepoolInstanceTypeFamily(d), v.(string))
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		sksNodepoolCreate.NvidiaMigProfiles = profiles
+	}
+
 	if set, ok := d.Get(resSKSNodepoolAttrPrivateNetworkIDs).(*schema.Set); ok {
 		sksNodepoolCreate.PrivateNetworks = utils.PrivateNetworkIDsToPrivateNetworks(set.List())
 	}
@@ -514,6 +530,7 @@ func resourceSKSNodepoolUpdate(ctx context.Context, d *schema.ResourceData, meta
 		InstanceType:       sksNp.InstanceType,
 		Labels:             sksNp.Labels,
 		Name:               sksNp.Name,
+		NvidiaMigProfiles:  sksNp.NvidiaMigProfiles,
 		PrivateNetworks:    sksNp.PrivateNetworks,
 		PublicIPAssignment: v3.UpdateSKSNodepoolRequestPublicIPAssignment(sksNp.PublicIPAssignment),
 		SecurityGroups:     sksNp.SecurityGroups,
@@ -575,6 +592,21 @@ func resourceSKSNodepoolUpdate(ctx context.Context, d *schema.ResourceData, meta
 	if d.HasChange(resSKSNodepoolAttrName) {
 		v := d.Get(resSKSNodepoolAttrName).(string)
 		sksNodepoolUpdate.Name = v
+		updated = true
+	}
+
+	// Recompute the MIG profiles when either the profile itself or the instance
+	// type (and thus the inferred GPU family) changes.
+	if d.HasChange(resSKSNodepoolAttrNvidiaMigProfile) || d.HasChange(resSKSNodepoolAttrInstanceType) {
+		if v, ok := d.GetOk(resSKSNodepoolAttrNvidiaMigProfile); ok {
+			profiles, err := sksNodepoolMIGProfiles(sksNodepoolInstanceTypeFamily(d), v.(string))
+			if err != nil {
+				return diag.FromErr(err)
+			}
+			sksNodepoolUpdate.NvidiaMigProfiles = profiles
+		} else {
+			sksNodepoolUpdate.NvidiaMigProfiles = nil
+		}
 		updated = true
 	}
 
@@ -803,6 +835,10 @@ func resourceSKSNodepoolApply(
 		return err
 	}
 
+	if err := d.Set(resSKSNodepoolAttrNvidiaMigProfile, sksNodepoolMIGProfile(sksNodepool.NvidiaMigProfiles)); err != nil {
+		return err
+	}
+
 	if sksNodepool.PrivateNetworks != nil {
 		privnets := utils.PrivateNetworksToPrivateNetworkIDs(sksNodepool.PrivateNetworks)
 		if err := d.Set(resSKSNodepoolAttrPrivateNetworkIDs, privnets); err != nil {
@@ -919,4 +955,75 @@ func parseSKSNodepoolTaintV3(v string) (*v3.SKSNodepoolTaint, error) {
 		Effect: v3.SKSNodepoolTaintEffect(taintEffect),
 		Value:  taintValue,
 	}, nil
+}
+
+// NVIDIA Multi-Instance GPU (MIG) profiles, keyed by the GPU instance type
+// family the profile applies to. A nodepool has a single instance type (hence a
+// single GPU family), so the family is inferred from `instance_type` rather than
+// specified by the user. The accepted values mirror the Exoscale OpenAPI
+// `nvidia-mig-profile-*` enums; update them if the spec gains new ones.
+var sksNodepoolMIGProfileValues = map[v3.InstanceTypeFamily][]string{
+	v3.InstanceTypeFamilyGpua30: {
+		"2g.12gb", "1g.6gb+me", "1g.6gb", "2g.12gb+me", "4g.24gb",
+	},
+	v3.InstanceTypeFamilyGpurtx6000pro: {
+		"1g.24gb-me", "1g.24gb", "2g.48gb-me", "2g.48gb", "4g.96gb+gfx",
+		"1g.24gb+me", "2g.48gb+me.all", "1g.24gb+gfx", "1g.24gb+me.all",
+		"4g.96gb", "2g.48gb+gfx",
+	},
+}
+
+// sksNodepoolInstanceTypeFamily returns the (lowercased) family part of the
+// nodepool's `instance_type` (`<family>.<size>`).
+func sksNodepoolInstanceTypeFamily(d *schema.ResourceData) string {
+	parts := strings.SplitN(d.Get(resSKSNodepoolAttrInstanceType).(string), ".", 2)
+	return strings.ToLower(parts[0])
+}
+
+// sksNodepoolMIGProfiles builds the egoscale NvidiaMigProfiles for the given
+// instance type family and MIG profile, inferring which GPU field to set from
+// the family. It errors if the family is not MIG-capable or the profile is not
+// valid for it.
+func sksNodepoolMIGProfiles(family, profile string) (*v3.NvidiaMigProfiles, error) {
+	values, ok := sksNodepoolMIGProfileValues[v3.InstanceTypeFamily(family)]
+	if !ok {
+		return nil, fmt.Errorf(
+			"%s is only supported on NVIDIA MIG-capable instance types (families %q and %q), not %q",
+			resSKSNodepoolAttrNvidiaMigProfile,
+			v3.InstanceTypeFamilyGpua30, v3.InstanceTypeFamilyGpurtx6000pro, family,
+		)
+	}
+
+	if !in(values, profile) {
+		return nil, fmt.Errorf(
+			"unsupported MIG profile %q for instance type family %q; supported profiles are %s",
+			profile, family, strings.Join(values, ", "),
+		)
+	}
+
+	switch v3.InstanceTypeFamily(family) {
+	case v3.InstanceTypeFamilyGpua30:
+		return &v3.NvidiaMigProfiles{A3024gb: v3.NvidiaMigProfileA3024gb(profile)}, nil
+	case v3.InstanceTypeFamilyGpurtx6000pro:
+		return &v3.NvidiaMigProfiles{Rtxpro600096gb: v3.NvidiaMigProfileRtxpro600096gb(profile)}, nil
+	default:
+		// Unreachable: family presence was validated above.
+		return nil, nil
+	}
+}
+
+// sksNodepoolMIGProfile flattens the egoscale NvidiaMigProfiles into the single
+// MIG profile value (whichever GPU family field is set), or "" when none is set.
+func sksNodepoolMIGProfile(profiles *v3.NvidiaMigProfiles) string {
+	if profiles == nil {
+		return ""
+	}
+	if profiles.A3024gb != "" {
+		return string(profiles.A3024gb)
+	}
+	if profiles.Rtxpro600096gb != "" {
+		return string(profiles.Rtxpro600096gb)
+	}
+
+	return ""
 }

--- a/exoscale/resource_exoscale_sks_nodepool_mig_test.go
+++ b/exoscale/resource_exoscale_sks_nodepool_mig_test.go
@@ -1,0 +1,109 @@
+package exoscale
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	v3 "github.com/exoscale/egoscale/v3"
+)
+
+func TestSKSNodepoolMIGProfiles(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		family    string
+		profile   string
+		expected  *v3.NvidiaMigProfiles
+		expectErr bool
+	}{
+		{
+			name:     "a30 family",
+			family:   string(v3.InstanceTypeFamilyGpua30),
+			profile:  "2g.12gb",
+			expected: &v3.NvidiaMigProfiles{A3024gb: v3.NvidiaMigProfileA3024gb("2g.12gb")},
+		},
+		{
+			name:     "rtxpro6000 family",
+			family:   string(v3.InstanceTypeFamilyGpurtx6000pro),
+			profile:  "1g.24gb+me.all",
+			expected: &v3.NvidiaMigProfiles{Rtxpro600096gb: v3.NvidiaMigProfileRtxpro600096gb("1g.24gb+me.all")},
+		},
+		{
+			name:      "non-GPU family",
+			family:    string(v3.InstanceTypeFamilyStandard),
+			profile:   "2g.12gb",
+			expectErr: true,
+		},
+		{
+			name:      "non-MIG GPU family",
+			family:    string(v3.InstanceTypeFamilyGpua5000),
+			profile:   "2g.12gb",
+			expectErr: true,
+		},
+		{
+			name:      "invalid profile for family",
+			family:    string(v3.InstanceTypeFamilyGpua30),
+			profile:   "1g.24gb", // an rtxpro6000 value
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := sksNodepoolMIGProfiles(tt.family, tt.profile)
+			if tt.expectErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestSKSNodepoolMIGProfile(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    *v3.NvidiaMigProfiles
+		expected string
+	}{
+		{
+			name:     "nil",
+			input:    nil,
+			expected: "",
+		},
+		{
+			name:     "empty struct",
+			input:    &v3.NvidiaMigProfiles{},
+			expected: "",
+		},
+		{
+			name:     "a30 set",
+			input:    &v3.NvidiaMigProfiles{A3024gb: v3.NvidiaMigProfileA3024gb("4g.24gb")},
+			expected: "4g.24gb",
+		},
+		{
+			name:     "rtxpro6000 set",
+			input:    &v3.NvidiaMigProfiles{Rtxpro600096gb: v3.NvidiaMigProfileRtxpro600096gb("2g.48gb+gfx")},
+			expected: "2g.48gb+gfx",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, sksNodepoolMIGProfile(tt.input))
+		})
+	}
+}
+
+func TestSKSNodepoolMIGProfilesRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	profiles, err := sksNodepoolMIGProfiles(string(v3.InstanceTypeFamilyGpurtx6000pro), "2g.48gb-me")
+	require.NoError(t, err)
+	require.Equal(t, "2g.48gb-me", sksNodepoolMIGProfile(profiles))
+}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.42
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.97.3
 	github.com/exoscale/egoscale v0.102.4
-	github.com/exoscale/egoscale/v3 v3.1.41
+	github.com/exoscale/egoscale/v3 v3.1.42
 	github.com/google/go-cmp v0.7.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-cty v1.5.0

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.42
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.97.3
 	github.com/exoscale/egoscale v0.102.4
-	github.com/exoscale/egoscale/v3 v3.1.35
+	github.com/exoscale/egoscale/v3 v3.1.41
 	github.com/google/go-cmp v0.7.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-cty v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -107,8 +107,8 @@ github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
 github.com/exoscale/egoscale v0.102.4 h1:GBKsZMIOzwBfSu+4ZmWka3Ejf2JLiaBDHp4CQUgvp2E=
 github.com/exoscale/egoscale v0.102.4/go.mod h1:ROSmPtle0wvf91iLZb09++N/9BH2Jo9XxIpAEumvocA=
-github.com/exoscale/egoscale/v3 v3.1.35 h1:Rwwuh7wuwUKI09StObArGrx21ZR27FCPBjgISa1InTo=
-github.com/exoscale/egoscale/v3 v3.1.35/go.mod h1:/1RTNibUdltIdzBbFxMMewNAkB6KKdxzRE/Icu8K5RU=
+github.com/exoscale/egoscale/v3 v3.1.41 h1:sFcGn74f5l73KCpYIWVmSPFUz6i+yrk5K7LdwTKAPbg=
+github.com/exoscale/egoscale/v3 v3.1.41/go.mod h1:DUTgeubl5msPAo3SKFed04AxNhyTNOrCTJHZDRYLR10=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=

--- a/go.sum
+++ b/go.sum
@@ -107,8 +107,8 @@ github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
 github.com/exoscale/egoscale v0.102.4 h1:GBKsZMIOzwBfSu+4ZmWka3Ejf2JLiaBDHp4CQUgvp2E=
 github.com/exoscale/egoscale v0.102.4/go.mod h1:ROSmPtle0wvf91iLZb09++N/9BH2Jo9XxIpAEumvocA=
-github.com/exoscale/egoscale/v3 v3.1.41 h1:sFcGn74f5l73KCpYIWVmSPFUz6i+yrk5K7LdwTKAPbg=
-github.com/exoscale/egoscale/v3 v3.1.41/go.mod h1:DUTgeubl5msPAo3SKFed04AxNhyTNOrCTJHZDRYLR10=
+github.com/exoscale/egoscale/v3 v3.1.42 h1:KlFDdm2ga1RdCdKuKlzJxLmgJjWVcDbJxF0t6FDswzw=
+github.com/exoscale/egoscale/v3 v3.1.42/go.mod h1:DUTgeubl5msPAo3SKFed04AxNhyTNOrCTJHZDRYLR10=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=

--- a/vendor/github.com/exoscale/egoscale/v3/errors.go
+++ b/vendor/github.com/exoscale/egoscale/v3/errors.go
@@ -94,11 +94,41 @@ var httpStatusCodeErrors = map[int]error{
 	http.StatusNetworkAuthenticationRequired: ErrNetworkAuthenticationRequired,
 }
 
+// APIError is the structured error returned for HTTP 4xx/5xx responses.
+// It wraps the HTTP sentinel error (e.g. ErrNotFound) so that errors.Is
+// checks against sentinels continue to work unchanged.
+type APIError struct {
+	// sentinel is the mapped HTTP status error (e.g. ErrNotFound).
+	sentinel error
+	// Message is the plain server message (from "message" or "error" fields).
+	Message string
+	// Title is the RFC 9457 "title" field.
+	Title string
+	// Detail is the RFC 9457 "detail" field.
+	Detail string
+	// Errors holds the RFC 9457 "errors" entries.
+	Errors []APIErrorEntry
+}
+
+// APIErrorEntry is one item from the RFC 9457 "errors" array.
+// Location is a JSONPath expression (e.g. "$['some-field']") when the server
+// provides field-level detail; it is empty for plain string error entries.
+type APIErrorEntry struct {
+	Detail   string
+	Location string
+}
+
+func (e *APIError) Error() string { return e.sentinel.Error() }
+func (e *APIError) Unwrap() error { return e.sentinel }
+
 func handleHTTPErrorResp(resp *http.Response) error {
 	if resp.StatusCode >= 400 && resp.StatusCode <= 599 {
 		var res struct {
-			Message string `json:"message"`
-			Error   string `json:"error"`
+			Message string          `json:"message"`
+			Error   string          `json:"error"`
+			Title   string          `json:"title"`
+			Detail  string          `json:"detail"`
+			Errors  json.RawMessage `json:"errors"`
 		}
 
 		data, err := io.ReadAll(resp.Body)
@@ -114,17 +144,52 @@ func handleHTTPErrorResp(resp *http.Response) error {
 			res.Message = string(data)
 		}
 
-		message := res.Message
-		if message == "" && res.Error != "" {
-			message = res.Error
+		sentinel, ok := httpStatusCodeErrors[resp.StatusCode]
+		if !ok {
+			sentinel = fmt.Errorf("HTTP error %d", resp.StatusCode)
 		}
 
-		err, ok := httpStatusCodeErrors[resp.StatusCode]
-		if ok {
-			return fmt.Errorf("%w: %s", err, message)
+		apiErr := &APIError{
+			sentinel: sentinel,
+			Message:  res.Message,
+			Title:    res.Title,
+			Detail:   res.Detail,
 		}
+		if res.Message == "" && res.Error != "" {
+			apiErr.Message = res.Error
+		}
+		apiErr.Errors = parseErrorEntries(res.Errors)
 
-		return fmt.Errorf("unmapped HTTP error: status code %d, message: %s", resp.StatusCode, message)
+		return apiErr
+	}
+
+	return nil
+}
+
+func parseErrorEntries(raw json.RawMessage) []APIErrorEntry {
+	if len(raw) == 0 {
+		return nil
+	}
+
+	var objErrors []struct {
+		Detail   string `json:"detail"`
+		Location string `json:"location"`
+	}
+	if json.Unmarshal(raw, &objErrors) == nil && len(objErrors) > 0 {
+		entries := make([]APIErrorEntry, len(objErrors))
+		for i, e := range objErrors {
+			entries[i] = APIErrorEntry{Detail: e.Detail, Location: e.Location}
+		}
+		return entries
+	}
+
+	var strErrors []string
+	if json.Unmarshal(raw, &strErrors) == nil {
+		entries := make([]APIErrorEntry, len(strErrors))
+		for i, e := range strErrors {
+			entries[i] = APIErrorEntry{Detail: e}
+		}
+		return entries
 	}
 
 	return nil

--- a/vendor/github.com/exoscale/egoscale/v3/errors.go
+++ b/vendor/github.com/exoscale/egoscale/v3/errors.go
@@ -118,7 +118,10 @@ type APIErrorEntry struct {
 	Location string
 }
 
-func (e *APIError) Error() string { return e.sentinel.Error() }
+func (e *APIError) Error() string {
+	return fmt.Sprintf("%s: %s", e.sentinel.Error(), e.Message)
+}
+
 func (e *APIError) Unwrap() error { return e.sentinel }
 
 func handleHTTPErrorResp(resp *http.Response) error {

--- a/vendor/github.com/exoscale/egoscale/v3/operations.go
+++ b/vendor/github.com/exoscale/egoscale/v3/operations.go
@@ -2783,7 +2783,7 @@ type CreateDBAASClickhouseUserRequest struct {
 	Username DBAASUserUsername              `json:"username" validate:"required,gte=1,lte=64"`
 }
 
-func (c Client) CreateDBAASClickhouseUser(ctx context.Context, serviceName string, req CreateDBAASClickhouseUserRequest) (*Operation, error) {
+func (c Client) CreateDBAASClickhouseUser(ctx context.Context, serviceName string, req CreateDBAASClickhouseUserRequest) (*DBAASUserClickhouseSecrets, error) {
 	path := fmt.Sprintf("/dbaas-clickhouse/%v/user", serviceName)
 
 	body, err := prepareJSONBody(req)
@@ -2825,7 +2825,7 @@ func (c Client) CreateDBAASClickhouseUser(ctx context.Context, serviceName strin
 		return nil, fmt.Errorf("CreateDBAASClickhouseUser: http response: %w", err)
 	}
 
-	bodyresp := new(Operation)
+	bodyresp := new(DBAASUserClickhouseSecrets)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("CreateDBAASClickhouseUser: prepare Json response: %w", err)
 	}
@@ -2880,7 +2880,7 @@ type ResetDBAASClickhouseUserPasswordRequest struct {
 	Password DBAASUserPassword `json:"password,omitempty" validate:"omitempty,gte=8,lte=256"`
 }
 
-func (c Client) ResetDBAASClickhouseUserPassword(ctx context.Context, serviceName string, username string, req ResetDBAASClickhouseUserPasswordRequest) (*Operation, error) {
+func (c Client) ResetDBAASClickhouseUserPassword(ctx context.Context, serviceName string, username string, req ResetDBAASClickhouseUserPasswordRequest) (*DBAASUserClickhouseSecrets, error) {
 	path := fmt.Sprintf("/dbaas-clickhouse/%v/user/%v/password/reset", serviceName, username)
 
 	body, err := prepareJSONBody(req)
@@ -2922,7 +2922,7 @@ func (c Client) ResetDBAASClickhouseUserPassword(ctx context.Context, serviceNam
 		return nil, fmt.Errorf("ResetDBAASClickhouseUserPassword: http response: %w", err)
 	}
 
-	bodyresp := new(Operation)
+	bodyresp := new(DBAASUserClickhouseSecrets)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("ResetDBAASClickhouseUserPassword: prepare Json response: %w", err)
 	}

--- a/vendor/github.com/exoscale/egoscale/v3/operations.go
+++ b/vendor/github.com/exoscale/egoscale/v3/operations.go
@@ -12,9 +12,9 @@ import (
 	"time"
 )
 
-// FindAIAPIKey attempts to find an AIAPIKey by nameOrID.
-func (l ListAIAPIKeysResponse) FindAIAPIKey(nameOrID string) (AIAPIKey, error) {
-	var result []AIAPIKey
+// FindListAIAPIKeysResponseEntry attempts to find an ListAIAPIKeysResponseEntry by nameOrID.
+func (l ListAIAPIKeysResponse) FindListAIAPIKeysResponseEntry(nameOrID string) (ListAIAPIKeysResponseEntry, error) {
+	var result []ListAIAPIKeysResponseEntry
 	for i, elem := range l.AIAPIKeys {
 		if string(elem.Name) == nameOrID || string(elem.ID) == nameOrID {
 			result = append(result, l.AIAPIKeys[i])
@@ -25,15 +25,15 @@ func (l ListAIAPIKeysResponse) FindAIAPIKey(nameOrID string) (AIAPIKey, error) {
 	}
 
 	if len(result) > 1 {
-		return AIAPIKey{}, fmt.Errorf("%q too many found in ListAIAPIKeysResponse: %w", nameOrID, ErrConflict)
+		return ListAIAPIKeysResponseEntry{}, fmt.Errorf("%q too many found in ListAIAPIKeysResponse: %w", nameOrID, ErrConflict)
 	}
 
-	return AIAPIKey{}, fmt.Errorf("%q not found in ListAIAPIKeysResponse: %w", nameOrID, ErrNotFound)
+	return ListAIAPIKeysResponseEntry{}, fmt.Errorf("%q not found in ListAIAPIKeysResponse: %w", nameOrID, ErrNotFound)
 }
 
 // List AI API keys for an organization
 func (c Client) ListAIAPIKeys(ctx context.Context) (*ListAIAPIKeysResponse, error) {
-	path := "/ai/ai-api-key"
+	path := "/ai/api-key"
 
 	request, err := http.NewRequestWithContext(ctx, "GET", c.serverEndpoint+path, nil)
 	if err != nil {
@@ -76,8 +76,8 @@ func (c Client) ListAIAPIKeys(ctx context.Context) (*ListAIAPIKeysResponse, erro
 }
 
 // Create a new AI API key
-func (c Client) CreateAIAPIKey(ctx context.Context, req CreateAIAPIKeyRequest) (*AIAPIKeyWithValue, error) {
-	path := "/ai/ai-api-key"
+func (c Client) CreateAIAPIKey(ctx context.Context, req CreateAIAPIKeyRequest) (*CreateAIAPIKeyResponse, error) {
+	path := "/ai/api-key"
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
@@ -118,7 +118,7 @@ func (c Client) CreateAIAPIKey(ctx context.Context, req CreateAIAPIKeyRequest) (
 		return nil, fmt.Errorf("CreateAIAPIKey: http response: %w", err)
 	}
 
-	bodyresp := new(AIAPIKeyWithValue)
+	bodyresp := new(CreateAIAPIKeyResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("CreateAIAPIKey: prepare Json response: %w", err)
 	}
@@ -126,13 +126,9 @@ func (c Client) CreateAIAPIKey(ctx context.Context, req CreateAIAPIKeyRequest) (
 	return bodyresp, nil
 }
 
-type DeleteAIAPIKeyResponse struct {
-	Deleted *bool `json:"deleted" validate:"required"`
-}
-
 // Delete AI API key
-func (c Client) DeleteAIAPIKey(ctx context.Context, id UUID) (*DeleteAIAPIKeyResponse, error) {
-	path := fmt.Sprintf("/ai/ai-api-key/%v", id)
+func (c Client) DeleteAIAPIKey(ctx context.Context, id UUID) (*Operation, error) {
+	path := fmt.Sprintf("/ai/api-key/%v", id)
 
 	request, err := http.NewRequestWithContext(ctx, "DELETE", c.serverEndpoint+path, nil)
 	if err != nil {
@@ -166,7 +162,7 @@ func (c Client) DeleteAIAPIKey(ctx context.Context, id UUID) (*DeleteAIAPIKeyRes
 		return nil, fmt.Errorf("DeleteAIAPIKey: http response: %w", err)
 	}
 
-	bodyresp := new(DeleteAIAPIKeyResponse)
+	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("DeleteAIAPIKey: prepare Json response: %w", err)
 	}
@@ -175,8 +171,8 @@ func (c Client) DeleteAIAPIKey(ctx context.Context, id UUID) (*DeleteAIAPIKeyRes
 }
 
 // Get AI API key metadata
-func (c Client) GetAIAPIKey(ctx context.Context, id UUID) (*AIAPIKey, error) {
-	path := fmt.Sprintf("/ai/ai-api-key/%v", id)
+func (c Client) GetAIAPIKey(ctx context.Context, id UUID) (*GetAIAPIKeyResponse, error) {
+	path := fmt.Sprintf("/ai/api-key/%v", id)
 
 	request, err := http.NewRequestWithContext(ctx, "GET", c.serverEndpoint+path, nil)
 	if err != nil {
@@ -210,7 +206,7 @@ func (c Client) GetAIAPIKey(ctx context.Context, id UUID) (*AIAPIKey, error) {
 		return nil, fmt.Errorf("GetAIAPIKey: http response: %w", err)
 	}
 
-	bodyresp := new(AIAPIKey)
+	bodyresp := new(GetAIAPIKeyResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("GetAIAPIKey: prepare Json response: %w", err)
 	}
@@ -219,8 +215,8 @@ func (c Client) GetAIAPIKey(ctx context.Context, id UUID) (*AIAPIKey, error) {
 }
 
 // Update AI API key name and/or scope
-func (c Client) UpdateAIAPIKey(ctx context.Context, id UUID, req UpdateAIAPIKeyRequest) (*AIAPIKey, error) {
-	path := fmt.Sprintf("/ai/ai-api-key/%v", id)
+func (c Client) UpdateAIAPIKey(ctx context.Context, id UUID, req UpdateAIAPIKeyRequest) (*UpdateAIAPIKeyResponse, error) {
+	path := fmt.Sprintf("/ai/api-key/%v", id)
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
@@ -261,7 +257,7 @@ func (c Client) UpdateAIAPIKey(ctx context.Context, id UUID, req UpdateAIAPIKeyR
 		return nil, fmt.Errorf("UpdateAIAPIKey: http response: %w", err)
 	}
 
-	bodyresp := new(AIAPIKey)
+	bodyresp := new(UpdateAIAPIKeyResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("UpdateAIAPIKey: prepare Json response: %w", err)
 	}
@@ -269,9 +265,53 @@ func (c Client) UpdateAIAPIKey(ctx context.Context, id UUID, req UpdateAIAPIKeyR
 	return bodyresp, nil
 }
 
+// Reveal AI API key plaintext value
+func (c Client) RevealAIAPIKey(ctx context.Context, id UUID) (*RevealAIAPIKeyResponse, error) {
+	path := fmt.Sprintf("/ai/api-key/%v/reveal", id)
+
+	request, err := http.NewRequestWithContext(ctx, "GET", c.serverEndpoint+path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("RevealAIAPIKey: new request: %w", err)
+	}
+
+	request.Header.Add("User-Agent", c.getUserAgent())
+
+	if err := c.executeRequestInterceptors(ctx, request); err != nil {
+		return nil, fmt.Errorf("RevealAIAPIKey: execute request editors: %w", err)
+	}
+
+	if err := c.signRequest(request); err != nil {
+		return nil, fmt.Errorf("RevealAIAPIKey: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "reveal-ai-api-key")
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("RevealAIAPIKey: http client do: %w", err)
+	}
+
+	if c.trace {
+		dumpResponse(response)
+	}
+
+	if err := handleHTTPErrorResp(response); err != nil {
+		return nil, fmt.Errorf("RevealAIAPIKey: http response: %w", err)
+	}
+
+	bodyresp := new(RevealAIAPIKeyResponse)
+	if err := prepareJSONResponse(response, bodyresp); err != nil {
+		return nil, fmt.Errorf("RevealAIAPIKey: prepare Json response: %w", err)
+	}
+
+	return bodyresp, nil
+}
+
 // Rotate AI API key value
-func (c Client) RotateAIAPIKey(ctx context.Context, id UUID) (*AIAPIKeyWithValue, error) {
-	path := fmt.Sprintf("/ai/ai-api-key/%v/rotate", id)
+func (c Client) RotateAIAPIKey(ctx context.Context, id UUID) (*RotateAIAPIKeyResponse, error) {
+	path := fmt.Sprintf("/ai/api-key/%v/rotate", id)
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, nil)
 	if err != nil {
@@ -305,7 +345,7 @@ func (c Client) RotateAIAPIKey(ctx context.Context, id UUID) (*AIAPIKeyWithValue
 		return nil, fmt.Errorf("RotateAIAPIKey: http response: %w", err)
 	}
 
-	bodyresp := new(AIAPIKeyWithValue)
+	bodyresp := new(RotateAIAPIKeyResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("RotateAIAPIKey: prepare Json response: %w", err)
 	}
@@ -1062,6 +1102,50 @@ func (c Client) GetModel(ctx context.Context, id UUID) (*GetModelResponse, error
 	bodyresp := new(GetModelResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("GetModel: prepare Json response: %w", err)
+	}
+
+	return bodyresp, nil
+}
+
+// Get per-org Unit Of Measurement (UOM) consumption quota (UOM/min). Null means unlimited. UOM represents weighted units across different AI workloads (e.g., tokens for LLMs, minutes for TTS, pages for OCR).
+func (c Client) GetUserOrgConsumptionQuota(ctx context.Context) (*OrgConsumptionQuotaResponse, error) {
+	path := "/ai/quota"
+
+	request, err := http.NewRequestWithContext(ctx, "GET", c.serverEndpoint+path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("GetUserOrgConsumptionQuota: new request: %w", err)
+	}
+
+	request.Header.Add("User-Agent", c.getUserAgent())
+
+	if err := c.executeRequestInterceptors(ctx, request); err != nil {
+		return nil, fmt.Errorf("GetUserOrgConsumptionQuota: execute request editors: %w", err)
+	}
+
+	if err := c.signRequest(request); err != nil {
+		return nil, fmt.Errorf("GetUserOrgConsumptionQuota: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "get-user-org-consumption-quota")
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("GetUserOrgConsumptionQuota: http client do: %w", err)
+	}
+
+	if c.trace {
+		dumpResponse(response)
+	}
+
+	if err := handleHTTPErrorResp(response); err != nil {
+		return nil, fmt.Errorf("GetUserOrgConsumptionQuota: http response: %w", err)
+	}
+
+	bodyresp := new(OrgConsumptionQuotaResponse)
+	if err := prepareJSONResponse(response, bodyresp); err != nil {
+		return nil, fmt.Errorf("GetUserOrgConsumptionQuota: prepare Json response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -2297,6 +2381,593 @@ func (c Client) GetDBAASCACertificate(ctx context.Context) (*GetDBAASCACertifica
 	bodyresp := new(GetDBAASCACertificateResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("GetDBAASCACertificate: prepare Json response: %w", err)
+	}
+
+	return bodyresp, nil
+}
+
+func (c Client) DeleteDBAASServiceClickhouse(ctx context.Context, name string) (*Operation, error) {
+	path := fmt.Sprintf("/dbaas-clickhouse/%v", name)
+
+	request, err := http.NewRequestWithContext(ctx, "DELETE", c.serverEndpoint+path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("DeleteDBAASServiceClickhouse: new request: %w", err)
+	}
+
+	request.Header.Add("User-Agent", c.getUserAgent())
+
+	if err := c.executeRequestInterceptors(ctx, request); err != nil {
+		return nil, fmt.Errorf("DeleteDBAASServiceClickhouse: execute request editors: %w", err)
+	}
+
+	if err := c.signRequest(request); err != nil {
+		return nil, fmt.Errorf("DeleteDBAASServiceClickhouse: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "delete-dbaas-service-clickhouse")
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("DeleteDBAASServiceClickhouse: http client do: %w", err)
+	}
+
+	if c.trace {
+		dumpResponse(response)
+	}
+
+	if err := handleHTTPErrorResp(response); err != nil {
+		return nil, fmt.Errorf("DeleteDBAASServiceClickhouse: http response: %w", err)
+	}
+
+	bodyresp := new(Operation)
+	if err := prepareJSONResponse(response, bodyresp); err != nil {
+		return nil, fmt.Errorf("DeleteDBAASServiceClickhouse: prepare Json response: %w", err)
+	}
+
+	return bodyresp, nil
+}
+
+func (c Client) GetDBAASServiceClickhouse(ctx context.Context, name string) (*DBAASServiceClickhouse, error) {
+	path := fmt.Sprintf("/dbaas-clickhouse/%v", name)
+
+	request, err := http.NewRequestWithContext(ctx, "GET", c.serverEndpoint+path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("GetDBAASServiceClickhouse: new request: %w", err)
+	}
+
+	request.Header.Add("User-Agent", c.getUserAgent())
+
+	if err := c.executeRequestInterceptors(ctx, request); err != nil {
+		return nil, fmt.Errorf("GetDBAASServiceClickhouse: execute request editors: %w", err)
+	}
+
+	if err := c.signRequest(request); err != nil {
+		return nil, fmt.Errorf("GetDBAASServiceClickhouse: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "get-dbaas-service-clickhouse")
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("GetDBAASServiceClickhouse: http client do: %w", err)
+	}
+
+	if c.trace {
+		dumpResponse(response)
+	}
+
+	if err := handleHTTPErrorResp(response); err != nil {
+		return nil, fmt.Errorf("GetDBAASServiceClickhouse: http response: %w", err)
+	}
+
+	bodyresp := new(DBAASServiceClickhouse)
+	if err := prepareJSONResponse(response, bodyresp); err != nil {
+		return nil, fmt.Errorf("GetDBAASServiceClickhouse: prepare Json response: %w", err)
+	}
+
+	return bodyresp, nil
+}
+
+type CreateDBAASServiceClickhouseRequestMaintenanceDow string
+
+const (
+	CreateDBAASServiceClickhouseRequestMaintenanceDowSaturday  CreateDBAASServiceClickhouseRequestMaintenanceDow = "saturday"
+	CreateDBAASServiceClickhouseRequestMaintenanceDowTuesday   CreateDBAASServiceClickhouseRequestMaintenanceDow = "tuesday"
+	CreateDBAASServiceClickhouseRequestMaintenanceDowNever     CreateDBAASServiceClickhouseRequestMaintenanceDow = "never"
+	CreateDBAASServiceClickhouseRequestMaintenanceDowWednesday CreateDBAASServiceClickhouseRequestMaintenanceDow = "wednesday"
+	CreateDBAASServiceClickhouseRequestMaintenanceDowSunday    CreateDBAASServiceClickhouseRequestMaintenanceDow = "sunday"
+	CreateDBAASServiceClickhouseRequestMaintenanceDowFriday    CreateDBAASServiceClickhouseRequestMaintenanceDow = "friday"
+	CreateDBAASServiceClickhouseRequestMaintenanceDowMonday    CreateDBAASServiceClickhouseRequestMaintenanceDow = "monday"
+	CreateDBAASServiceClickhouseRequestMaintenanceDowThursday  CreateDBAASServiceClickhouseRequestMaintenanceDow = "thursday"
+)
+
+// Automatic maintenance settings
+type CreateDBAASServiceClickhouseRequestMaintenance struct {
+	// Day of week for installing updates
+	Dow CreateDBAASServiceClickhouseRequestMaintenanceDow `json:"dow" validate:"required"`
+	// Time for installing updates, UTC
+	Time string `json:"time" validate:"required,gte=8,lte=8"`
+}
+
+type CreateDBAASServiceClickhouseRequest struct {
+	// ClickHouse settings
+	ClickhouseSettings *JSONSchemaClickhouse `json:"clickhouse-settings,omitempty"`
+	ForkFromService    DBAASServiceName      `json:"fork-from-service,omitempty" validate:"omitempty,gte=0,lte=63"`
+	// Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'
+	IPFilter []string `json:"ip-filter,omitempty"`
+	// Automatic maintenance settings
+	Maintenance *CreateDBAASServiceClickhouseRequestMaintenance `json:"maintenance,omitempty"`
+	// Subscription plan
+	Plan string `json:"plan" validate:"required,gte=1,lte=128"`
+	// Name of a backup to recover from for services that support backup names
+	RecoveryBackupName string `json:"recovery-backup-name,omitempty" validate:"omitempty,gte=1"`
+	// Service is protected against termination and powering off
+	TerminationProtection *bool `json:"termination-protection,omitempty"`
+	// ClickHouse major version
+	Version string `json:"version,omitempty" validate:"omitempty,gte=1"`
+}
+
+func (c Client) CreateDBAASServiceClickhouse(ctx context.Context, name string, req CreateDBAASServiceClickhouseRequest) (*Operation, error) {
+	path := fmt.Sprintf("/dbaas-clickhouse/%v", name)
+
+	body, err := prepareJSONBody(req)
+	if err != nil {
+		return nil, fmt.Errorf("CreateDBAASServiceClickhouse: prepare Json body: %w", err)
+	}
+
+	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
+	if err != nil {
+		return nil, fmt.Errorf("CreateDBAASServiceClickhouse: new request: %w", err)
+	}
+
+	request.Header.Add("User-Agent", c.getUserAgent())
+
+	request.Header.Add("Content-Type", "application/json")
+
+	if err := c.executeRequestInterceptors(ctx, request); err != nil {
+		return nil, fmt.Errorf("CreateDBAASServiceClickhouse: execute request editors: %w", err)
+	}
+
+	if err := c.signRequest(request); err != nil {
+		return nil, fmt.Errorf("CreateDBAASServiceClickhouse: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "create-dbaas-service-clickhouse")
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("CreateDBAASServiceClickhouse: http client do: %w", err)
+	}
+
+	if c.trace {
+		dumpResponse(response)
+	}
+
+	if err := handleHTTPErrorResp(response); err != nil {
+		return nil, fmt.Errorf("CreateDBAASServiceClickhouse: http response: %w", err)
+	}
+
+	bodyresp := new(Operation)
+	if err := prepareJSONResponse(response, bodyresp); err != nil {
+		return nil, fmt.Errorf("CreateDBAASServiceClickhouse: prepare Json response: %w", err)
+	}
+
+	return bodyresp, nil
+}
+
+type UpdateDBAASServiceClickhouseRequestMaintenanceDow string
+
+const (
+	UpdateDBAASServiceClickhouseRequestMaintenanceDowSaturday  UpdateDBAASServiceClickhouseRequestMaintenanceDow = "saturday"
+	UpdateDBAASServiceClickhouseRequestMaintenanceDowTuesday   UpdateDBAASServiceClickhouseRequestMaintenanceDow = "tuesday"
+	UpdateDBAASServiceClickhouseRequestMaintenanceDowNever     UpdateDBAASServiceClickhouseRequestMaintenanceDow = "never"
+	UpdateDBAASServiceClickhouseRequestMaintenanceDowWednesday UpdateDBAASServiceClickhouseRequestMaintenanceDow = "wednesday"
+	UpdateDBAASServiceClickhouseRequestMaintenanceDowSunday    UpdateDBAASServiceClickhouseRequestMaintenanceDow = "sunday"
+	UpdateDBAASServiceClickhouseRequestMaintenanceDowFriday    UpdateDBAASServiceClickhouseRequestMaintenanceDow = "friday"
+	UpdateDBAASServiceClickhouseRequestMaintenanceDowMonday    UpdateDBAASServiceClickhouseRequestMaintenanceDow = "monday"
+	UpdateDBAASServiceClickhouseRequestMaintenanceDowThursday  UpdateDBAASServiceClickhouseRequestMaintenanceDow = "thursday"
+)
+
+// Automatic maintenance settings
+type UpdateDBAASServiceClickhouseRequestMaintenance struct {
+	// Day of week for installing updates
+	Dow UpdateDBAASServiceClickhouseRequestMaintenanceDow `json:"dow" validate:"required"`
+	// Time for installing updates, UTC
+	Time string `json:"time" validate:"required,gte=8,lte=8"`
+}
+
+type UpdateDBAASServiceClickhouseRequest struct {
+	// ClickHouse settings
+	ClickhouseSettings *JSONSchemaClickhouse `json:"clickhouse-settings,omitempty"`
+	// Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'
+	IPFilter []string `json:"ip-filter,omitempty"`
+	// Automatic maintenance settings
+	Maintenance *UpdateDBAASServiceClickhouseRequestMaintenance `json:"maintenance,omitempty"`
+	// Subscription plan
+	Plan string `json:"plan,omitempty" validate:"omitempty,gte=1,lte=128"`
+	// Service is protected against termination and powering off
+	TerminationProtection *bool `json:"termination-protection,omitempty"`
+	// ClickHouse major version
+	Version string `json:"version,omitempty" validate:"omitempty,gte=1"`
+}
+
+func (c Client) UpdateDBAASServiceClickhouse(ctx context.Context, name string, req UpdateDBAASServiceClickhouseRequest) (*Operation, error) {
+	path := fmt.Sprintf("/dbaas-clickhouse/%v", name)
+
+	body, err := prepareJSONBody(req)
+	if err != nil {
+		return nil, fmt.Errorf("UpdateDBAASServiceClickhouse: prepare Json body: %w", err)
+	}
+
+	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
+	if err != nil {
+		return nil, fmt.Errorf("UpdateDBAASServiceClickhouse: new request: %w", err)
+	}
+
+	request.Header.Add("User-Agent", c.getUserAgent())
+
+	request.Header.Add("Content-Type", "application/json")
+
+	if err := c.executeRequestInterceptors(ctx, request); err != nil {
+		return nil, fmt.Errorf("UpdateDBAASServiceClickhouse: execute request editors: %w", err)
+	}
+
+	if err := c.signRequest(request); err != nil {
+		return nil, fmt.Errorf("UpdateDBAASServiceClickhouse: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "update-dbaas-service-clickhouse")
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("UpdateDBAASServiceClickhouse: http client do: %w", err)
+	}
+
+	if c.trace {
+		dumpResponse(response)
+	}
+
+	if err := handleHTTPErrorResp(response); err != nil {
+		return nil, fmt.Errorf("UpdateDBAASServiceClickhouse: http response: %w", err)
+	}
+
+	bodyresp := new(Operation)
+	if err := prepareJSONResponse(response, bodyresp); err != nil {
+		return nil, fmt.Errorf("UpdateDBAASServiceClickhouse: prepare Json response: %w", err)
+	}
+
+	return bodyresp, nil
+}
+
+func (c Client) StartDBAASClickhouseMaintenance(ctx context.Context, name string) (*Operation, error) {
+	path := fmt.Sprintf("/dbaas-clickhouse/%v/maintenance/start", name)
+
+	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("StartDBAASClickhouseMaintenance: new request: %w", err)
+	}
+
+	request.Header.Add("User-Agent", c.getUserAgent())
+
+	if err := c.executeRequestInterceptors(ctx, request); err != nil {
+		return nil, fmt.Errorf("StartDBAASClickhouseMaintenance: execute request editors: %w", err)
+	}
+
+	if err := c.signRequest(request); err != nil {
+		return nil, fmt.Errorf("StartDBAASClickhouseMaintenance: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "start-dbaas-clickhouse-maintenance")
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("StartDBAASClickhouseMaintenance: http client do: %w", err)
+	}
+
+	if c.trace {
+		dumpResponse(response)
+	}
+
+	if err := handleHTTPErrorResp(response); err != nil {
+		return nil, fmt.Errorf("StartDBAASClickhouseMaintenance: http response: %w", err)
+	}
+
+	bodyresp := new(Operation)
+	if err := prepareJSONResponse(response, bodyresp); err != nil {
+		return nil, fmt.Errorf("StartDBAASClickhouseMaintenance: prepare Json response: %w", err)
+	}
+
+	return bodyresp, nil
+}
+
+func (c Client) GetDBAASClickhouseAclConfig(ctx context.Context, serviceName string) (*DBAASClickhouseAclConfig, error) {
+	path := fmt.Sprintf("/dbaas-clickhouse/%v/acl-config", serviceName)
+
+	request, err := http.NewRequestWithContext(ctx, "GET", c.serverEndpoint+path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("GetDBAASClickhouseAclConfig: new request: %w", err)
+	}
+
+	request.Header.Add("User-Agent", c.getUserAgent())
+
+	if err := c.executeRequestInterceptors(ctx, request); err != nil {
+		return nil, fmt.Errorf("GetDBAASClickhouseAclConfig: execute request editors: %w", err)
+	}
+
+	if err := c.signRequest(request); err != nil {
+		return nil, fmt.Errorf("GetDBAASClickhouseAclConfig: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "get-dbaas-clickhouse-acl-config")
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("GetDBAASClickhouseAclConfig: http client do: %w", err)
+	}
+
+	if c.trace {
+		dumpResponse(response)
+	}
+
+	if err := handleHTTPErrorResp(response); err != nil {
+		return nil, fmt.Errorf("GetDBAASClickhouseAclConfig: http response: %w", err)
+	}
+
+	bodyresp := new(DBAASClickhouseAclConfig)
+	if err := prepareJSONResponse(response, bodyresp); err != nil {
+		return nil, fmt.Errorf("GetDBAASClickhouseAclConfig: prepare Json response: %w", err)
+	}
+
+	return bodyresp, nil
+}
+
+func (c Client) ListDBAASClickhouseUsers(ctx context.Context, serviceName string) (*DBAASClickhouseUsers, error) {
+	path := fmt.Sprintf("/dbaas-clickhouse/%v/user", serviceName)
+
+	request, err := http.NewRequestWithContext(ctx, "GET", c.serverEndpoint+path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("ListDBAASClickhouseUsers: new request: %w", err)
+	}
+
+	request.Header.Add("User-Agent", c.getUserAgent())
+
+	if err := c.executeRequestInterceptors(ctx, request); err != nil {
+		return nil, fmt.Errorf("ListDBAASClickhouseUsers: execute request editors: %w", err)
+	}
+
+	if err := c.signRequest(request); err != nil {
+		return nil, fmt.Errorf("ListDBAASClickhouseUsers: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "list-dbaas-clickhouse-users")
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("ListDBAASClickhouseUsers: http client do: %w", err)
+	}
+
+	if c.trace {
+		dumpResponse(response)
+	}
+
+	if err := handleHTTPErrorResp(response); err != nil {
+		return nil, fmt.Errorf("ListDBAASClickhouseUsers: http response: %w", err)
+	}
+
+	bodyresp := new(DBAASClickhouseUsers)
+	if err := prepareJSONResponse(response, bodyresp); err != nil {
+		return nil, fmt.Errorf("ListDBAASClickhouseUsers: prepare Json response: %w", err)
+	}
+
+	return bodyresp, nil
+}
+
+type CreateDBAASClickhouseUserRequest struct {
+	Password DBAASUserPassword `json:"password,omitempty" validate:"omitempty,gte=8,lte=256"`
+	// ClickHouse roles to grant to the user
+	Roles    []DBAASClickhouseUserRoleInput `json:"roles,omitempty"`
+	Username DBAASUserUsername              `json:"username" validate:"required,gte=1,lte=64"`
+}
+
+func (c Client) CreateDBAASClickhouseUser(ctx context.Context, serviceName string, req CreateDBAASClickhouseUserRequest) (*Operation, error) {
+	path := fmt.Sprintf("/dbaas-clickhouse/%v/user", serviceName)
+
+	body, err := prepareJSONBody(req)
+	if err != nil {
+		return nil, fmt.Errorf("CreateDBAASClickhouseUser: prepare Json body: %w", err)
+	}
+
+	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
+	if err != nil {
+		return nil, fmt.Errorf("CreateDBAASClickhouseUser: new request: %w", err)
+	}
+
+	request.Header.Add("User-Agent", c.getUserAgent())
+
+	request.Header.Add("Content-Type", "application/json")
+
+	if err := c.executeRequestInterceptors(ctx, request); err != nil {
+		return nil, fmt.Errorf("CreateDBAASClickhouseUser: execute request editors: %w", err)
+	}
+
+	if err := c.signRequest(request); err != nil {
+		return nil, fmt.Errorf("CreateDBAASClickhouseUser: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "create-dbaas-clickhouse-user")
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("CreateDBAASClickhouseUser: http client do: %w", err)
+	}
+
+	if c.trace {
+		dumpResponse(response)
+	}
+
+	if err := handleHTTPErrorResp(response); err != nil {
+		return nil, fmt.Errorf("CreateDBAASClickhouseUser: http response: %w", err)
+	}
+
+	bodyresp := new(Operation)
+	if err := prepareJSONResponse(response, bodyresp); err != nil {
+		return nil, fmt.Errorf("CreateDBAASClickhouseUser: prepare Json response: %w", err)
+	}
+
+	return bodyresp, nil
+}
+
+func (c Client) DeleteDBAASClickhouseUser(ctx context.Context, serviceName string, username string) (*Operation, error) {
+	path := fmt.Sprintf("/dbaas-clickhouse/%v/user/%v", serviceName, username)
+
+	request, err := http.NewRequestWithContext(ctx, "DELETE", c.serverEndpoint+path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("DeleteDBAASClickhouseUser: new request: %w", err)
+	}
+
+	request.Header.Add("User-Agent", c.getUserAgent())
+
+	if err := c.executeRequestInterceptors(ctx, request); err != nil {
+		return nil, fmt.Errorf("DeleteDBAASClickhouseUser: execute request editors: %w", err)
+	}
+
+	if err := c.signRequest(request); err != nil {
+		return nil, fmt.Errorf("DeleteDBAASClickhouseUser: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "delete-dbaas-clickhouse-user")
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("DeleteDBAASClickhouseUser: http client do: %w", err)
+	}
+
+	if c.trace {
+		dumpResponse(response)
+	}
+
+	if err := handleHTTPErrorResp(response); err != nil {
+		return nil, fmt.Errorf("DeleteDBAASClickhouseUser: http response: %w", err)
+	}
+
+	bodyresp := new(Operation)
+	if err := prepareJSONResponse(response, bodyresp); err != nil {
+		return nil, fmt.Errorf("DeleteDBAASClickhouseUser: prepare Json response: %w", err)
+	}
+
+	return bodyresp, nil
+}
+
+type ResetDBAASClickhouseUserPasswordRequest struct {
+	Password DBAASUserPassword `json:"password,omitempty" validate:"omitempty,gte=8,lte=256"`
+}
+
+func (c Client) ResetDBAASClickhouseUserPassword(ctx context.Context, serviceName string, username string, req ResetDBAASClickhouseUserPasswordRequest) (*Operation, error) {
+	path := fmt.Sprintf("/dbaas-clickhouse/%v/user/%v/password/reset", serviceName, username)
+
+	body, err := prepareJSONBody(req)
+	if err != nil {
+		return nil, fmt.Errorf("ResetDBAASClickhouseUserPassword: prepare Json body: %w", err)
+	}
+
+	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
+	if err != nil {
+		return nil, fmt.Errorf("ResetDBAASClickhouseUserPassword: new request: %w", err)
+	}
+
+	request.Header.Add("User-Agent", c.getUserAgent())
+
+	request.Header.Add("Content-Type", "application/json")
+
+	if err := c.executeRequestInterceptors(ctx, request); err != nil {
+		return nil, fmt.Errorf("ResetDBAASClickhouseUserPassword: execute request editors: %w", err)
+	}
+
+	if err := c.signRequest(request); err != nil {
+		return nil, fmt.Errorf("ResetDBAASClickhouseUserPassword: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "reset-dbaas-clickhouse-user-password")
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("ResetDBAASClickhouseUserPassword: http client do: %w", err)
+	}
+
+	if c.trace {
+		dumpResponse(response)
+	}
+
+	if err := handleHTTPErrorResp(response); err != nil {
+		return nil, fmt.Errorf("ResetDBAASClickhouseUserPassword: http response: %w", err)
+	}
+
+	bodyresp := new(Operation)
+	if err := prepareJSONResponse(response, bodyresp); err != nil {
+		return nil, fmt.Errorf("ResetDBAASClickhouseUserPassword: prepare Json response: %w", err)
+	}
+
+	return bodyresp, nil
+}
+
+func (c Client) RevealDBAASClickhouseUserPassword(ctx context.Context, serviceName string, username string) (*DBAASUserClickhouseSecrets, error) {
+	path := fmt.Sprintf("/dbaas-clickhouse/%v/user/%v/password/reveal", serviceName, username)
+
+	request, err := http.NewRequestWithContext(ctx, "GET", c.serverEndpoint+path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("RevealDBAASClickhouseUserPassword: new request: %w", err)
+	}
+
+	request.Header.Add("User-Agent", c.getUserAgent())
+
+	if err := c.executeRequestInterceptors(ctx, request); err != nil {
+		return nil, fmt.Errorf("RevealDBAASClickhouseUserPassword: execute request editors: %w", err)
+	}
+
+	if err := c.signRequest(request); err != nil {
+		return nil, fmt.Errorf("RevealDBAASClickhouseUserPassword: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "reveal-dbaas-clickhouse-user-password")
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("RevealDBAASClickhouseUserPassword: http client do: %w", err)
+	}
+
+	if c.trace {
+		dumpResponse(response)
+	}
+
+	if err := handleHTTPErrorResp(response); err != nil {
+		return nil, fmt.Errorf("RevealDBAASClickhouseUserPassword: http response: %w", err)
+	}
+
+	bodyresp := new(DBAASUserClickhouseSecrets)
+	if err := prepareJSONResponse(response, bodyresp); err != nil {
+		return nil, fmt.Errorf("RevealDBAASClickhouseUserPassword: prepare Json response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -5535,6 +6206,8 @@ type UpdateDBAASServiceMysqlRequest struct {
 	Plan string `json:"plan,omitempty" validate:"omitempty,gte=1,lte=128"`
 	// Service is protected against termination and powering off
 	TerminationProtection *bool `json:"termination-protection,omitempty"`
+	// MySQL version
+	Version string `json:"version,omitempty"`
 }
 
 // Update a DBaaS MySQL service
@@ -6864,6 +7537,8 @@ type CreateDBAASServicePGRequest struct {
 	Migration *CreateDBAASServicePGRequestMigration `json:"migration,omitempty"`
 	// postgresql.conf configuration values
 	PGSettings *JSONSchemaPG `json:"pg-settings,omitempty"`
+	// System-wide settings for the pgaudit extension.
+	PgauditSettings *JSONSchemaPgaudit `json:"pgaudit-settings,omitempty"`
 	// System-wide settings for pgbouncer.
 	PgbouncerSettings *JSONSchemaPgbouncer `json:"pgbouncer-settings,omitempty"`
 	// System-wide settings for pglookout.
@@ -6992,6 +7667,8 @@ type UpdateDBAASServicePGRequest struct {
 	Migration *UpdateDBAASServicePGRequestMigration `json:"migration,omitempty"`
 	// postgresql.conf configuration values
 	PGSettings *JSONSchemaPG `json:"pg-settings,omitempty"`
+	// System-wide settings for the pgaudit extension.
+	PgauditSettings *JSONSchemaPgaudit `json:"pgaudit-settings,omitempty"`
 	// System-wide settings for pgbouncer.
 	PgbouncerSettings *JSONSchemaPgbouncer `json:"pgbouncer-settings,omitempty"`
 	// System-wide settings for pglookout.
@@ -8062,6 +8739,66 @@ func (c Client) DeleteDBAASService(ctx context.Context, name string) (*Operation
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("DeleteDBAASService: prepare Json response: %w", err)
+	}
+
+	return bodyresp, nil
+}
+
+// ClickHouse configuration values
+type GetDBAASSettingsClickhouseResponseSettingsClickhouse struct {
+	AdditionalProperties *bool          `json:"additionalProperties,omitempty"`
+	Properties           map[string]any `json:"properties,omitempty"`
+	Title                string         `json:"title,omitempty"`
+	Type                 string         `json:"type,omitempty"`
+}
+
+type GetDBAASSettingsClickhouseResponseSettings struct {
+	// ClickHouse configuration values
+	Clickhouse *GetDBAASSettingsClickhouseResponseSettingsClickhouse `json:"clickhouse,omitempty"`
+}
+
+type GetDBAASSettingsClickhouseResponse struct {
+	Settings *GetDBAASSettingsClickhouseResponseSettings `json:"settings,omitempty"`
+}
+
+func (c Client) GetDBAASSettingsClickhouse(ctx context.Context) (*GetDBAASSettingsClickhouseResponse, error) {
+	path := "/dbaas-settings-clickhouse"
+
+	request, err := http.NewRequestWithContext(ctx, "GET", c.serverEndpoint+path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("GetDBAASSettingsClickhouse: new request: %w", err)
+	}
+
+	request.Header.Add("User-Agent", c.getUserAgent())
+
+	if err := c.executeRequestInterceptors(ctx, request); err != nil {
+		return nil, fmt.Errorf("GetDBAASSettingsClickhouse: execute request editors: %w", err)
+	}
+
+	if err := c.signRequest(request); err != nil {
+		return nil, fmt.Errorf("GetDBAASSettingsClickhouse: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "get-dbaas-settings-clickhouse")
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("GetDBAASSettingsClickhouse: http client do: %w", err)
+	}
+
+	if c.trace {
+		dumpResponse(response)
+	}
+
+	if err := handleHTTPErrorResp(response); err != nil {
+		return nil, fmt.Errorf("GetDBAASSettingsClickhouse: http response: %w", err)
+	}
+
+	bodyresp := new(GetDBAASSettingsClickhouseResponse)
+	if err := prepareJSONResponse(response, bodyresp); err != nil {
+		return nil, fmt.Errorf("GetDBAASSettingsClickhouse: prepare Json response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -9143,6 +9880,8 @@ type CreateDBAASServiceValkeyRequest struct {
 	TerminationProtection *bool `json:"termination-protection,omitempty"`
 	// Valkey settings
 	ValkeySettings *JSONSchemaValkey `json:"valkey-settings,omitempty"`
+	// Valkey major version
+	Version string `json:"version,omitempty" validate:"omitempty,gte=1"`
 }
 
 // Create a DBaaS Valkey service
@@ -9249,6 +9988,8 @@ type UpdateDBAASServiceValkeyRequest struct {
 	TerminationProtection *bool `json:"termination-protection,omitempty"`
 	// Valkey settings
 	ValkeySettings *JSONSchemaValkey `json:"valkey-settings,omitempty"`
+	// Valkey major version
+	Version string `json:"version,omitempty" validate:"omitempty,gte=1"`
 }
 
 // Update a DBaaS Valkey service
@@ -11115,8 +11856,8 @@ func (c Client) ListIAMRoles(ctx context.Context) (*ListIAMRolesResponse, error)
 }
 
 type CreateIAMRoleRequest struct {
-	// Policy
-	AssumeRolePolicy *IAMPolicy `json:"assume-role-policy,omitempty"`
+	// Assume Role Policy
+	AssumeRolePolicy *IAMAssumeRolePolicy `json:"assume-role-policy,omitempty"`
 	// IAM Role description
 	Description string `json:"description,omitempty" validate:"omitempty,gte=1,lte=255"`
 	// Sets if the IAM Role Policy is editable or not (default: true). This setting cannot be changed after creation
@@ -11272,6 +12013,8 @@ func (c Client) GetIAMRole(ctx context.Context, id UUID) (*IAMRole, error) {
 }
 
 type UpdateIAMRoleRequest struct {
+	// Assume Role Policy
+	AssumeRolePolicy *IAMAssumeRolePolicy `json:"assume-role-policy,omitempty"`
 	// IAM Role description
 	Description string `json:"description,omitempty" validate:"omitempty,gte=1,lte=255"`
 	Labels      Labels `json:"labels,omitempty"`
@@ -11332,18 +12075,32 @@ func (c Client) UpdateIAMRole(ctx context.Context, id UUID, req UpdateIAMRoleReq
 	return bodyresp, nil
 }
 
-// Update IAM Assume role Policy
-func (c Client) UpdateIAMRoleAssumePolicy(ctx context.Context, id UUID, req IAMPolicy) (*Operation, error) {
-	path := fmt.Sprintf("/iam-role/%v:assume-role-policy", id)
+type AssumeIAMRoleResponse struct {
+	ExpiresAT string `json:"expires-at,omitempty"`
+	Key       string `json:"key,omitempty"`
+	Name      string `json:"name,omitempty"`
+	OrgID     string `json:"org-id,omitempty"`
+	RoleID    string `json:"role-id,omitempty"`
+	Secret    string `json:"secret,omitempty"`
+}
+
+type AssumeIAMRoleRequest struct {
+	// TTL in seconds for the generated access key (cannot exceed the max TTL defined in the targeted assume role)
+	Ttl int64 `json:"ttl" validate:"required,gt=0"`
+}
+
+// [BETA] Request generation of key/secret that allow caller to assume target role
+func (c Client) AssumeIAMRole(ctx context.Context, id UUID, req AssumeIAMRoleRequest) (*AssumeIAMRoleResponse, error) {
+	path := fmt.Sprintf("/iam-role/%v/assume", id)
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateIAMRoleAssumePolicy: prepare Json body: %w", err)
+		return nil, fmt.Errorf("AssumeIAMRole: prepare Json body: %w", err)
 	}
 
-	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
+	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateIAMRoleAssumePolicy: new request: %w", err)
+		return nil, fmt.Errorf("AssumeIAMRole: new request: %w", err)
 	}
 
 	request.Header.Add("User-Agent", c.getUserAgent())
@@ -11351,20 +12108,20 @@ func (c Client) UpdateIAMRoleAssumePolicy(ctx context.Context, id UUID, req IAMP
 	request.Header.Add("Content-Type", "application/json")
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
-		return nil, fmt.Errorf("UpdateIAMRoleAssumePolicy: execute request editors: %w", err)
+		return nil, fmt.Errorf("AssumeIAMRole: execute request editors: %w", err)
 	}
 
 	if err := c.signRequest(request); err != nil {
-		return nil, fmt.Errorf("UpdateIAMRoleAssumePolicy: sign request: %w", err)
+		return nil, fmt.Errorf("AssumeIAMRole: sign request: %w", err)
 	}
 
 	if c.trace {
-		dumpRequest(request, "update-iam-role-assume-policy")
+		dumpRequest(request, "assume-iam-role")
 	}
 
 	response, err := c.httpClient.Do(request)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateIAMRoleAssumePolicy: http client do: %w", err)
+		return nil, fmt.Errorf("AssumeIAMRole: http client do: %w", err)
 	}
 
 	if c.trace {
@@ -11372,12 +12129,12 @@ func (c Client) UpdateIAMRoleAssumePolicy(ctx context.Context, id UUID, req IAMP
 	}
 
 	if err := handleHTTPErrorResp(response); err != nil {
-		return nil, fmt.Errorf("UpdateIAMRoleAssumePolicy: http response: %w", err)
+		return nil, fmt.Errorf("AssumeIAMRole: http response: %w", err)
 	}
 
-	bodyresp := new(Operation)
+	bodyresp := new(AssumeIAMRoleResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateIAMRoleAssumePolicy: prepare Json response: %w", err)
+		return nil, fmt.Errorf("AssumeIAMRole: prepare Json response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -11429,70 +12186,6 @@ func (c Client) UpdateIAMRolePolicy(ctx context.Context, id UUID, req IAMPolicy)
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("UpdateIAMRolePolicy: prepare Json response: %w", err)
-	}
-
-	return bodyresp, nil
-}
-
-type AssumeIAMRoleResponse struct {
-	Key    string `json:"key,omitempty"`
-	Name   string `json:"name,omitempty"`
-	OrgID  string `json:"org-id,omitempty"`
-	RoleID string `json:"role-id,omitempty"`
-	Secret string `json:"secret,omitempty"`
-}
-
-type AssumeIAMRoleRequest struct {
-	// TTL in seconds for the generated access key (cannot exceed the max TTL defined in the targeted assume role)
-	Ttl int64 `json:"ttl,omitempty" validate:"omitempty,gt=0"`
-}
-
-// [BETA] Request generation of key/secret that allow caller to assume target role
-func (c Client) AssumeIAMRole(ctx context.Context, targetRoleID UUID, req AssumeIAMRoleRequest) (*AssumeIAMRoleResponse, error) {
-	path := fmt.Sprintf("/iam-role/%v/assume", targetRoleID)
-
-	body, err := prepareJSONBody(req)
-	if err != nil {
-		return nil, fmt.Errorf("AssumeIAMRole: prepare Json body: %w", err)
-	}
-
-	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
-	if err != nil {
-		return nil, fmt.Errorf("AssumeIAMRole: new request: %w", err)
-	}
-
-	request.Header.Add("User-Agent", c.getUserAgent())
-
-	request.Header.Add("Content-Type", "application/json")
-
-	if err := c.executeRequestInterceptors(ctx, request); err != nil {
-		return nil, fmt.Errorf("AssumeIAMRole: execute request editors: %w", err)
-	}
-
-	if err := c.signRequest(request); err != nil {
-		return nil, fmt.Errorf("AssumeIAMRole: sign request: %w", err)
-	}
-
-	if c.trace {
-		dumpRequest(request, "assume-iam-role")
-	}
-
-	response, err := c.httpClient.Do(request)
-	if err != nil {
-		return nil, fmt.Errorf("AssumeIAMRole: http client do: %w", err)
-	}
-
-	if c.trace {
-		dumpResponse(response)
-	}
-
-	if err := handleHTTPErrorResp(response); err != nil {
-		return nil, fmt.Errorf("AssumeIAMRole: http response: %w", err)
-	}
-
-	bodyresp := new(AssumeIAMRoleResponse)
-	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("AssumeIAMRole: prepare Json response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -13232,7 +13925,7 @@ func (l ListKmsKeysResponse) FindListKmsKeysResponseEntry(nameOrID string) (List
 	return ListKmsKeysResponseEntry{}, fmt.Errorf("%q not found in ListKmsKeysResponse: %w", nameOrID, ErrNotFound)
 }
 
-// List KMS Keys details for an organization in a given zone.
+// Lists all KMS Keys in your organization in a given zone.
 func (c Client) ListKmsKeys(ctx context.Context) (*ListKmsKeysResponse, error) {
 	path := "/kms-key"
 
@@ -13276,7 +13969,7 @@ func (c Client) ListKmsKeys(ctx context.Context) (*ListKmsKeysResponse, error) {
 	return bodyresp, nil
 }
 
-// Create a KMS Key in a given zone with a given name.
+// Create a customer-managed unique KMS Key in your organization. A KMS Key is a logical represention of a cryptographic key material. It also includes metadata such as a UUID, a name and its state.
 func (c Client) CreateKmsKey(ctx context.Context, req CreateKmsKeyRequest) (*CreateKmsKeyResponse, error) {
 	path := "/kms-key"
 
@@ -13371,7 +14064,7 @@ func (c Client) GetKmsKey(ctx context.Context, id UUID) (*GetKmsKeyResponse, err
 	return bodyresp, nil
 }
 
-// Cancel the scheduled deletion of a KMS Key.
+// Cancels the scheduled deletion of a KMS Key.
 func (c Client) CancelKmsKeyDeletion(ctx context.Context, id UUID) (*SuccessResponse, error) {
 	path := fmt.Sprintf("/kms-key/%v/cancel-deletion", id)
 
@@ -13415,7 +14108,7 @@ func (c Client) CancelKmsKeyDeletion(ctx context.Context, id UUID) (*SuccessResp
 	return bodyresp, nil
 }
 
-// Decrypt a ciphertext.
+// Decrypts a ciphertext.
 func (c Client) Decrypt(ctx context.Context, id UUID, req DecryptRequest) (*DecryptResponse, error) {
 	path := fmt.Sprintf("/kms-key/%v/decrypt", id)
 
@@ -13466,7 +14159,7 @@ func (c Client) Decrypt(ctx context.Context, id UUID, req DecryptRequest) (*Decr
 	return bodyresp, nil
 }
 
-// Disable a KMS Key
+// Disables a KMS Key by setting its state to "disabled". This prevents the use of the KMS key for cryptographic and key lifecycle operations.
 func (c Client) DisableKmsKey(ctx context.Context, id UUID) (*SuccessResponse, error) {
 	path := fmt.Sprintf("/kms-key/%v/disable", id)
 
@@ -13554,7 +14247,7 @@ func (c Client) DisableKmsKeyRotation(ctx context.Context, id UUID) (*DisableKms
 	return bodyresp, nil
 }
 
-// Enable a KMS Key"
+// Enables a KMS Key by setting its stated to "enabled". It restores the ability to fully use the KMS key for cryptographic operations and key lifecycle operations.
 func (c Client) EnableKmsKey(ctx context.Context, id UUID) (*SuccessResponse, error) {
 	path := fmt.Sprintf("/kms-key/%v/enable", id)
 
@@ -13649,7 +14342,7 @@ func (c Client) EnableKmsKeyRotation(ctx context.Context, id UUID, req EnableKms
 	return bodyresp, nil
 }
 
-// Encrypt a plaintext.
+// Encrypts a plaintext.
 func (c Client) Encrypt(ctx context.Context, id UUID, req EncryptRequest) (*EncryptResponse, error) {
 	path := fmt.Sprintf("/kms-key/%v/encrypt", id)
 
@@ -13897,7 +14590,7 @@ func (c Client) ReplicateKmsKey(ctx context.Context, id UUID, req ReplicateKmsKe
 	return bodyresp, nil
 }
 
-// Perform a manual rotation of the key material for a symmetric key.
+// Performs an immediate rotation of the key material for a symmetric key.
 func (c Client) RotateKmsKey(ctx context.Context, id UUID) (*RotateKmsKeyResponse, error) {
 	path := fmt.Sprintf("/kms-key/%v/rotate", id)
 
@@ -13941,8 +14634,8 @@ func (c Client) RotateKmsKey(ctx context.Context, id UUID) (*RotateKmsKeyRespons
 	return bodyresp, nil
 }
 
-// Schedule a KMS key for deletion after a delay.
-func (c Client) ScheduleKmsKeyDeletion(ctx context.Context, id UUID, req ScheduleKmsKeyDeletionRequest) (*SuccessResponse, error) {
+// Schedules a KMS key for deletion after a delay. You can specify a delay of 7-30 days.
+func (c Client) ScheduleKmsKeyDeletion(ctx context.Context, id UUID, req ScheduleKmsKeyDeletionRequest) (*ScheduleKmsKeyDeletionResponse, error) {
 	path := fmt.Sprintf("/kms-key/%v/schedule-deletion", id)
 
 	body, err := prepareJSONBody(req)
@@ -13984,9 +14677,53 @@ func (c Client) ScheduleKmsKeyDeletion(ctx context.Context, id UUID, req Schedul
 		return nil, fmt.Errorf("ScheduleKmsKeyDeletion: http response: %w", err)
 	}
 
-	bodyresp := new(SuccessResponse)
+	bodyresp := new(ScheduleKmsKeyDeletionResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("ScheduleKmsKeyDeletion: prepare Json response: %w", err)
+	}
+
+	return bodyresp, nil
+}
+
+// [BETA] Returns the live-balance of the current organization.
+func (c Client) GetLiveBalance(ctx context.Context) (*LiveBalance, error) {
+	path := "/live-balance"
+
+	request, err := http.NewRequestWithContext(ctx, "GET", c.serverEndpoint+path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("GetLiveBalance: new request: %w", err)
+	}
+
+	request.Header.Add("User-Agent", c.getUserAgent())
+
+	if err := c.executeRequestInterceptors(ctx, request); err != nil {
+		return nil, fmt.Errorf("GetLiveBalance: execute request editors: %w", err)
+	}
+
+	if err := c.signRequest(request); err != nil {
+		return nil, fmt.Errorf("GetLiveBalance: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "get-live-balance")
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("GetLiveBalance: http client do: %w", err)
+	}
+
+	if c.trace {
+		dumpResponse(response)
+	}
+
+	if err := handleHTTPErrorResp(response); err != nil {
+		return nil, fmt.Errorf("GetLiveBalance: http response: %w", err)
+	}
+
+	bodyresp := new(LiveBalance)
+	if err := prepareJSONResponse(response, bodyresp); err != nil {
+		return nil, fmt.Errorf("GetLiveBalance: prepare Json response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -16315,7 +17052,7 @@ type CreateSKSClusterRequest struct {
 	Level CreateSKSClusterRequestLevel `json:"level" validate:"required"`
 	// Cluster name
 	Name string `json:"name" validate:"required,gte=1,lte=255"`
-	// Cluster networking configuration.
+	// EXPERIMENTAL: Cluster networking configuration.
 	Networking *Networking `json:"networking,omitempty"`
 	// SKS Cluster OpenID config map
 	Oidc *SKSOidc `json:"oidc,omitempty"`
@@ -16752,6 +17489,102 @@ func (c Client) GetSKSClusterAuthorityCert(ctx context.Context, id UUID, authori
 	return bodyresp, nil
 }
 
+type GenerateSKSKarpenterExoscaleNodeclassResponse struct {
+	ExoscaleNodeclass string `json:"exoscale-nodeclass,omitempty"`
+}
+
+// Generate a Karpenter ExoscaleNodeClass manifest for an SKS cluster, including its default security group and feature flags if present
+func (c Client) GenerateSKSKarpenterExoscaleNodeclass(ctx context.Context, id UUID) (*GenerateSKSKarpenterExoscaleNodeclassResponse, error) {
+	path := fmt.Sprintf("/sks-cluster/%v/generate-karpenter-exoscale-nodeclass", id)
+
+	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("GenerateSKSKarpenterExoscaleNodeclass: new request: %w", err)
+	}
+
+	request.Header.Add("User-Agent", c.getUserAgent())
+
+	if err := c.executeRequestInterceptors(ctx, request); err != nil {
+		return nil, fmt.Errorf("GenerateSKSKarpenterExoscaleNodeclass: execute request editors: %w", err)
+	}
+
+	if err := c.signRequest(request); err != nil {
+		return nil, fmt.Errorf("GenerateSKSKarpenterExoscaleNodeclass: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "generate-sks-karpenter-exoscale-nodeclass")
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("GenerateSKSKarpenterExoscaleNodeclass: http client do: %w", err)
+	}
+
+	if c.trace {
+		dumpResponse(response)
+	}
+
+	if err := handleHTTPErrorResp(response); err != nil {
+		return nil, fmt.Errorf("GenerateSKSKarpenterExoscaleNodeclass: http response: %w", err)
+	}
+
+	bodyresp := new(GenerateSKSKarpenterExoscaleNodeclassResponse)
+	if err := prepareJSONResponse(response, bodyresp); err != nil {
+		return nil, fmt.Errorf("GenerateSKSKarpenterExoscaleNodeclass: prepare Json response: %w", err)
+	}
+
+	return bodyresp, nil
+}
+
+type GenerateSKSKarpenterNodepoolResponse struct {
+	Nodepool string `json:"nodepool,omitempty"`
+}
+
+// Generate a Karpenter NodePool manifest with minimal configuration for an SKS cluster
+func (c Client) GenerateSKSKarpenterNodepool(ctx context.Context, id UUID) (*GenerateSKSKarpenterNodepoolResponse, error) {
+	path := fmt.Sprintf("/sks-cluster/%v/generate-karpenter-nodepool", id)
+
+	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("GenerateSKSKarpenterNodepool: new request: %w", err)
+	}
+
+	request.Header.Add("User-Agent", c.getUserAgent())
+
+	if err := c.executeRequestInterceptors(ctx, request); err != nil {
+		return nil, fmt.Errorf("GenerateSKSKarpenterNodepool: execute request editors: %w", err)
+	}
+
+	if err := c.signRequest(request); err != nil {
+		return nil, fmt.Errorf("GenerateSKSKarpenterNodepool: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "generate-sks-karpenter-nodepool")
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("GenerateSKSKarpenterNodepool: http client do: %w", err)
+	}
+
+	if c.trace {
+		dumpResponse(response)
+	}
+
+	if err := handleHTTPErrorResp(response); err != nil {
+		return nil, fmt.Errorf("GenerateSKSKarpenterNodepool: http response: %w", err)
+	}
+
+	bodyresp := new(GenerateSKSKarpenterNodepoolResponse)
+	if err := prepareJSONResponse(response, bodyresp); err != nil {
+		return nil, fmt.Errorf("GenerateSKSKarpenterNodepool: prepare Json response: %w", err)
+	}
+
+	return bodyresp, nil
+}
+
 type GetSKSClusterInspectionResponse map[string]any
 
 // Helps troubleshoot common problems when deploying a kubernetes cluster. Inspections run every couple of minutes.
@@ -16825,6 +17658,8 @@ type CreateSKSNodepoolRequest struct {
 	Labels         SKSNodepoolLabels `json:"labels,omitempty"`
 	// Nodepool name, lowercase only
 	Name string `json:"name" validate:"required,gte=1,lte=255"`
+	// Nvidia MIG Profiles enabled
+	NvidiaMigProfiles *NvidiaMigProfiles `json:"nvidia-mig-profiles,omitempty"`
 	// Nodepool Private Networks
 	PrivateNetworks []PrivateNetwork `json:"private-networks,omitempty"`
 	// Configures public IP assignment of the Instances with:
@@ -17002,6 +17837,8 @@ type UpdateSKSNodepoolRequest struct {
 	Labels         SKSNodepoolLabels `json:"labels,omitempty"`
 	// Nodepool name, lowercase only
 	Name string `json:"name,omitempty" validate:"omitempty,gte=1,lte=255"`
+	// Nvidia MIG Profiles enabled
+	NvidiaMigProfiles *NvidiaMigProfiles `json:"nvidia-mig-profiles"`
 	// Nodepool Private Networks
 	PrivateNetworks []PrivateNetwork `json:"private-networks,omitempty"`
 	// Configures public IP assignment of the Instances with:
@@ -18801,6 +19638,922 @@ func (c Client) UpdateUserRole(ctx context.Context, id UUID, req UpdateUserRoleR
 	return bodyresp, nil
 }
 
+type ListVpcsResponse struct {
+	Vpcs []ListVpcEntry `json:"vpcs,omitempty"`
+}
+
+// FindListVpcEntry attempts to find an ListVpcEntry by nameOrID.
+func (l ListVpcsResponse) FindListVpcEntry(nameOrID string) (ListVpcEntry, error) {
+	var result []ListVpcEntry
+	for i, elem := range l.Vpcs {
+		if string(elem.Name) == nameOrID || string(elem.ID) == nameOrID {
+			result = append(result, l.Vpcs[i])
+		}
+	}
+	if len(result) == 1 {
+		return result[0], nil
+	}
+
+	if len(result) > 1 {
+		return ListVpcEntry{}, fmt.Errorf("%q too many found in ListVpcsResponse: %w", nameOrID, ErrConflict)
+	}
+
+	return ListVpcEntry{}, fmt.Errorf("%q not found in ListVpcsResponse: %w", nameOrID, ErrNotFound)
+}
+
+// [BETA] List VPCs
+func (c Client) ListVpcs(ctx context.Context) (*ListVpcsResponse, error) {
+	path := "/vpc"
+
+	request, err := http.NewRequestWithContext(ctx, "GET", c.serverEndpoint+path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("ListVpcs: new request: %w", err)
+	}
+
+	request.Header.Add("User-Agent", c.getUserAgent())
+
+	if err := c.executeRequestInterceptors(ctx, request); err != nil {
+		return nil, fmt.Errorf("ListVpcs: execute request editors: %w", err)
+	}
+
+	if err := c.signRequest(request); err != nil {
+		return nil, fmt.Errorf("ListVpcs: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "list-vpcs")
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("ListVpcs: http client do: %w", err)
+	}
+
+	if c.trace {
+		dumpResponse(response)
+	}
+
+	if err := handleHTTPErrorResp(response); err != nil {
+		return nil, fmt.Errorf("ListVpcs: http response: %w", err)
+	}
+
+	bodyresp := new(ListVpcsResponse)
+	if err := prepareJSONResponse(response, bodyresp); err != nil {
+		return nil, fmt.Errorf("ListVpcs: prepare Json response: %w", err)
+	}
+
+	return bodyresp, nil
+}
+
+type CreateVpcRequest struct {
+	// VPC description
+	Description string `json:"description,omitempty" validate:"omitempty,lte=4096"`
+	Labels      Labels `json:"labels,omitempty"`
+	// VPC name
+	Name string `json:"name" validate:"required,gte=1,lte=255"`
+}
+
+// [BETA] Create a VPC
+func (c Client) CreateVpc(ctx context.Context, req CreateVpcRequest) (*Operation, error) {
+	path := "/vpc"
+
+	body, err := prepareJSONBody(req)
+	if err != nil {
+		return nil, fmt.Errorf("CreateVpc: prepare Json body: %w", err)
+	}
+
+	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
+	if err != nil {
+		return nil, fmt.Errorf("CreateVpc: new request: %w", err)
+	}
+
+	request.Header.Add("User-Agent", c.getUserAgent())
+
+	request.Header.Add("Content-Type", "application/json")
+
+	if err := c.executeRequestInterceptors(ctx, request); err != nil {
+		return nil, fmt.Errorf("CreateVpc: execute request editors: %w", err)
+	}
+
+	if err := c.signRequest(request); err != nil {
+		return nil, fmt.Errorf("CreateVpc: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "create-vpc")
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("CreateVpc: http client do: %w", err)
+	}
+
+	if c.trace {
+		dumpResponse(response)
+	}
+
+	if err := handleHTTPErrorResp(response); err != nil {
+		return nil, fmt.Errorf("CreateVpc: http response: %w", err)
+	}
+
+	bodyresp := new(Operation)
+	if err := prepareJSONResponse(response, bodyresp); err != nil {
+		return nil, fmt.Errorf("CreateVpc: prepare Json response: %w", err)
+	}
+
+	return bodyresp, nil
+}
+
+// [BETA] Delete a VPC
+func (c Client) DeleteVpc(ctx context.Context, id UUID) (*Empty, error) {
+	path := fmt.Sprintf("/vpc/%v", id)
+
+	request, err := http.NewRequestWithContext(ctx, "DELETE", c.serverEndpoint+path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("DeleteVpc: new request: %w", err)
+	}
+
+	request.Header.Add("User-Agent", c.getUserAgent())
+
+	if err := c.executeRequestInterceptors(ctx, request); err != nil {
+		return nil, fmt.Errorf("DeleteVpc: execute request editors: %w", err)
+	}
+
+	if err := c.signRequest(request); err != nil {
+		return nil, fmt.Errorf("DeleteVpc: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "delete-vpc")
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("DeleteVpc: http client do: %w", err)
+	}
+
+	if c.trace {
+		dumpResponse(response)
+	}
+
+	if err := handleHTTPErrorResp(response); err != nil {
+		return nil, fmt.Errorf("DeleteVpc: http response: %w", err)
+	}
+
+	bodyresp := new(Empty)
+	if err := prepareJSONResponse(response, bodyresp); err != nil {
+		return nil, fmt.Errorf("DeleteVpc: prepare Json response: %w", err)
+	}
+
+	return bodyresp, nil
+}
+
+// [BETA] Retrieve VPC details
+func (c Client) GetVpc(ctx context.Context, id UUID) (*Vpc, error) {
+	path := fmt.Sprintf("/vpc/%v", id)
+
+	request, err := http.NewRequestWithContext(ctx, "GET", c.serverEndpoint+path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("GetVpc: new request: %w", err)
+	}
+
+	request.Header.Add("User-Agent", c.getUserAgent())
+
+	if err := c.executeRequestInterceptors(ctx, request); err != nil {
+		return nil, fmt.Errorf("GetVpc: execute request editors: %w", err)
+	}
+
+	if err := c.signRequest(request); err != nil {
+		return nil, fmt.Errorf("GetVpc: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "get-vpc")
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("GetVpc: http client do: %w", err)
+	}
+
+	if c.trace {
+		dumpResponse(response)
+	}
+
+	if err := handleHTTPErrorResp(response); err != nil {
+		return nil, fmt.Errorf("GetVpc: http response: %w", err)
+	}
+
+	bodyresp := new(Vpc)
+	if err := prepareJSONResponse(response, bodyresp); err != nil {
+		return nil, fmt.Errorf("GetVpc: prepare Json response: %w", err)
+	}
+
+	return bodyresp, nil
+}
+
+type UpdateVpcRequest struct {
+	// VPC description
+	Description *string `json:"description,omitempty" validate:"omitempty,lte=4096"`
+	Labels      Labels  `json:"labels"`
+	// VPC name
+	Name *string `json:"name,omitempty" validate:"omitempty,gte=1,lte=255"`
+}
+
+// [BETA] Update a VPC
+func (c Client) UpdateVpc(ctx context.Context, id UUID, req UpdateVpcRequest) (*Vpc, error) {
+	path := fmt.Sprintf("/vpc/%v", id)
+
+	body, err := prepareJSONBody(req)
+	if err != nil {
+		return nil, fmt.Errorf("UpdateVpc: prepare Json body: %w", err)
+	}
+
+	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
+	if err != nil {
+		return nil, fmt.Errorf("UpdateVpc: new request: %w", err)
+	}
+
+	request.Header.Add("User-Agent", c.getUserAgent())
+
+	request.Header.Add("Content-Type", "application/json")
+
+	if err := c.executeRequestInterceptors(ctx, request); err != nil {
+		return nil, fmt.Errorf("UpdateVpc: execute request editors: %w", err)
+	}
+
+	if err := c.signRequest(request); err != nil {
+		return nil, fmt.Errorf("UpdateVpc: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "update-vpc")
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("UpdateVpc: http client do: %w", err)
+	}
+
+	if c.trace {
+		dumpResponse(response)
+	}
+
+	if err := handleHTTPErrorResp(response); err != nil {
+		return nil, fmt.Errorf("UpdateVpc: http response: %w", err)
+	}
+
+	bodyresp := new(Vpc)
+	if err := prepareJSONResponse(response, bodyresp); err != nil {
+		return nil, fmt.Errorf("UpdateVpc: prepare Json response: %w", err)
+	}
+
+	return bodyresp, nil
+}
+
+type ListVpcRoutesResponse struct {
+	Routes []ListRouteEntry `json:"routes,omitempty"`
+}
+
+// FindListRouteEntry attempts to find an ListRouteEntry by id.
+func (l ListVpcRoutesResponse) FindListRouteEntry(id string) (ListRouteEntry, error) {
+	var result []ListRouteEntry
+	for i, elem := range l.Routes {
+		if string(elem.ID) == id {
+			result = append(result, l.Routes[i])
+		}
+	}
+	if len(result) == 1 {
+		return result[0], nil
+	}
+
+	if len(result) > 1 {
+		return ListRouteEntry{}, fmt.Errorf("%q too many found in ListVpcRoutesResponse: %w", id, ErrConflict)
+	}
+
+	return ListRouteEntry{}, fmt.Errorf("%q not found in ListVpcRoutesResponse: %w", id, ErrNotFound)
+}
+
+// [BETA] List VPC routes
+func (c Client) ListVpcRoutes(ctx context.Context, vpcID UUID) (*ListVpcRoutesResponse, error) {
+	path := fmt.Sprintf("/vpc/%v/route", vpcID)
+
+	request, err := http.NewRequestWithContext(ctx, "GET", c.serverEndpoint+path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("ListVpcRoutes: new request: %w", err)
+	}
+
+	request.Header.Add("User-Agent", c.getUserAgent())
+
+	if err := c.executeRequestInterceptors(ctx, request); err != nil {
+		return nil, fmt.Errorf("ListVpcRoutes: execute request editors: %w", err)
+	}
+
+	if err := c.signRequest(request); err != nil {
+		return nil, fmt.Errorf("ListVpcRoutes: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "list-vpc-routes")
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("ListVpcRoutes: http client do: %w", err)
+	}
+
+	if c.trace {
+		dumpResponse(response)
+	}
+
+	if err := handleHTTPErrorResp(response); err != nil {
+		return nil, fmt.Errorf("ListVpcRoutes: http response: %w", err)
+	}
+
+	bodyresp := new(ListVpcRoutesResponse)
+	if err := prepareJSONResponse(response, bodyresp); err != nil {
+		return nil, fmt.Errorf("ListVpcRoutes: prepare Json response: %w", err)
+	}
+
+	return bodyresp, nil
+}
+
+type ListSubnetsResponse struct {
+	Subnets []ListSubnetEntry `json:"subnets,omitempty"`
+}
+
+// FindListSubnetEntry attempts to find an ListSubnetEntry by nameOrID.
+func (l ListSubnetsResponse) FindListSubnetEntry(nameOrID string) (ListSubnetEntry, error) {
+	var result []ListSubnetEntry
+	for i, elem := range l.Subnets {
+		if string(elem.Name) == nameOrID || string(elem.ID) == nameOrID {
+			result = append(result, l.Subnets[i])
+		}
+	}
+	if len(result) == 1 {
+		return result[0], nil
+	}
+
+	if len(result) > 1 {
+		return ListSubnetEntry{}, fmt.Errorf("%q too many found in ListSubnetsResponse: %w", nameOrID, ErrConflict)
+	}
+
+	return ListSubnetEntry{}, fmt.Errorf("%q not found in ListSubnetsResponse: %w", nameOrID, ErrNotFound)
+}
+
+// [BETA] List Subnets
+func (c Client) ListSubnets(ctx context.Context, vpcID UUID) (*ListSubnetsResponse, error) {
+	path := fmt.Sprintf("/vpc/%v/subnet", vpcID)
+
+	request, err := http.NewRequestWithContext(ctx, "GET", c.serverEndpoint+path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("ListSubnets: new request: %w", err)
+	}
+
+	request.Header.Add("User-Agent", c.getUserAgent())
+
+	if err := c.executeRequestInterceptors(ctx, request); err != nil {
+		return nil, fmt.Errorf("ListSubnets: execute request editors: %w", err)
+	}
+
+	if err := c.signRequest(request); err != nil {
+		return nil, fmt.Errorf("ListSubnets: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "list-subnets")
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("ListSubnets: http client do: %w", err)
+	}
+
+	if c.trace {
+		dumpResponse(response)
+	}
+
+	if err := handleHTTPErrorResp(response); err != nil {
+		return nil, fmt.Errorf("ListSubnets: http response: %w", err)
+	}
+
+	bodyresp := new(ListSubnetsResponse)
+	if err := prepareJSONResponse(response, bodyresp); err != nil {
+		return nil, fmt.Errorf("ListSubnets: prepare Json response: %w", err)
+	}
+
+	return bodyresp, nil
+}
+
+type CreateSubnetRequestAddressSpace string
+
+const (
+	CreateSubnetRequestAddressSpacePrivate CreateSubnetRequestAddressSpace = "private"
+)
+
+type CreateSubnetRequestAddressfamily string
+
+const (
+	CreateSubnetRequestAddressfamilyInet4 CreateSubnetRequestAddressfamily = "inet4"
+)
+
+type CreateSubnetRequest struct {
+	// Subnet address space
+	AddressSpace CreateSubnetRequestAddressSpace `json:"address-space" validate:"required"`
+	// Subnet address family
+	Addressfamily CreateSubnetRequestAddressfamily `json:"addressfamily" validate:"required"`
+	// Subnet description
+	Description string `json:"description,omitempty" validate:"omitempty,lte=4096"`
+	// Subnet ipv4 CIDR
+	Ipv4Block string `json:"ipv4-block,omitempty"`
+	Labels    Labels `json:"labels,omitempty"`
+	// Subnet name
+	Name string `json:"name" validate:"required,gte=1,lte=255"`
+}
+
+// [BETA] Create a Subnet
+func (c Client) CreateSubnet(ctx context.Context, vpcID UUID, req CreateSubnetRequest) (*Operation, error) {
+	path := fmt.Sprintf("/vpc/%v/subnet", vpcID)
+
+	body, err := prepareJSONBody(req)
+	if err != nil {
+		return nil, fmt.Errorf("CreateSubnet: prepare Json body: %w", err)
+	}
+
+	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
+	if err != nil {
+		return nil, fmt.Errorf("CreateSubnet: new request: %w", err)
+	}
+
+	request.Header.Add("User-Agent", c.getUserAgent())
+
+	request.Header.Add("Content-Type", "application/json")
+
+	if err := c.executeRequestInterceptors(ctx, request); err != nil {
+		return nil, fmt.Errorf("CreateSubnet: execute request editors: %w", err)
+	}
+
+	if err := c.signRequest(request); err != nil {
+		return nil, fmt.Errorf("CreateSubnet: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "create-subnet")
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("CreateSubnet: http client do: %w", err)
+	}
+
+	if c.trace {
+		dumpResponse(response)
+	}
+
+	if err := handleHTTPErrorResp(response); err != nil {
+		return nil, fmt.Errorf("CreateSubnet: http response: %w", err)
+	}
+
+	bodyresp := new(Operation)
+	if err := prepareJSONResponse(response, bodyresp); err != nil {
+		return nil, fmt.Errorf("CreateSubnet: prepare Json response: %w", err)
+	}
+
+	return bodyresp, nil
+}
+
+// [BETA] Delete a Subnet
+func (c Client) DeleteSubnet(ctx context.Context, vpcID UUID, id UUID) (*Empty, error) {
+	path := fmt.Sprintf("/vpc/%v/subnet/%v", vpcID, id)
+
+	request, err := http.NewRequestWithContext(ctx, "DELETE", c.serverEndpoint+path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("DeleteSubnet: new request: %w", err)
+	}
+
+	request.Header.Add("User-Agent", c.getUserAgent())
+
+	if err := c.executeRequestInterceptors(ctx, request); err != nil {
+		return nil, fmt.Errorf("DeleteSubnet: execute request editors: %w", err)
+	}
+
+	if err := c.signRequest(request); err != nil {
+		return nil, fmt.Errorf("DeleteSubnet: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "delete-subnet")
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("DeleteSubnet: http client do: %w", err)
+	}
+
+	if c.trace {
+		dumpResponse(response)
+	}
+
+	if err := handleHTTPErrorResp(response); err != nil {
+		return nil, fmt.Errorf("DeleteSubnet: http response: %w", err)
+	}
+
+	bodyresp := new(Empty)
+	if err := prepareJSONResponse(response, bodyresp); err != nil {
+		return nil, fmt.Errorf("DeleteSubnet: prepare Json response: %w", err)
+	}
+
+	return bodyresp, nil
+}
+
+// [BETA] Retrieve Subnet details
+func (c Client) GetSubnet(ctx context.Context, vpcID UUID, id UUID) (*Subnet, error) {
+	path := fmt.Sprintf("/vpc/%v/subnet/%v", vpcID, id)
+
+	request, err := http.NewRequestWithContext(ctx, "GET", c.serverEndpoint+path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("GetSubnet: new request: %w", err)
+	}
+
+	request.Header.Add("User-Agent", c.getUserAgent())
+
+	if err := c.executeRequestInterceptors(ctx, request); err != nil {
+		return nil, fmt.Errorf("GetSubnet: execute request editors: %w", err)
+	}
+
+	if err := c.signRequest(request); err != nil {
+		return nil, fmt.Errorf("GetSubnet: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "get-subnet")
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("GetSubnet: http client do: %w", err)
+	}
+
+	if c.trace {
+		dumpResponse(response)
+	}
+
+	if err := handleHTTPErrorResp(response); err != nil {
+		return nil, fmt.Errorf("GetSubnet: http response: %w", err)
+	}
+
+	bodyresp := new(Subnet)
+	if err := prepareJSONResponse(response, bodyresp); err != nil {
+		return nil, fmt.Errorf("GetSubnet: prepare Json response: %w", err)
+	}
+
+	return bodyresp, nil
+}
+
+type UpdateSubnetRequest struct {
+	// Subnet description
+	Description *string `json:"description,omitempty" validate:"omitempty,lte=4096"`
+	// Subnet CIDR
+	Ipv4Block *string `json:"ipv4-block,omitempty"`
+	Labels    Labels  `json:"labels"`
+	// Subnet name
+	Name *string `json:"name,omitempty" validate:"omitempty,gte=1,lte=255"`
+}
+
+// [BETA] Update a Subnet
+func (c Client) UpdateSubnet(ctx context.Context, vpcID UUID, id UUID, req UpdateSubnetRequest) (*Subnet, error) {
+	path := fmt.Sprintf("/vpc/%v/subnet/%v", vpcID, id)
+
+	body, err := prepareJSONBody(req)
+	if err != nil {
+		return nil, fmt.Errorf("UpdateSubnet: prepare Json body: %w", err)
+	}
+
+	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
+	if err != nil {
+		return nil, fmt.Errorf("UpdateSubnet: new request: %w", err)
+	}
+
+	request.Header.Add("User-Agent", c.getUserAgent())
+
+	request.Header.Add("Content-Type", "application/json")
+
+	if err := c.executeRequestInterceptors(ctx, request); err != nil {
+		return nil, fmt.Errorf("UpdateSubnet: execute request editors: %w", err)
+	}
+
+	if err := c.signRequest(request); err != nil {
+		return nil, fmt.Errorf("UpdateSubnet: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "update-subnet")
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("UpdateSubnet: http client do: %w", err)
+	}
+
+	if c.trace {
+		dumpResponse(response)
+	}
+
+	if err := handleHTTPErrorResp(response); err != nil {
+		return nil, fmt.Errorf("UpdateSubnet: http response: %w", err)
+	}
+
+	bodyresp := new(Subnet)
+	if err := prepareJSONResponse(response, bodyresp); err != nil {
+		return nil, fmt.Errorf("UpdateSubnet: prepare Json response: %w", err)
+	}
+
+	return bodyresp, nil
+}
+
+type AttachInstanceToSubnetRequest struct {
+	// Target Instance
+	Instance *InstanceRef `json:"instance" validate:"required"`
+}
+
+// [BETA] Attach a Compute instance to a Subnet
+func (c Client) AttachInstanceToSubnet(ctx context.Context, vpcID UUID, subnetID UUID, req AttachInstanceToSubnetRequest) (*Operation, error) {
+	path := fmt.Sprintf("/vpc/%v/subnet/%v/attach", vpcID, subnetID)
+
+	body, err := prepareJSONBody(req)
+	if err != nil {
+		return nil, fmt.Errorf("AttachInstanceToSubnet: prepare Json body: %w", err)
+	}
+
+	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
+	if err != nil {
+		return nil, fmt.Errorf("AttachInstanceToSubnet: new request: %w", err)
+	}
+
+	request.Header.Add("User-Agent", c.getUserAgent())
+
+	request.Header.Add("Content-Type", "application/json")
+
+	if err := c.executeRequestInterceptors(ctx, request); err != nil {
+		return nil, fmt.Errorf("AttachInstanceToSubnet: execute request editors: %w", err)
+	}
+
+	if err := c.signRequest(request); err != nil {
+		return nil, fmt.Errorf("AttachInstanceToSubnet: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "attach-instance-to-subnet")
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("AttachInstanceToSubnet: http client do: %w", err)
+	}
+
+	if c.trace {
+		dumpResponse(response)
+	}
+
+	if err := handleHTTPErrorResp(response); err != nil {
+		return nil, fmt.Errorf("AttachInstanceToSubnet: http response: %w", err)
+	}
+
+	bodyresp := new(Operation)
+	if err := prepareJSONResponse(response, bodyresp); err != nil {
+		return nil, fmt.Errorf("AttachInstanceToSubnet: prepare Json response: %w", err)
+	}
+
+	return bodyresp, nil
+}
+
+type DetachInstanceFromSubnetRequest struct {
+	// Target Instance
+	Instance *InstanceRef `json:"instance" validate:"required"`
+}
+
+// [BETA] Detach a Compute instance from a Subnet
+func (c Client) DetachInstanceFromSubnet(ctx context.Context, vpcID UUID, subnetID UUID, req DetachInstanceFromSubnetRequest) (*Operation, error) {
+	path := fmt.Sprintf("/vpc/%v/subnet/%v/detach", vpcID, subnetID)
+
+	body, err := prepareJSONBody(req)
+	if err != nil {
+		return nil, fmt.Errorf("DetachInstanceFromSubnet: prepare Json body: %w", err)
+	}
+
+	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
+	if err != nil {
+		return nil, fmt.Errorf("DetachInstanceFromSubnet: new request: %w", err)
+	}
+
+	request.Header.Add("User-Agent", c.getUserAgent())
+
+	request.Header.Add("Content-Type", "application/json")
+
+	if err := c.executeRequestInterceptors(ctx, request); err != nil {
+		return nil, fmt.Errorf("DetachInstanceFromSubnet: execute request editors: %w", err)
+	}
+
+	if err := c.signRequest(request); err != nil {
+		return nil, fmt.Errorf("DetachInstanceFromSubnet: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "detach-instance-from-subnet")
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("DetachInstanceFromSubnet: http client do: %w", err)
+	}
+
+	if c.trace {
+		dumpResponse(response)
+	}
+
+	if err := handleHTTPErrorResp(response); err != nil {
+		return nil, fmt.Errorf("DetachInstanceFromSubnet: http response: %w", err)
+	}
+
+	bodyresp := new(Operation)
+	if err := prepareJSONResponse(response, bodyresp); err != nil {
+		return nil, fmt.Errorf("DetachInstanceFromSubnet: prepare Json response: %w", err)
+	}
+
+	return bodyresp, nil
+}
+
+type ListRoutesResponse struct {
+	Routes []ListRouteEntry `json:"routes,omitempty"`
+}
+
+// FindListRouteEntry attempts to find an ListRouteEntry by id.
+func (l ListRoutesResponse) FindListRouteEntry(id string) (ListRouteEntry, error) {
+	var result []ListRouteEntry
+	for i, elem := range l.Routes {
+		if string(elem.ID) == id {
+			result = append(result, l.Routes[i])
+		}
+	}
+	if len(result) == 1 {
+		return result[0], nil
+	}
+
+	if len(result) > 1 {
+		return ListRouteEntry{}, fmt.Errorf("%q too many found in ListRoutesResponse: %w", id, ErrConflict)
+	}
+
+	return ListRouteEntry{}, fmt.Errorf("%q not found in ListRoutesResponse: %w", id, ErrNotFound)
+}
+
+// [BETA] List Subnet routes
+func (c Client) ListRoutes(ctx context.Context, vpcID UUID, subnetID UUID) (*ListRoutesResponse, error) {
+	path := fmt.Sprintf("/vpc/%v/subnet/%v/route", vpcID, subnetID)
+
+	request, err := http.NewRequestWithContext(ctx, "GET", c.serverEndpoint+path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("ListRoutes: new request: %w", err)
+	}
+
+	request.Header.Add("User-Agent", c.getUserAgent())
+
+	if err := c.executeRequestInterceptors(ctx, request); err != nil {
+		return nil, fmt.Errorf("ListRoutes: execute request editors: %w", err)
+	}
+
+	if err := c.signRequest(request); err != nil {
+		return nil, fmt.Errorf("ListRoutes: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "list-routes")
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("ListRoutes: http client do: %w", err)
+	}
+
+	if c.trace {
+		dumpResponse(response)
+	}
+
+	if err := handleHTTPErrorResp(response); err != nil {
+		return nil, fmt.Errorf("ListRoutes: http response: %w", err)
+	}
+
+	bodyresp := new(ListRoutesResponse)
+	if err := prepareJSONResponse(response, bodyresp); err != nil {
+		return nil, fmt.Errorf("ListRoutes: prepare Json response: %w", err)
+	}
+
+	return bodyresp, nil
+}
+
+type CreateRouteRequest struct {
+	// Route description
+	Description string `json:"description,omitempty" validate:"omitempty,lte=4096"`
+	// Route destination CIDR
+	Destination string `json:"destination" validate:"required"`
+	// Route target
+	Target string `json:"target" validate:"required"`
+}
+
+// [BETA] Create a route
+func (c Client) CreateRoute(ctx context.Context, vpcID UUID, subnetID UUID, req CreateRouteRequest) (*Route, error) {
+	path := fmt.Sprintf("/vpc/%v/subnet/%v/route", vpcID, subnetID)
+
+	body, err := prepareJSONBody(req)
+	if err != nil {
+		return nil, fmt.Errorf("CreateRoute: prepare Json body: %w", err)
+	}
+
+	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
+	if err != nil {
+		return nil, fmt.Errorf("CreateRoute: new request: %w", err)
+	}
+
+	request.Header.Add("User-Agent", c.getUserAgent())
+
+	request.Header.Add("Content-Type", "application/json")
+
+	if err := c.executeRequestInterceptors(ctx, request); err != nil {
+		return nil, fmt.Errorf("CreateRoute: execute request editors: %w", err)
+	}
+
+	if err := c.signRequest(request); err != nil {
+		return nil, fmt.Errorf("CreateRoute: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "create-route")
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("CreateRoute: http client do: %w", err)
+	}
+
+	if c.trace {
+		dumpResponse(response)
+	}
+
+	if err := handleHTTPErrorResp(response); err != nil {
+		return nil, fmt.Errorf("CreateRoute: http response: %w", err)
+	}
+
+	bodyresp := new(Route)
+	if err := prepareJSONResponse(response, bodyresp); err != nil {
+		return nil, fmt.Errorf("CreateRoute: prepare Json response: %w", err)
+	}
+
+	return bodyresp, nil
+}
+
+// [BETA] Delete a route
+func (c Client) DeleteRoute(ctx context.Context, vpcID UUID, subnetID UUID, id UUID) (*Empty, error) {
+	path := fmt.Sprintf("/vpc/%v/subnet/%v/route/%v", vpcID, subnetID, id)
+
+	request, err := http.NewRequestWithContext(ctx, "DELETE", c.serverEndpoint+path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("DeleteRoute: new request: %w", err)
+	}
+
+	request.Header.Add("User-Agent", c.getUserAgent())
+
+	if err := c.executeRequestInterceptors(ctx, request); err != nil {
+		return nil, fmt.Errorf("DeleteRoute: execute request editors: %w", err)
+	}
+
+	if err := c.signRequest(request); err != nil {
+		return nil, fmt.Errorf("DeleteRoute: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "delete-route")
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("DeleteRoute: http client do: %w", err)
+	}
+
+	if c.trace {
+		dumpResponse(response)
+	}
+
+	if err := handleHTTPErrorResp(response); err != nil {
+		return nil, fmt.Errorf("DeleteRoute: http response: %w", err)
+	}
+
+	bodyresp := new(Empty)
+	if err := prepareJSONResponse(response, bodyresp); err != nil {
+		return nil, fmt.Errorf("DeleteRoute: prepare Json response: %w", err)
+	}
+
+	return bodyresp, nil
+}
+
 type ListZonesResponse struct {
 	Zones []Zone `json:"zones,omitempty"`
 }
@@ -18837,10 +20590,6 @@ func (c Client) ListZones(ctx context.Context) (*ListZonesResponse, error) {
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("ListZones: execute request editors: %w", err)
-	}
-
-	if err := c.signRequest(request); err != nil {
-		return nil, fmt.Errorf("ListZones: sign request: %w", err)
 	}
 
 	if c.trace {

--- a/vendor/github.com/exoscale/egoscale/v3/schemas.go
+++ b/vendor/github.com/exoscale/egoscale/v3/schemas.go
@@ -206,7 +206,7 @@ type BlockStorageVolumeRef struct {
 // Request to create a new AI API key
 type CreateAIAPIKeyRequest struct {
 	// Human-readable name for the AI API key
-	Name string `json:"name" validate:"required"`
+	Name string `json:"name" validate:"required,gte=1,lte=50"`
 	// Key scope: 'public' for all deployments, or a specific deployment UUID
 	Scope string `json:"scope" validate:"required"`
 }
@@ -225,6 +225,8 @@ type CreateAIAPIKeyResponse struct {
 	Scope string `json:"scope" validate:"required"`
 	// Last update timestamp
 	UpdatedAT time.Time `json:"updated-at" validate:"required"`
+	// Plaintext AI API key value
+	Value string `json:"value" validate:"required"`
 }
 
 // Deploy an AI model onto a set of GPUs
@@ -241,6 +243,8 @@ type CreateDeploymentRequest struct {
 	Model *ModelRef `json:"model" validate:"required"`
 	// Deployment name
 	Name string `json:"name" validate:"required,gte=1"`
+	// Billing identifier for this deployment. Used by the Router for usage counters and Kafka events.
+	ProductName string `json:"product-name,omitempty" validate:"omitempty,gte=1"`
 	// Number of replicas (>=1)
 	Replicas int64 `json:"replicas" validate:"required,gte=1"`
 }
@@ -2605,6 +2609,13 @@ const (
 	GetDeploymentResponseStateUpdating  GetDeploymentResponseState = "updating"
 )
 
+type GetDeploymentResponseVisibility string
+
+const (
+	GetDeploymentResponseVisibilityPublic  GetDeploymentResponseVisibility = "public"
+	GetDeploymentResponseVisibilityPrivate GetDeploymentResponseVisibility = "private"
+)
+
 // AI deployment
 type GetDeploymentResponse struct {
 	// Creation time
@@ -2635,6 +2646,8 @@ type GetDeploymentResponse struct {
 	StateDetails string `json:"state-details" validate:"required"`
 	// Update time
 	UpdatedAT time.Time `json:"updated-at" validate:"required"`
+	// Deployment visibility: private for your organization's deployments, public for Exoscale Managed Inference deployments.
+	Visibility GetDeploymentResponseVisibility `json:"visibility" validate:"required"`
 }
 
 // List of allowed inference-engine parameters
@@ -2845,16 +2858,17 @@ const (
 	InferenceEngineVersion0221 InferenceEngineVersion = "0.22.1"
 	InferenceEngineVersion0230 InferenceEngineVersion = "0.23.0"
 	InferenceEngineVersion0240 InferenceEngineVersion = "0.24.0"
+	InferenceEngineVersion0250 InferenceEngineVersion = "0.25.0"
 )
 
 // Router flush payload: the router's full in-memory usage map with flush identity fields
 type IngestMeteringRequest struct {
-	// ISO-8601 UTC timestamp when the flush snapshot was created (truncated to minute boundary for bucketing)
-	CreatedAT time.Time `json:"created-at" validate:"required"`
 	// UUID identifying this flush; used for idempotent deduplication
 	FlushID UUID `json:"flush-id" validate:"required"`
 	// Router instance identifier that produced this flush
 	RouterID string `json:"router-id" validate:"required,gte=1"`
+	// ISO-8601 UTC timestamp when the flush snapshot was created (truncated to minute boundary for bucketing)
+	Timestamp time.Time `json:"timestamp" validate:"required"`
 	// Map of api-key-uuid to usage entry. Keys are API key UUIDs. Mirrors the router's in-memory accumulator structure directly.
 	Usage map[string]APIKeyUsageEntry `json:"usage" validate:"required"`
 }
@@ -4396,6 +4410,13 @@ const (
 	ListDeploymentsResponseEntryStateUpdating  ListDeploymentsResponseEntryState = "updating"
 )
 
+type ListDeploymentsResponseEntryVisibility string
+
+const (
+	ListDeploymentsResponseEntryVisibilityPublic  ListDeploymentsResponseEntryVisibility = "public"
+	ListDeploymentsResponseEntryVisibilityPrivate ListDeploymentsResponseEntryVisibility = "private"
+)
+
 // AI deployment
 type ListDeploymentsResponseEntry struct {
 	// Creation time
@@ -4420,6 +4441,8 @@ type ListDeploymentsResponseEntry struct {
 	State ListDeploymentsResponseEntryState `json:"state" validate:"required"`
 	// Update time
 	UpdatedAT time.Time `json:"updated-at" validate:"required"`
+	// Deployment visibility: private for your organization's deployments, public for Exoscale Managed Inference deployments.
+	Visibility ListDeploymentsResponseEntryVisibility `json:"visibility" validate:"required"`
 }
 
 type ListKmsKeyRotationsResponse struct {
@@ -5588,7 +5611,7 @@ type TemplateRef struct {
 // Request to update an AI API key (at least one property required)
 type UpdateAIAPIKeyRequest struct {
 	// Human-readable name for the AI API key
-	Name string `json:"name,omitempty"`
+	Name string `json:"name,omitempty" validate:"omitempty,gte=1,lte=50"`
 	// Key scope: 'public' for all deployments, or a specific deployment UUID
 	Scope string `json:"scope,omitempty"`
 }

--- a/vendor/github.com/exoscale/egoscale/v3/schemas.go
+++ b/vendor/github.com/exoscale/egoscale/v3/schemas.go
@@ -74,24 +74,26 @@ type AccessKeyResource struct {
 	ResourceType AccessKeyResourceResourceType `json:"resource-type,omitempty"`
 }
 
-// AI API key metadata (without value)
+// AI API key metadata
 type AIAPIKey struct {
 	// Creation timestamp
-	CreatedAT time.Time `json:"created-at,omitempty"`
+	CreatedAT time.Time `json:"created-at" validate:"required"`
 	// AI API key ID
-	ID UUID `json:"id,omitempty"`
+	ID UUID `json:"id" validate:"required"`
 	// Human-readable name for the AI API key
-	Name string `json:"name,omitempty"`
+	Name string `json:"name" validate:"required"`
 	// Organization UUID that owns this key
-	OrgUuid UUID `json:"org-uuid,omitempty"`
+	OrgUuid UUID `json:"org-uuid" validate:"required"`
 	// Key scope: 'public' for all deployments, or a specific deployment UUID
-	Scope string `json:"scope,omitempty"`
+	Scope string `json:"scope" validate:"required"`
 	// Last update timestamp
-	UpdatedAT time.Time `json:"updated-at,omitempty"`
+	UpdatedAT time.Time `json:"updated-at" validate:"required"`
 }
 
-// AI API key with plaintext value
-type AIAPIKeyWithValue struct {
+// AI API key plaintext value
+type AIAPIKeyValue struct {
+	// Plaintext AI API key value
+	Value string `json:"value" validate:"required"`
 }
 
 // Anti-affinity Group
@@ -110,6 +112,14 @@ type AntiAffinityGroup struct {
 type AntiAffinityGroupRef struct {
 	// Anti-affinity group ID
 	ID UUID `json:"id,omitempty"`
+}
+
+// Usage breakdown for one API key, grouped by model
+type APIKeyUsageEntry struct {
+	// Map of model-uuid to accumulated counters. Keys are model UUIDs.
+	Models map[string]ModelUsageCounters `json:"models" validate:"required"`
+	// Organization that owns this API key
+	OrganizationID UUID `json:"organization-id" validate:"required"`
 }
 
 type BlockStorageSnapshotState string
@@ -172,6 +182,8 @@ type BlockStorageVolume struct {
 	Blocksize int64 `json:"blocksize,omitempty" validate:"omitempty,gte=0"`
 	// Volume creation date
 	CreatedAT time.Time `json:"created-at,omitempty"`
+	// Indicates if the block-storage volume is encrypted
+	Encrypted *bool `json:"encrypted,omitempty"`
 	// Volume ID
 	ID UUID `json:"id,omitempty"`
 	// Target Instance
@@ -199,7 +211,23 @@ type CreateAIAPIKeyRequest struct {
 	Scope string `json:"scope" validate:"required"`
 }
 
-// Deployment an AI model onto a set of GPUs
+// Create AI API key response
+type CreateAIAPIKeyResponse struct {
+	// Creation timestamp
+	CreatedAT time.Time `json:"created-at" validate:"required"`
+	// AI API key ID
+	ID UUID `json:"id" validate:"required"`
+	// Human-readable name for the AI API key
+	Name string `json:"name" validate:"required"`
+	// Organization UUID that owns this key
+	OrgUuid UUID `json:"org-uuid" validate:"required"`
+	// Key scope: 'public' for all deployments, or a specific deployment UUID
+	Scope string `json:"scope" validate:"required"`
+	// Last update timestamp
+	UpdatedAT time.Time `json:"updated-at" validate:"required"`
+}
+
+// Deploy an AI model onto a set of GPUs
 type CreateDeploymentRequest struct {
 	// Number of GPUs (1-8)
 	GpuCount int64 `json:"gpu-count" validate:"required,gte=1"`
@@ -209,7 +237,8 @@ type CreateDeploymentRequest struct {
 	InferenceEngineParameters []string `json:"inference-engine-parameters,omitempty"`
 	// Inference engine version
 	InferenceEngineVersion InferenceEngineVersion `json:"inference-engine-version,omitempty"`
-	Model                  *ModelRef              `json:"model" validate:"required"`
+	// Model reference. Provide either id or name.
+	Model *ModelRef `json:"model" validate:"required"`
 	// Deployment name
 	Name string `json:"name" validate:"required,gte=1"`
 	// Number of replicas (>=1)
@@ -223,10 +252,13 @@ const (
 )
 
 type CreateKmsKeyRequest struct {
-	Description string                   `json:"description" validate:"required"`
-	MultiZone   *bool                    `json:"multi-zone" validate:"required"`
-	Name        string                   `json:"name" validate:"required"`
-	Usage       CreateKmsKeyRequestUsage `json:"usage" validate:"required"`
+	// An optional detailed description providing additional context about the key's intended use case.
+	Description string `json:"description,omitempty"`
+	// True if this is a multi-zone key.
+	MultiZone *bool `json:"multi-zone,omitempty"`
+	// A human-readable display name uniquely identifying the KMS key within the tenant space.
+	Name  string                   `json:"name" validate:"required"`
+	Usage CreateKmsKeyRequestUsage `json:"usage,omitempty"`
 }
 
 type CreateKmsKeyResponseSource string
@@ -244,16 +276,25 @@ const (
 )
 
 type CreateKmsKeyResponse struct {
-	CreatedAT   time.Time                  `json:"created-at" validate:"required"`
-	Description string                     `json:"description" validate:"required"`
-	ID          UUID                       `json:"id" validate:"required"`
-	MultiZone   *bool                      `json:"multi-zone" validate:"required"`
-	Name        string                     `json:"name" validate:"required"`
-	OriginZone  string                     `json:"origin-zone" validate:"required"`
-	Revision    *RevisionStamp             `json:"revision" validate:"required"`
-	Source      CreateKmsKeyResponseSource `json:"source" validate:"required"`
-	Status      CreateKmsKeyResponseStatus `json:"status" validate:"required"`
-	Usage       string                     `json:"usage" validate:"required"`
+	// The UTC timestamp showing when the KMS key was originally provisioned.
+	CreatedAT time.Time `json:"created-at" validate:"required"`
+	// An optional detailed description providing additional context about the key's intended use case.
+	Description string `json:"description,omitempty"`
+	// The globally unique identifier (UUID) assigned to the newly created KMS key.
+	ID UUID `json:"id" validate:"required"`
+	// True if this is a multi-zone key.
+	MultiZone *bool `json:"multi-zone" validate:"required"`
+	// The display name assigned to the KMS key.
+	Name string `json:"name" validate:"required"`
+	// The creation zone of the KMS key.
+	OriginZone string                     `json:"origin-zone" validate:"required"`
+	Revision   *RevisionStamp             `json:"revision" validate:"required"`
+	Source     CreateKmsKeyResponseSource `json:"source" validate:"required"`
+	Status     CreateKmsKeyResponseStatus `json:"status" validate:"required"`
+	// The timestamp indicating exactly when the current key status was last transitioned.
+	StatusSince time.Time `json:"status-since" validate:"required"`
+	// The cryptographic operation constraints allowed on this key.
+	Usage string `json:"usage" validate:"required"`
 }
 
 // AI model
@@ -286,6 +327,48 @@ type DBAASBackupConfig struct {
 	// is restored to the state it was when the backup was generated.
 	// 'pitr' means point-in-time-recovery, which allows restoring the system to any state since the first available full snapshot.
 	RecoveryMode string `json:"recovery-mode,omitempty"`
+}
+
+type DBAASClickhouseAclConfig struct {
+	Users []DBAASClickhouseUserAclConfig `json:"users,omitempty"`
+}
+
+type DBAASClickhouseUser struct {
+	Required *bool             `json:"required,omitempty"`
+	Username DBAASUserUsername `json:"username" validate:"required,gte=1,lte=64"`
+	Uuid     UUID              `json:"uuid,omitempty"`
+}
+
+type DBAASClickhouseUserAclConfig struct {
+	Privileges []DBAASClickhouseUserPrivilege `json:"privileges,omitempty"`
+	Roles      []DBAASClickhouseUserRole      `json:"roles,omitempty"`
+	Username   DBAASUserUsername              `json:"username" validate:"required,gte=1,lte=64"`
+	Uuid       UUID                           `json:"uuid,omitempty"`
+}
+
+type DBAASClickhouseUserPrivilege struct {
+	AccessType    string `json:"access-type,omitempty"`
+	Column        string `json:"column,omitempty"`
+	Database      string `json:"database,omitempty"`
+	GrantOption   *bool  `json:"grant-option,omitempty"`
+	PartialRevoke *bool  `json:"partial-revoke,omitempty"`
+	Table         string `json:"table,omitempty"`
+}
+
+type DBAASClickhouseUserRole struct {
+	Default         *bool  `json:"default,omitempty"`
+	Name            string `json:"name,omitempty"`
+	Uuid            UUID   `json:"uuid,omitempty"`
+	WithAdminOption *bool  `json:"with-admin-option,omitempty"`
+}
+
+type DBAASClickhouseUserRoleInput struct {
+	// Role UUID
+	Uuid UUID `json:"uuid" validate:"required"`
+}
+
+type DBAASClickhouseUsers struct {
+	Users []DBAASClickhouseUser `json:"users,omitempty"`
 }
 
 type DBAASDatabaseName string
@@ -957,6 +1040,86 @@ type DBAASServiceBackup struct {
 	DataSize int64 `json:"data-size" validate:"required,gte=0"`
 }
 
+type DBAASServiceClickhouseComponents struct {
+	// Service component name
+	Component string `json:"component" validate:"required"`
+	// DNS name for connecting to the service component
+	Host string `json:"host" validate:"required"`
+	// Port number for connecting to the service component
+	Port  int64              `json:"port" validate:"required,gte=0,lte=65535"`
+	Route EnumComponentRoute `json:"route" validate:"required"`
+	// Whether the endpoint is encrypted or accepts plaintext.
+	// By default endpoints are always encrypted and
+	// this property is only included for service components that may disable encryption.
+	SSL   *bool              `json:"ssl,omitempty"`
+	Usage EnumComponentUsage `json:"usage" validate:"required"`
+}
+
+// ClickHouse connection information properties
+type DBAASServiceClickhouseConnectionInfo struct {
+	ArrowflightURI string   `json:"arrowflight-uri,omitempty"`
+	MysqlURI       string   `json:"mysql-uri,omitempty"`
+	URI            []string `json:"uri,omitempty"`
+}
+
+// Prometheus integration URI
+type DBAASServiceClickhousePrometheusURI struct {
+	Host string `json:"host,omitempty"`
+	Port int64  `json:"port,omitempty" validate:"omitempty,gte=0,lte=65535"`
+}
+
+type DBAASServiceClickhouse struct {
+	// List of backups for the service
+	Backups []DBAASServiceBackup `json:"backups,omitempty"`
+	// ClickHouse settings
+	ClickhouseSettings *JSONSchemaClickhouse `json:"clickhouse-settings,omitempty"`
+	// Service component information objects
+	Components []DBAASServiceClickhouseComponents `json:"components,omitempty"`
+	// ClickHouse connection information properties
+	ConnectionInfo *DBAASServiceClickhouseConnectionInfo `json:"connection-info,omitempty"`
+	// Service creation timestamp (ISO 8601)
+	CreatedAT time.Time `json:"created-at,omitempty"`
+	// TODO UNIT disk space for data storage
+	DiskSize int64 `json:"disk-size,omitempty" validate:"omitempty,gte=0"`
+	// Service integrations
+	Integrations []DBAASIntegration `json:"integrations,omitempty"`
+	// Allowed CIDR address blocks for incoming connections
+	IPFilter []string `json:"ip-filter,omitempty"`
+	// Automatic maintenance settings
+	Maintenance *DBAASServiceMaintenance `json:"maintenance,omitempty"`
+	Name        DBAASServiceName         `json:"name" validate:"required,gte=0,lte=63"`
+	// Number of service nodes in the active plan
+	NodeCount int64 `json:"node-count,omitempty" validate:"omitempty,gte=0"`
+	// Number of CPUs for each node
+	NodeCPUCount int64 `json:"node-cpu-count,omitempty" validate:"omitempty,gte=0"`
+	// TODO UNIT of memory for each node
+	NodeMemory int64 `json:"node-memory,omitempty" validate:"omitempty,gte=0"`
+	// State of individual service nodes
+	NodeStates []DBAASNodeState `json:"node-states,omitempty"`
+	// Service notifications
+	Notifications []DBAASServiceNotification `json:"notifications,omitempty"`
+	// Subscription plan
+	Plan string `json:"plan" validate:"required"`
+	// Prometheus integration URI
+	PrometheusURI *DBAASServiceClickhousePrometheusURI `json:"prometheus-uri" validate:"required"`
+	State         EnumServiceState                     `json:"state,omitempty"`
+	// Service is protected against termination and powering off
+	TerminationProtection *bool                `json:"termination-protection,omitempty"`
+	Type                  DBAASServiceTypeName `json:"type" validate:"required,gte=0,lte=64"`
+	// Service last update timestamp (ISO 8601)
+	UpdatedAT time.Time `json:"updated-at,omitempty"`
+	// URI for connecting to the service (may be absent)
+	URI string `json:"uri,omitempty"`
+	// service_uri parameterized into key-value pairs
+	URIParams map[string]any `json:"uri-params,omitempty"`
+	// List of ClickHouse users
+	Users []DBAASClickhouseUser `json:"users,omitempty"`
+	// ClickHouse version
+	Version string `json:"version,omitempty"`
+	// The zone where the service is running
+	Zone string `json:"zone,omitempty"`
+}
+
 type DBAASServiceCommon struct {
 	// Service creation timestamp (ISO 8601)
 	CreatedAT time.Time `json:"created-at,omitempty"`
@@ -1297,6 +1460,8 @@ type DBAASServiceMysql struct {
 	BackupSchedule *DBAASServiceMysqlBackupSchedule `json:"backup-schedule,omitempty"`
 	// List of backups for the service
 	Backups []DBAASServiceBackup `json:"backups,omitempty"`
+	// The minimum amount of time in seconds to keep binlog entries before deletion. This may be extended for services that require binlog entries for longer than the default for example if using the MySQL Debezium Kafka connector.
+	BinlogRetentionPeriod int64 `json:"binlog-retention-period,omitempty" validate:"omitempty,gt=0"`
 	// Service component information objects
 	Components []DBAASServiceMysqlComponents `json:"components,omitempty"`
 	// MySQL connection information properties
@@ -1599,6 +1764,8 @@ type DBAASServicePG struct {
 	Notifications []DBAASServiceNotification `json:"notifications,omitempty"`
 	// postgresql.conf configuration values
 	PGSettings *JSONSchemaPG `json:"pg-settings,omitempty"`
+	// System-wide settings for the pgaudit extension.
+	PgauditSettings *JSONSchemaPgaudit `json:"pgaudit-settings,omitempty"`
 	// System-wide settings for pgbouncer.
 	PgbouncerSettings *JSONSchemaPgbouncer `json:"pgbouncer-settings,omitempty"`
 	// System-wide settings for pglookout.
@@ -1852,6 +2019,14 @@ type DBAASTask struct {
 	TaskType    string                 `json:"task-type,omitempty"`
 }
 
+// ClickHouse User secrets
+type DBAASUserClickhouseSecrets struct {
+	// ClickHouse password
+	Password string `json:"password,omitempty"`
+	// ClickHouse username
+	Username string `json:"username,omitempty"`
+}
+
 // Grafana User secrets
 type DBAASUserGrafanaSecrets struct {
 	// Grafana password
@@ -1947,11 +2122,14 @@ type DBAASValkeyUsers struct {
 }
 
 type DecryptRequest struct {
-	Ciphertext        []byte  `json:"ciphertext" validate:"required"`
+	// The Base64-encoded ciphertext payload to be decrypted.
+	Ciphertext []byte `json:"ciphertext" validate:"required"`
+	// The exact Base64-encoded Additional Authenticated Data (AAD) used during encryption to verify data integrity.
 	EncryptionContext *[]byte `json:"encryption-context,omitempty"`
 }
 
 type DecryptResponse struct {
+	// The recovered Base64-encoded original plaintext payload.
 	Plaintext []byte `json:"plaintext" validate:"required"`
 }
 
@@ -2105,7 +2283,12 @@ type ElasticIPRef struct {
 	ID UUID `json:"id,omitempty"`
 }
 
+// An empty map response
+type Empty struct {
+}
+
 type EnableKmsKeyRotationRequest struct {
+	// The number of days between each automatic key rotation.
 	RotationPeriod int `json:"rotation-period,omitempty" validate:"omitempty,gte=90,lte=2560"`
 }
 
@@ -2114,11 +2297,14 @@ type EnableKmsKeyRotationResponse struct {
 }
 
 type EncryptRequest struct {
+	// Base64-encoded bytes to be used as the Additional Authenticated Data (AAD) for encryption integrity.
 	EncryptionContext *[]byte `json:"encryption-context,omitempty"`
-	Plaintext         []byte  `json:"plaintext" validate:"required"`
+	// The Base64-encoded plaintext data you wish to encrypt.
+	Plaintext []byte `json:"plaintext" validate:"required"`
 }
 
 type EncryptResponse struct {
+	// The resulting Base64-encoded ciphertext after encryption.
 	Ciphertext []byte `json:"ciphertext" validate:"required"`
 }
 
@@ -2305,21 +2491,15 @@ type EnvProduct struct {
 	Value string `json:"value,omitempty"`
 }
 
-type ErrorResponseErrors struct {
-	Detail   string `json:"detail,omitempty"`
-	Location string `json:"location,omitempty"`
-	Path     string `json:"path,omitempty"`
-	Pointer  string `json:"pointer,omitempty"`
-}
-
 // RFC 9457 Problem Details error response
 type ErrorResponse struct {
-	Detail   string                `json:"detail" validate:"required"`
-	Errors   []ErrorResponseErrors `json:"errors,omitempty"`
-	Instance string                `json:"instance,omitempty"`
-	Status   int                   `json:"status" validate:"required,gte=100,lte=599"`
-	Title    string                `json:"title" validate:"required"`
-	Type     string                `json:"type" validate:"required"`
+	// A highly contextual, readable explanation breaking down explicitly what triggered this error scenario.
+	Detail string `json:"detail" validate:"required"`
+	Status int    `json:"status" validate:"required,gte=100,lte=599"`
+	// A brief summary defining the class of failure, optimal for quick user interface groupings.
+	Title string `json:"title" validate:"required"`
+	// An absolute or relative URI reference pointing to human-readable documentation concerning the specific problem type encountered.
+	Type string `json:"type" validate:"required"`
 }
 
 // A notable Mutation Event which happened on the infrastructure
@@ -2356,20 +2536,6 @@ type Event struct {
 	Zone string `json:"zone,omitempty"`
 }
 
-type ForbiddenOperationResponseCode string
-
-const (
-	ForbiddenOperationResponseCodeForbiddenOperation ForbiddenOperationResponseCode = "forbidden_operation"
-)
-
-// Forbidden operation response
-type ForbiddenOperationResponse struct {
-	// Machine-readable forbidden error code
-	Code ForbiddenOperationResponseCode `json:"code" validate:"required"`
-	// Forbidden error message
-	Error string `json:"error" validate:"required"`
-}
-
 type GenerateDataKeyRequestKeySpec string
 
 const (
@@ -2377,35 +2543,54 @@ const (
 )
 
 type GenerateDataKeyRequest struct {
-	BytesCount        int                           `json:"bytes-count,omitempty" validate:"omitempty,gte=1,lte=1024"`
+	BytesCount int `json:"bytes-count,omitempty" validate:"omitempty,gte=1,lte=1024"`
+	// Base64-encoded Additional Authenticated Data binding key generation parameters securely to operational scope.
 	EncryptionContext *[]byte                       `json:"encryption-context,omitempty"`
 	KeySpec           GenerateDataKeyRequestKeySpec `json:"key-spec,omitempty"`
 }
 
 type GenerateDataKeyResponse struct {
+	// The identical symmetric data key, returned safely wrapped/encrypted using the designated root parent KMS key.
 	Ciphertext []byte `json:"ciphertext" validate:"required"`
-	Plaintext  []byte `json:"plaintext" validate:"required"`
+	// The Base64-encoded raw symmetric data key payload. Expose only securely during active application setups.
+	Plaintext []byte `json:"plaintext" validate:"required"`
+}
+
+// Get AI API key response
+type GetAIAPIKeyResponse struct {
+	// Creation timestamp
+	CreatedAT time.Time `json:"created-at" validate:"required"`
+	// AI API key ID
+	ID UUID `json:"id" validate:"required"`
+	// Human-readable name for the AI API key
+	Name string `json:"name" validate:"required"`
+	// Organization UUID that owns this key
+	OrgUuid UUID `json:"org-uuid" validate:"required"`
+	// Key scope: 'public' for all deployments, or a specific deployment UUID
+	Scope string `json:"scope" validate:"required"`
+	// Last update timestamp
+	UpdatedAT time.Time `json:"updated-at" validate:"required"`
 }
 
 // GPU usage for all organizations
 type GetConfederatioUsageResponse struct {
-	OrganizationsUsages map[string]OrganizationUsage `json:"organizations_usages" validate:"required"`
+	OrganizationsUsages map[string]OrganizationUsage `json:"organizations-usages" validate:"required"`
 }
 
 // A single log entry
 type GetDeploymentLogsEntry struct {
 	// Log message content
-	Message string `json:"message,omitempty"`
+	Message string `json:"message" validate:"required"`
 	// Node identifier
-	Node string `json:"node,omitempty"`
+	Node string `json:"node" validate:"required"`
 	// Timestamp of the log entry
-	Time string `json:"time,omitempty"`
+	Time time.Time `json:"time" validate:"required"`
 }
 
 // Deployment logs
 type GetDeploymentLogsResponse struct {
 	// List of log entries
-	Logs []GetDeploymentLogsEntry `json:"logs,omitempty"`
+	Logs []GetDeploymentLogsEntry `json:"logs" validate:"required"`
 }
 
 type GetDeploymentResponseState string
@@ -2413,44 +2598,48 @@ type GetDeploymentResponseState string
 const (
 	GetDeploymentResponseStateReady     GetDeploymentResponseState = "ready"
 	GetDeploymentResponseStateCreating  GetDeploymentResponseState = "creating"
+	GetDeploymentResponseStatePreparing GetDeploymentResponseState = "preparing"
 	GetDeploymentResponseStateError     GetDeploymentResponseState = "error"
 	GetDeploymentResponseStateDeploying GetDeploymentResponseState = "deploying"
+	GetDeploymentResponseStateScaling   GetDeploymentResponseState = "scaling"
+	GetDeploymentResponseStateUpdating  GetDeploymentResponseState = "updating"
 )
 
 // AI deployment
 type GetDeploymentResponse struct {
 	// Creation time
-	CreatedAT time.Time `json:"created-at,omitempty"`
-	// Deployment URL (nullable)
-	DeploymentURL string `json:"deployment-url,omitempty"`
+	CreatedAT time.Time `json:"created-at" validate:"required"`
+	// Deployment inference endpoint URL
+	DeploymentURL string `json:"deployment-url" validate:"required"`
 	// Number of GPUs
-	GpuCount int64 `json:"gpu-count,omitempty" validate:"omitempty,gte=1"`
+	GpuCount int64 `json:"gpu-count" validate:"required,gte=1"`
 	// GPU type family
-	GpuType string `json:"gpu-type,omitempty" validate:"omitempty,gte=1"`
+	GpuType string `json:"gpu-type" validate:"required,gte=1"`
 	// Deployment ID
-	ID UUID `json:"id,omitempty"`
+	ID UUID `json:"id" validate:"required"`
 	// Optional extra inference engine server CLI args
-	InferenceEngineParameters []string `json:"inference-engine-parameters,omitempty"`
+	InferenceEngineParameters []string `json:"inference-engine-parameters" validate:"required"`
 	// Inference engine version
-	InferenceEngineVersion InferenceEngineVersion `json:"inference-engine-version,omitempty"`
-	Model                  *ModelRef              `json:"model,omitempty"`
+	InferenceEngineVersion InferenceEngineVersion `json:"inference-engine-version" validate:"required"`
+	// Model reference. Provide either id or name.
+	Model *ModelRef `json:"model" validate:"required"`
 	// Deployment name
-	Name string `json:"name,omitempty" validate:"omitempty,gte=1"`
+	Name string `json:"name" validate:"required,gte=1"`
 	// Number of replicas (>=0)
-	Replicas int64 `json:"replicas,omitempty" validate:"omitempty,gte=0"`
+	Replicas int64 `json:"replicas" validate:"required,gte=0"`
 	// Service level
-	ServiceLevel string `json:"service-level,omitempty" validate:"omitempty,gte=1"`
+	ServiceLevel string `json:"service-level" validate:"required,gte=1"`
 	// Deployment state
-	State GetDeploymentResponseState `json:"state,omitempty"`
+	State GetDeploymentResponseState `json:"state" validate:"required"`
 	// Deployment state details
-	StateDetails string `json:"state-details,omitempty"`
+	StateDetails string `json:"state-details" validate:"required"`
 	// Update time
-	UpdatedAT time.Time `json:"updated-at,omitempty"`
+	UpdatedAT time.Time `json:"updated-at" validate:"required"`
 }
 
 // List of allowed inference-engine parameters
 type GetInferenceEngineHelpResponse struct {
-	Parameters []InferenceEngineParameterEntry `json:"parameters,omitempty"`
+	Parameters []InferenceEngineParameterEntry `json:"parameters" validate:"required"`
 }
 
 type GetKmsKeyResponseSource string
@@ -2468,21 +2657,32 @@ const (
 )
 
 type GetKmsKeyResponse struct {
-	CreatedAT      time.Time               `json:"created-at" validate:"required"`
-	Description    string                  `json:"description" validate:"required"`
-	ID             UUID                    `json:"id" validate:"required"`
-	Material       *KeyMaterial            `json:"material" validate:"required"`
-	MultiZone      *bool                   `json:"multi-zone" validate:"required"`
-	Name           string                  `json:"name" validate:"required"`
-	OriginZone     string                  `json:"origin-zone" validate:"required"`
-	Replicas       []string                `json:"replicas" validate:"required"`
+	// The UTC timestamp showing when the KMS key was originally provisioned.
+	CreatedAT time.Time `json:"created-at" validate:"required"`
+	DeleteAT  time.Time `json:"delete-at,omitempty"`
+	// An optional detailed description providing additional context about the key's intended use case.
+	Description string `json:"description,omitempty"`
+	// The globally unique identifier (UUID) of the retrieved KMS key.
+	ID       UUID         `json:"id" validate:"required"`
+	Material *KeyMaterial `json:"material" validate:"required"`
+	// True if this is a multi-zone key.
+	MultiZone *bool `json:"multi-zone" validate:"required"`
+	// The display name of the KMS key.
+	Name string `json:"name" validate:"required"`
+	// The creation zone of the KMS key.
+	OriginZone string `json:"origin-zone" validate:"required"`
+	// A list of availability zones where this specific key has active replica mirrors.
+	Replicas []string `json:"replicas,omitempty"`
+	// Detailed synchronization metrics for each regional replica mirror.
 	ReplicasStatus []ReplicaState          `json:"replicas-status,omitempty"`
 	Revision       *RevisionStamp          `json:"revision" validate:"required"`
 	Rotation       *KeyRotationConfig      `json:"rotation" validate:"required"`
 	Source         GetKmsKeyResponseSource `json:"source" validate:"required"`
 	Status         GetKmsKeyResponseStatus `json:"status" validate:"required"`
-	StatusSince    time.Time               `json:"status-since" validate:"required"`
-	Usage          string                  `json:"usage" validate:"required"`
+	// The timestamp indicating exactly when the current key status was last transitioned.
+	StatusSince time.Time `json:"status-since" validate:"required"`
+	// The cryptographic operation constraints allowed on this key.
+	Usage string `json:"usage" validate:"required"`
 }
 
 type GetModelResponseState string
@@ -2498,23 +2698,23 @@ const (
 // AI model
 type GetModelResponse struct {
 	// Creation time
-	CreatedAT time.Time `json:"created-at,omitempty"`
+	CreatedAT time.Time `json:"created-at" validate:"required"`
 	// Model ID
-	ID UUID `json:"id,omitempty"`
-	// Model size (nullable)
-	ModelSize int64 `json:"model-size,omitempty" validate:"omitempty,gte=0"`
+	ID UUID `json:"id" validate:"required"`
+	// Model size in bytes
+	ModelSize int64 `json:"model-size" validate:"required,gte=0"`
 	// Model name
-	Name string `json:"name,omitempty" validate:"omitempty,gte=1"`
+	Name string `json:"name" validate:"required,gte=1"`
 	// Model state
-	State GetModelResponseState `json:"state,omitempty"`
+	State GetModelResponseState `json:"state" validate:"required"`
 	// Update time
-	UpdatedAT time.Time `json:"updated-at,omitempty"`
+	UpdatedAT time.Time `json:"updated-at" validate:"required"`
 }
 
 // GPU usage for an organization
 type GetOrganizationUsageResponse struct {
 	// Total GPU count
-	Gpu int64 `json:"gpu,omitempty" validate:"omitempty,gte=0"`
+	Gpu int64 `json:"gpu" validate:"required,gte=0"`
 }
 
 // IAM API Key
@@ -2539,6 +2739,12 @@ type IAMAPIKeyCreated struct {
 	Secret string `json:"secret,omitempty"`
 }
 
+// Assume Role Policy
+type IAMAssumeRolePolicy struct {
+	// IAM Assume Role Policy rules
+	Rules []IAMServicePolicyRule `json:"rules,omitempty"`
+}
+
 type IAMPolicyDefaultServiceStrategy string
 
 const (
@@ -2556,8 +2762,8 @@ type IAMPolicy struct {
 
 // IAM Role
 type IAMRole struct {
-	// Policy
-	AssumeRolePolicy *IAMPolicy `json:"assume-role-policy,omitempty"`
+	// Assume Role Policy
+	AssumeRolePolicy *IAMAssumeRolePolicy `json:"assume-role-policy,omitempty"`
 	// IAM Role description
 	Description string `json:"description,omitempty" validate:"omitempty,gte=1,lte=255"`
 	// IAM Role mutability
@@ -2630,7 +2836,36 @@ const (
 	InferenceEngineVersion0180 InferenceEngineVersion = "0.18.0"
 	InferenceEngineVersion0181 InferenceEngineVersion = "0.18.1"
 	InferenceEngineVersion0190 InferenceEngineVersion = "0.19.0"
+	InferenceEngineVersion0191 InferenceEngineVersion = "0.19.1"
+	InferenceEngineVersion0200 InferenceEngineVersion = "0.20.0"
+	InferenceEngineVersion0201 InferenceEngineVersion = "0.20.1"
+	InferenceEngineVersion0202 InferenceEngineVersion = "0.20.2"
+	InferenceEngineVersion0210 InferenceEngineVersion = "0.21.0"
+	InferenceEngineVersion0220 InferenceEngineVersion = "0.22.0"
+	InferenceEngineVersion0221 InferenceEngineVersion = "0.22.1"
+	InferenceEngineVersion0230 InferenceEngineVersion = "0.23.0"
+	InferenceEngineVersion0240 InferenceEngineVersion = "0.24.0"
 )
+
+// Router flush payload: the router's full in-memory usage map with flush identity fields
+type IngestMeteringRequest struct {
+	// ISO-8601 UTC timestamp when the flush snapshot was created (truncated to minute boundary for bucketing)
+	CreatedAT time.Time `json:"created-at" validate:"required"`
+	// UUID identifying this flush; used for idempotent deduplication
+	FlushID UUID `json:"flush-id" validate:"required"`
+	// Router instance identifier that produced this flush
+	RouterID string `json:"router-id" validate:"required,gte=1"`
+	// Map of api-key-uuid to usage entry. Keys are API key UUIDs. Mirrors the router's in-memory accumulator structure directly.
+	Usage map[string]APIKeyUsageEntry `json:"usage" validate:"required"`
+}
+
+// Result of a metering ingest operation
+type IngestMeteringResponse struct {
+	// True if flush-id was already processed (idempotent retry)
+	Duplicate *bool `json:"duplicate,omitempty"`
+	// Number of rows affected (inserted or updated) in usage_minutely; 0 if duplicate flush-id
+	Upserted int `json:"upserted" validate:"required"`
+}
 
 // Private Network
 type InstancePrivateNetworks struct {
@@ -2650,6 +2885,8 @@ type Instance struct {
 	CreatedAT time.Time `json:"created-at,omitempty"`
 	// Deploy target reference
 	DeployTarget *DeployTarget `json:"deploy-target,omitempty"`
+	// Indicates if the root volume of the instance is encrypted
+	DiskEncrypted *bool `json:"disk-encrypted,omitempty"`
 	// Instance disk size in GiB
 	DiskSize int64 `json:"disk-size,omitempty" validate:"omitempty,gte=10,lte=51200"`
 	// Instance Elastic IPs
@@ -2795,6 +3032,7 @@ const (
 	InstanceTypeFamilyGpu           InstanceTypeFamily = "gpu"
 	InstanceTypeFamilyMemory        InstanceTypeFamily = "memory"
 	InstanceTypeFamilyGpua5000      InstanceTypeFamily = "gpua5000"
+	InstanceTypeFamilyGpub300       InstanceTypeFamily = "gpub300"
 	InstanceTypeFamilyGpurtx6000pro InstanceTypeFamily = "gpurtx6000pro"
 	InstanceTypeFamilyStorage       InstanceTypeFamily = "storage"
 	InstanceTypeFamilyStandard      InstanceTypeFamily = "standard"
@@ -2842,15 +3080,27 @@ type InstanceType struct {
 // Instance type with authorization status
 type InstanceTypeEntry struct {
 	// Whether this instance type is authorized based on server availability
-	Authorized *bool `json:"authorized,omitempty"`
+	Authorized *bool `json:"authorized" validate:"required"`
 	// GPU family name
-	Family string `json:"family,omitempty"`
+	Family string `json:"family" validate:"required"`
 }
 
 // Instance type reference
 type InstanceTypeRef struct {
 	// Instance type ID
 	ID UUID `json:"id,omitempty"`
+}
+
+// ClickHouse server settings, which can be found in the `system.server_settings` table.
+type JSONSchemaClickhouseServerSettings struct {
+	// Fraction of total server memory allocated to the vector similarity index cache. 0 disables the cache. Default is 0.07 (7% of server memory). Only effective on ClickHouse 25.8+.
+	VectorSimilarityIndexCacheSize float64 `json:"vector_similarity_index_cache_size,omitempty" validate:"omitempty,gte=0,lte=0.5"`
+}
+
+// ClickHouse settings
+type JSONSchemaClickhouse struct {
+	// ClickHouse server settings, which can be found in the `system.server_settings` table.
+	ServerSettings *JSONSchemaClickhouseServerSettings `json:"server_settings,omitempty"`
 }
 
 type JSONSchemaGrafanaAlertingErrorORTimeout string
@@ -3875,6 +4125,58 @@ type JSONSchemaPG struct {
 	Wal *JSONSchemaPGWal `json:"wal,omitempty"`
 }
 
+type JSONSchemaPgauditLogLevel string
+
+const (
+	JSONSchemaPgauditLogLevelDebug1  JSONSchemaPgauditLogLevel = "debug1"
+	JSONSchemaPgauditLogLevelDebug2  JSONSchemaPgauditLogLevel = "debug2"
+	JSONSchemaPgauditLogLevelDebug3  JSONSchemaPgauditLogLevel = "debug3"
+	JSONSchemaPgauditLogLevelDebug4  JSONSchemaPgauditLogLevel = "debug4"
+	JSONSchemaPgauditLogLevelDebug5  JSONSchemaPgauditLogLevel = "debug5"
+	JSONSchemaPgauditLogLevelInfo    JSONSchemaPgauditLogLevel = "info"
+	JSONSchemaPgauditLogLevelNotice  JSONSchemaPgauditLogLevel = "notice"
+	JSONSchemaPgauditLogLevelWarning JSONSchemaPgauditLogLevel = "warning"
+	JSONSchemaPgauditLogLevelLog     JSONSchemaPgauditLogLevel = "log"
+)
+
+// System-wide settings for the pgaudit extension.
+type JSONSchemaPgaudit struct {
+	// Enable pgaudit extension. When enabled, pgaudit extension will be automatically installed.Otherwise, extension will be uninstalled but auditing configurations will be preserved.
+	FeatureEnabled *bool `json:"feature_enabled,omitempty"`
+	// Specifies which classes of statements will be logged by session audit logging.
+	Log []string `json:"log,omitempty"`
+	// Specifies that session logging should be enabled in the case where all relations
+	// in a statement are in pg_catalog.
+	LogCatalog *bool `json:"log_catalog,omitempty"`
+	// Specifies whether log messages will be visible to a client process such as psql.
+	LogClient *bool `json:"log_client,omitempty"`
+	// Specifies the log level that will be used for log entries.
+	LogLevel JSONSchemaPgauditLogLevel `json:"log_level,omitempty"`
+	// Crop parameters representation and whole statements if they exceed this threshold.
+	// A (default) value of -1 disable the truncation.
+	LogMaxStringLength int `json:"log_max_string_length,omitempty" validate:"omitempty,gte=-1,lte=102400"`
+	// This GUC allows to turn off logging nested statements, that is, statements that are
+	// executed as part of another ExecutorRun.
+	LogNestedStatements *bool `json:"log_nested_statements,omitempty"`
+	// Specifies that audit logging should include the parameters that were passed with the statement.
+	LogParameter *bool `json:"log_parameter,omitempty"`
+	// Specifies that parameter values longer than this setting (in bytes) should not be logged,
+	// but replaced with <long param suppressed>.
+	LogParameterMaxSize int `json:"log_parameter_max_size,omitempty"`
+	// Specifies whether session audit logging should create a separate log entry
+	// for each relation (TABLE, VIEW, etc.) referenced in a SELECT or DML statement.
+	LogRelation *bool `json:"log_relation,omitempty"`
+	// Log Rows
+	LogRows *bool `json:"log_rows,omitempty"`
+	// Specifies whether logging will include the statement text and parameters (if enabled).
+	LogStatement *bool `json:"log_statement,omitempty"`
+	// Specifies whether logging will include the statement text and parameters with
+	// the first log entry for a statement/substatement combination or with every entry.
+	LogStatementOnce *bool `json:"log_statement_once,omitempty"`
+	// Specifies the master role to use for object audit logging.
+	Role string `json:"role,omitempty" validate:"omitempty,lte=64"`
+}
+
 type JSONSchemaPgbouncerAutodbPoolMode string
 
 const (
@@ -3996,6 +4298,10 @@ const (
 type JSONSchemaValkey struct {
 	// Determines default pub/sub channels' ACL for new users if ACL is not supplied. When this option is not defined, all_channels is assumed to keep backward compatibility. This option doesn't affect Valkey configuration acl-pubsub-default.
 	AclChannelsDefault JSONSchemaValkeyAclChannelsDefault `json:"acl_channels_default,omitempty"`
+	// Valkey reclaims expired keys both when accessed and in the background. The background process scans for expired keys to free memory. Increasing the active-expire-effort setting (default 1, max 10) uses more CPU to reclaim expired keys faster, reducing memory usage but potentially increasing latency.
+	ActiveExpireEffort int `json:"active_expire_effort,omitempty" validate:"omitempty,gte=1,lte=10"`
+	// When enabled, Valkey will create frequent local RDB snapshots. When disabled, Valkey will only take RDB snapshots when a backup is created, based on the backup schedule. This setting is ignored when `valkey_persistence` is set to `off`.
+	FrequentSnapshots *bool `json:"frequent_snapshots,omitempty"`
 	// Set Valkey IO thread count. Changing this will cause a restart of the Valkey service.
 	IoThreads int `json:"io_threads,omitempty" validate:"omitempty,gte=1,lte=32"`
 	// LFU maxmemory-policy counter decay time in minutes
@@ -4019,16 +4325,23 @@ type JSONSchemaValkey struct {
 }
 
 type KeyMaterial struct {
-	Automatic *bool     `json:"automatic" validate:"required"`
+	// A boolean flag indicating whether this specific material version was created during an automated system rotation window.
+	Automatic *bool `json:"automatic" validate:"required"`
+	// The UTC date-time indicating when this particular generation of physical cryptographic material was seeded.
 	CreatedAT time.Time `json:"created-at" validate:"required"`
-	Version   int       `json:"version" validate:"required"`
+	// The incremental index tracing internal key rotation cycles for the key material.
+	Version int `json:"version" validate:"required"`
 }
 
 type KeyRotationConfig struct {
-	Automatic      *bool     `json:"automatic" validate:"required"`
-	ManualCount    int       `json:"manual-count" validate:"required"`
-	NextAT         time.Time `json:"next-at" validate:"required"`
-	RotationPeriod int       `json:"rotation-period" validate:"required"`
+	// When set to true, dictates that the system automatically rotates material periodically.
+	Automatic *bool `json:"automatic" validate:"required"`
+	// Total running tally of manual key rotation tasks executed by users over this key resource's lifecycle.
+	ManualCount int `json:"manual-count" validate:"required"`
+	// Scheduled deadline calculation pinpointing the next automated rotational iteration target date.
+	NextAT time.Time `json:"next-at" validate:"required"`
+	// The set frequency period (measured in days) for triggers monitoring auto-rotation loops.
+	RotationPeriod int `json:"rotation-period" validate:"required"`
 }
 
 // Kubelet image GC options
@@ -4042,17 +4355,33 @@ type Labels map[string]string
 
 // List of AI API keys
 type ListAIAPIKeysResponse struct {
-	AIAPIKeys []AIAPIKey `json:"ai-api-keys" validate:"required"`
+	AIAPIKeys []ListAIAPIKeysResponseEntry `json:"ai-api-keys" validate:"required"`
+}
+
+// AI API key list entry
+type ListAIAPIKeysResponseEntry struct {
+	// Creation timestamp
+	CreatedAT time.Time `json:"created-at" validate:"required"`
+	// AI API key ID
+	ID UUID `json:"id" validate:"required"`
+	// Human-readable name for the AI API key
+	Name string `json:"name" validate:"required"`
+	// Organization UUID that owns this key
+	OrgUuid UUID `json:"org-uuid" validate:"required"`
+	// Key scope: 'public' for all deployments, or a specific deployment UUID
+	Scope string `json:"scope" validate:"required"`
+	// Last update timestamp
+	UpdatedAT time.Time `json:"updated-at" validate:"required"`
 }
 
 // List of available instance types with authorization status
 type ListAIInstanceTypesResponse struct {
-	InstanceTypes []InstanceTypeEntry `json:"instance-types,omitempty"`
+	InstanceTypes []InstanceTypeEntry `json:"instance-types" validate:"required"`
 }
 
-// AI model list
+// AI deployment list
 type ListDeploymentsResponse struct {
-	Deployments []ListDeploymentsResponseEntry `json:"deployments,omitempty"`
+	Deployments []ListDeploymentsResponseEntry `json:"deployments" validate:"required"`
 }
 
 type ListDeploymentsResponseEntryState string
@@ -4060,46 +4389,55 @@ type ListDeploymentsResponseEntryState string
 const (
 	ListDeploymentsResponseEntryStateReady     ListDeploymentsResponseEntryState = "ready"
 	ListDeploymentsResponseEntryStateCreating  ListDeploymentsResponseEntryState = "creating"
+	ListDeploymentsResponseEntryStatePreparing ListDeploymentsResponseEntryState = "preparing"
 	ListDeploymentsResponseEntryStateError     ListDeploymentsResponseEntryState = "error"
 	ListDeploymentsResponseEntryStateDeploying ListDeploymentsResponseEntryState = "deploying"
+	ListDeploymentsResponseEntryStateScaling   ListDeploymentsResponseEntryState = "scaling"
+	ListDeploymentsResponseEntryStateUpdating  ListDeploymentsResponseEntryState = "updating"
 )
 
 // AI deployment
 type ListDeploymentsResponseEntry struct {
 	// Creation time
-	CreatedAT time.Time `json:"created-at,omitempty"`
-	// Deployment URL (nullable)
-	DeploymentURL string `json:"deployment-url,omitempty"`
+	CreatedAT time.Time `json:"created-at" validate:"required"`
+	// Deployment inference endpoint URL
+	DeploymentURL string `json:"deployment-url" validate:"required"`
 	// Number of GPUs
-	GpuCount int64 `json:"gpu-count,omitempty" validate:"omitempty,gte=1"`
+	GpuCount int64 `json:"gpu-count" validate:"required,gte=1"`
 	// GPU type family
-	GpuType string `json:"gpu-type,omitempty" validate:"omitempty,gte=1"`
+	GpuType string `json:"gpu-type" validate:"required,gte=1"`
 	// Deployment ID
-	ID    UUID      `json:"id,omitempty"`
-	Model *ModelRef `json:"model,omitempty"`
+	ID UUID `json:"id" validate:"required"`
+	// Model reference. Provide either id or name.
+	Model *ModelRef `json:"model" validate:"required"`
 	// Deployment name
-	Name string `json:"name,omitempty" validate:"omitempty,gte=1"`
+	Name string `json:"name" validate:"required,gte=1"`
 	// Number of replicas (>=0)
-	Replicas int64 `json:"replicas,omitempty" validate:"omitempty,gte=0"`
+	Replicas int64 `json:"replicas" validate:"required,gte=0"`
 	// Service level
-	ServiceLevel string `json:"service-level,omitempty" validate:"omitempty,gte=1"`
+	ServiceLevel string `json:"service-level" validate:"required,gte=1"`
 	// Deployment state
-	State ListDeploymentsResponseEntryState `json:"state,omitempty"`
+	State ListDeploymentsResponseEntryState `json:"state" validate:"required"`
 	// Update time
-	UpdatedAT time.Time `json:"updated-at,omitempty"`
+	UpdatedAT time.Time `json:"updated-at" validate:"required"`
 }
 
 type ListKmsKeyRotationsResponse struct {
+	// A chronologically ordered collection tracking historical rotation lifecycle occurrences for this resource.
 	Rotations []ListKmsKeyRotationsResponseEntry `json:"rotations" validate:"required"`
 }
 
 type ListKmsKeyRotationsResponseEntry struct {
-	Automatic *bool     `json:"automatic" validate:"required"`
+	// Flag stating whether an automation run handled this historic mutation or if manual actor keys initiated it.
+	Automatic *bool `json:"automatic" validate:"required"`
+	// The UTC timestamp tracking precisely when this historical adjustment pass finished processing.
 	RotatedAT time.Time `json:"rotated-at" validate:"required"`
-	Version   int       `json:"version" validate:"required"`
+	// The absolute increment index referencing this specific historical structural material setup.
+	Version int `json:"version" validate:"required"`
 }
 
 type ListKmsKeysResponse struct {
+	// An array containing metadata entries for all available keys for your organization in the requested zone.
 	KmsKeys []ListKmsKeysResponseEntry `json:"kms-keys" validate:"required"`
 }
 
@@ -4118,25 +4456,35 @@ const (
 )
 
 type ListKmsKeysResponseEntry struct {
-	CreatedAT   time.Time                      `json:"created-at" validate:"required"`
-	Description string                         `json:"description" validate:"required"`
-	ID          UUID                           `json:"id" validate:"required"`
-	Material    *KeyMaterial                   `json:"material" validate:"required"`
-	MultiZone   *bool                          `json:"multi-zone" validate:"required"`
-	Name        string                         `json:"name" validate:"required"`
-	OriginZone  string                         `json:"origin-zone" validate:"required"`
-	Replicas    []string                       `json:"replicas" validate:"required"`
-	Revision    *RevisionStamp                 `json:"revision" validate:"required"`
-	Rotation    *KeyRotationConfig             `json:"rotation" validate:"required"`
-	Source      ListKmsKeysResponseEntrySource `json:"source" validate:"required"`
-	Status      ListKmsKeysResponseEntryStatus `json:"status" validate:"required"`
-	StatusSince time.Time                      `json:"status-since" validate:"required"`
-	Usage       string                         `json:"usage" validate:"required"`
+	// The UTC timestamp showing when the KMS key was originally provisioned.
+	CreatedAT time.Time `json:"created-at" validate:"required"`
+	DeleteAT  time.Time `json:"delete-at,omitempty"`
+	// An optional detailed description providing additional context about the key's intended use case.
+	Description string `json:"description,omitempty"`
+	// The globally unique identifier (UUID) tracking this key entity.
+	ID       UUID         `json:"id" validate:"required"`
+	Material *KeyMaterial `json:"material" validate:"required"`
+	// True if this is a multi-zone key.
+	MultiZone *bool `json:"multi-zone" validate:"required"`
+	// The display name of the KMS key.
+	Name string `json:"name" validate:"required"`
+	// The creation zone of the KMS key.
+	OriginZone string `json:"origin-zone" validate:"required"`
+	// Array tracking target zones currently maintaining copies of this item.
+	Replicas []string                       `json:"replicas,omitempty"`
+	Revision *RevisionStamp                 `json:"revision" validate:"required"`
+	Rotation *KeyRotationConfig             `json:"rotation" validate:"required"`
+	Source   ListKmsKeysResponseEntrySource `json:"source" validate:"required"`
+	Status   ListKmsKeysResponseEntryStatus `json:"status" validate:"required"`
+	// The precise time when the key entered its current configuration phase.
+	StatusSince time.Time `json:"status-since" validate:"required"`
+	// The cryptographic operation constraints allowed on this key.
+	Usage string `json:"usage" validate:"required"`
 }
 
 // AI model list
 type ListModelsResponse struct {
-	Models []ListModelsResponseEntry `json:"models,omitempty"`
+	Models []ListModelsResponseEntry `json:"models" validate:"required"`
 }
 
 type ListModelsResponseEntryState string
@@ -4152,17 +4500,91 @@ const (
 // AI model
 type ListModelsResponseEntry struct {
 	// Creation time
-	CreatedAT time.Time `json:"created-at,omitempty"`
+	CreatedAT time.Time `json:"created-at" validate:"required"`
 	// Model ID
-	ID UUID `json:"id,omitempty"`
-	// Model size (nullable)
-	ModelSize int64 `json:"model-size,omitempty" validate:"omitempty,gte=0"`
+	ID UUID `json:"id" validate:"required"`
+	// Model size in bytes
+	ModelSize int64 `json:"model-size" validate:"required,gte=0"`
 	// Model name
-	Name string `json:"name,omitempty" validate:"omitempty,gte=1"`
+	Name string `json:"name" validate:"required,gte=1"`
 	// Model state
-	State ListModelsResponseEntryState `json:"state,omitempty"`
+	State ListModelsResponseEntryState `json:"state" validate:"required"`
 	// Update time
-	UpdatedAT time.Time `json:"updated-at,omitempty"`
+	UpdatedAT time.Time `json:"updated-at" validate:"required"`
+}
+
+type ListRouteEntryKind string
+
+const (
+	ListRouteEntryKindSubnet ListRouteEntryKind = "Subnet"
+	ListRouteEntryKindVpc    ListRouteEntryKind = "Vpc"
+)
+
+// Route
+type ListRouteEntry struct {
+	// Route description
+	Description string `json:"description,omitempty" validate:"omitempty,lte=4096"`
+	// Route destination CIDR
+	Destination string `json:"destination,omitempty"`
+	// Route ID
+	ID UUID `json:"id,omitempty"`
+	// Route kind
+	Kind ListRouteEntryKind `json:"kind,omitempty"`
+	// Route target
+	Target string `json:"target,omitempty"`
+}
+
+type ListSubnetEntryAddressSpace string
+
+const (
+	ListSubnetEntryAddressSpacePrivate ListSubnetEntryAddressSpace = "private"
+)
+
+type ListSubnetEntryAddressfamily string
+
+const (
+	ListSubnetEntryAddressfamilyInet4 ListSubnetEntryAddressfamily = "inet4"
+	ListSubnetEntryAddressfamilyDual  ListSubnetEntryAddressfamily = "dual"
+)
+
+// Subnet
+type ListSubnetEntry struct {
+	// Subnet address space
+	AddressSpace ListSubnetEntryAddressSpace `json:"address-space,omitempty"`
+	// Subnet address family
+	Addressfamily ListSubnetEntryAddressfamily `json:"addressfamily,omitempty"`
+	// Subnet creation date
+	CreatedAT time.Time `json:"created-at,omitempty"`
+	// Subnet description
+	Description string `json:"description,omitempty" validate:"omitempty,lte=4096"`
+	// Subnet ID
+	ID UUID `json:"id,omitempty"`
+	// Subnet ipv4 CIDR
+	Ipv4Block string `json:"ipv4-block,omitempty"`
+	Labels    Labels `json:"labels,omitempty"`
+	// Subnet name
+	Name string `json:"name,omitempty" validate:"omitempty,gte=1,lte=255"`
+}
+
+// VPC
+type ListVpcEntry struct {
+	// VPC creation date
+	CreatedAT time.Time `json:"created-at,omitempty"`
+	// VPC description
+	Description string `json:"description,omitempty" validate:"omitempty,lte=4096"`
+	// VPC ID
+	ID     UUID   `json:"id,omitempty"`
+	Labels Labels `json:"labels,omitempty"`
+	// VPC name
+	Name string `json:"name,omitempty" validate:"omitempty,gte=1,lte=255"`
+}
+
+// Live balance
+type LiveBalance struct {
+	// Organization live balance
+	Balance float64 `json:"balance,omitempty"`
+	// Organization currency
+	Currency string `json:"currency,omitempty"`
 }
 
 type LoadBalancerState string
@@ -4302,6 +4724,7 @@ type Manager struct {
 	Type ManagerType `json:"type,omitempty"`
 }
 
+// Model reference. Provide either id or name.
 type ModelRef struct {
 	// Associated model ID
 	ID UUID `json:"id,omitempty"`
@@ -4309,18 +4732,60 @@ type ModelRef struct {
 	Name string `json:"name,omitempty" validate:"omitempty,gte=1"`
 }
 
-// Cluster networking configuration.
+// Accumulated Unit Of Measurement (UOM) counters for one model over a flush window
+type ModelUsageCounters struct {
+	// Number of inference calls in this flush window
+	CallCount int `json:"call-count" validate:"required,gte=1"`
+	// Total prompt/input Unit Of Measurement (UOM) across all calls in this flush window (e.g., tokens for LLMs, minutes for TTS, pages for OCR)
+	InputUom int `json:"input-uom" validate:"required,gte=0"`
+	// Total completion/output Unit Of Measurement (UOM) across all calls in this flush window (e.g., tokens for LLMs, minutes for TTS, pages for OCR)
+	OutputUom int `json:"output-uom" validate:"required,gte=0"`
+}
+
+// EXPERIMENTAL: Cluster networking configuration.
 type Networking struct {
 	// CIDR Range for Pods in cluster. This must not overlap with any IP ranges assigned to pods. Max of two, comma-separated, dual-stack CIDRs is allowed.
 	// If not specified, defaults to 192.168.0.0/16.
 	ClusterCidr string `json:"cluster-cidr,omitempty"`
-	// Mask size for node cidr in cluster. It must be larger than the Pod CIDR subnet mask. Defaults to 24
+	// Mask size for node cidr in cluster. It must be larger than, and at most 16 bits longer than, the Pod CIDR subnet mask. Defaults to 24
 	NodeCidrMaskSizeIpv4 int64 `json:"node-cidr-mask-size-ipv4,omitempty" validate:"omitempty,gt=0"`
-	// Mask size for node cidr in cluster. It must be larger than the Pod CIDR subnet mask. Defaults to 64
+	// Mask size for node cidr in cluster. It must be larger than, and at most 16 bits longer than, the Pod CIDR subnet mask. Defaults to 64
 	NodeCidrMaskSizeIpv6 int64 `json:"node-cidr-mask-size-ipv6,omitempty" validate:"omitempty,gt=0"`
-	// CIDR range for service cluster IPs. This must not overlap with any IP ranges assigned to nodes or pods. Max of two, comma-separated, dual-stack CIDRs is allowed.
+	// CIDR range for service cluster IPs. This must not overlap with any IP ranges assigned to nodes or pods. Max of two, comma-separated, dual-stack CIDRs is allowed. The IPv6 range must be no larger than a /108 (upstream Kubernetes apiserver limit).
 	// If not specified, defaults to 10.96.0.0/12.
 	ServiceClusterIPRange string `json:"service-cluster-ip-range,omitempty"`
+}
+
+type NvidiaMigProfileA3024gb string
+
+const (
+	NvidiaMigProfileA3024gb1G6Gb    NvidiaMigProfileA3024gb = "1g.6gb"
+	NvidiaMigProfileA3024gb1G6GbMe  NvidiaMigProfileA3024gb = "1g.6gb+me"
+	NvidiaMigProfileA3024gb2G12Gb   NvidiaMigProfileA3024gb = "2g.12gb"
+	NvidiaMigProfileA3024gb2G12GbMe NvidiaMigProfileA3024gb = "2g.12gb+me"
+	NvidiaMigProfileA3024gb4G24Gb   NvidiaMigProfileA3024gb = "4g.24gb"
+)
+
+type NvidiaMigProfileRtxpro600096gb string
+
+const (
+	NvidiaMigProfileRtxpro600096gb1G24Gb      NvidiaMigProfileRtxpro600096gb = "1g.24gb"
+	NvidiaMigProfileRtxpro600096gb1G24GbMe    NvidiaMigProfileRtxpro600096gb = "1g.24gb+me"
+	NvidiaMigProfileRtxpro600096gb1G24GbGfx   NvidiaMigProfileRtxpro600096gb = "1g.24gb+gfx"
+	NvidiaMigProfileRtxpro600096gb1G24GbMeAll NvidiaMigProfileRtxpro600096gb = "1g.24gb+me.all"
+	NvidiaMigProfileRtxpro600096gb1G24GbNoMe  NvidiaMigProfileRtxpro600096gb = "1g.24gb-me"
+	NvidiaMigProfileRtxpro600096gb2G48Gb      NvidiaMigProfileRtxpro600096gb = "2g.48gb"
+	NvidiaMigProfileRtxpro600096gb2G48GbGfx   NvidiaMigProfileRtxpro600096gb = "2g.48gb+gfx"
+	NvidiaMigProfileRtxpro600096gb2G48GbMeAll NvidiaMigProfileRtxpro600096gb = "2g.48gb+me.all"
+	NvidiaMigProfileRtxpro600096gb2G48GbNoMe  NvidiaMigProfileRtxpro600096gb = "2g.48gb-me"
+	NvidiaMigProfileRtxpro600096gb4G96Gb      NvidiaMigProfileRtxpro600096gb = "4g.96gb"
+	NvidiaMigProfileRtxpro600096gb4G96GbGfx   NvidiaMigProfileRtxpro600096gb = "4g.96gb+gfx"
+)
+
+// Nvidia MIG Profiles enabled
+type NvidiaMigProfiles struct {
+	A3024gb        NvidiaMigProfileA3024gb        `json:"a30.24gb,omitempty"`
+	Rtxpro600096gb NvidiaMigProfileRtxpro600096gb `json:"rtxpro6000.96gb,omitempty"`
 }
 
 type OperationReason string
@@ -4372,17 +4837,17 @@ type Operation struct {
 	State OperationState `json:"state,omitempty"`
 }
 
-type OperationResourceRef struct {
-	Command string `json:"command" validate:"required"`
-	ID      UUID   `json:"id" validate:"required"`
-	Link    string `json:"link,omitempty"`
+// Per-org Unit Of Measurement (UOM) consumption quota response
+type OrgConsumptionQuotaResponse struct {
+	// Per-org Unit Of Measurement (UOM) consumption quota (UOM/min). Null means unlimited. UOM represents weighted units across different AI workloads (e.g., tokens for LLMs, minutes for TTS, pages for OCR).
+	QuotaUomPerMinute int `json:"quota-uom-per-minute,omitempty" validate:"omitempty,gte=0"`
 }
 
 // Organization
 type Organization struct {
 	// Organization address
 	Address string `json:"address,omitempty"`
-	// Organization balance
+	// Organization balance. DEPRECATED: use the dedicated `live-balance` endpoint
 	Balance float64 `json:"balance,omitempty"`
 	// Organization city
 	City string `json:"city,omitempty"`
@@ -4400,8 +4865,18 @@ type Organization struct {
 
 // Organization GPU usage
 type OrganizationUsage struct {
-	// Total GPU count
+	// Total GPU count (sum of all GPU types)
 	Gpu int64 `json:"gpu" validate:"required,gte=0"`
+	// GPU3 count
+	Gpu3 int64 `json:"gpu3,omitempty" validate:"omitempty,gte=0"`
+	// GPU3080TI count
+	Gpu3080ti int64 `json:"gpu3080ti,omitempty" validate:"omitempty,gte=0"`
+	// GPUA30 count
+	Gpua30 int64 `json:"gpua30,omitempty" validate:"omitempty,gte=0"`
+	// GPUA5000 count
+	Gpua5000 int64 `json:"gpua5000,omitempty" validate:"omitempty,gte=0"`
+	// GPURTX6000PRO count
+	Gpurtx6000pro int64 `json:"gpurtx6000pro,omitempty" validate:"omitempty,gte=0"`
 }
 
 // Private Network
@@ -4471,18 +4946,27 @@ type Quota struct {
 	Usage int64 `json:"usage,omitempty"`
 }
 
+// Rate Limit
+type RateLimited struct {
+	// The error message
+	Error string `json:"error,omitempty"`
+	// The time in seconds to wait before the next request
+	RetryAfter float64 `json:"retry_after,omitempty"`
+}
+
 type ReEncryptRequestDestination struct {
-	// Optional encryption context appended to the AAD.
+	// Optional new Base64-encoded encryption context to apply under the target destination envelope.
 	EncryptionContext *[]byte `json:"encryption-context,omitempty"`
-	// The ID of the target key.
+	// The ID of the target key chosen to encapsulate the newly shifted data translation.
 	Key UUID `json:"key" validate:"required"`
 }
 
 type ReEncryptRequestSource struct {
+	// The Base64-encoded encrypted payload package ready to undergo source-side key decryption.
 	Ciphertext []byte `json:"ciphertext" validate:"required"`
-	// Optional encryption context appended to the AAD.
+	// Optional Base64-encoded encryption context originally appended to the AAD to confirm package validation rules.
 	EncryptionContext *[]byte `json:"encryption-context,omitempty"`
-	// The ID of the source key.
+	// The ID of the source key currently protecting the data payload.
 	Key UUID `json:"key" validate:"required"`
 }
 
@@ -4492,6 +4976,7 @@ type ReEncryptRequest struct {
 }
 
 type ReEncryptResponse struct {
+	// The new Base64-encoded ciphertext block safely wrapped by the chosen destination key parameters.
 	Ciphertext []byte `json:"ciphertext" validate:"required"`
 }
 
@@ -4502,18 +4987,24 @@ type RecomputeBundleResponse struct {
 }
 
 type ReplicaFailure struct {
-	AttemptedWatermark int       `json:"attempted-watermark" validate:"required"`
-	Error              string    `json:"error" validate:"required"`
-	FailedAT           time.Time `json:"failed-at" validate:"required"`
+	// The target sync sequence watermark that triggered the replication failure.
+	AttemptedWatermark int `json:"attempted-watermark" validate:"required"`
+	// A descriptive message containing error logs or system details regarding the sync failure.
+	Error string `json:"error" validate:"required"`
+	// The UTC timestamp showing exactly when the replication sync window failed.
+	FailedAT time.Time `json:"failed-at" validate:"required"`
 }
 
 type ReplicaState struct {
+	// The latest logical sequence number or state watermark successfully synced to this regional replica.
 	LastAppliedWatermark int             `json:"last-applied-watermark" validate:"required"`
 	LastFailure          *ReplicaFailure `json:"last-failure,omitempty"`
-	Zone                 string          `json:"zone" validate:"required"`
+	// The destination target zone tracking this specific replica instance.
+	Zone string `json:"zone" validate:"required"`
 }
 
 type ReplicateKmsKeyRequest struct {
+	// The targeted cloud zone where the KMS key should be replicated.
 	Zone string `json:"zone" validate:"required"`
 }
 
@@ -4525,9 +5016,16 @@ type Resource struct {
 	Name string `json:"name,omitempty"`
 }
 
+// Reveal AI API key response
+type RevealAIAPIKeyResponse struct {
+	// Plaintext AI API key value
+	Value string `json:"value" validate:"required"`
+}
+
 // AI deployment inference endpoint authentication key
 type RevealDeploymentAPIKeyResponse struct {
-	APIKey string `json:"api-key,omitempty"`
+	// Inference endpoint authentication key
+	APIKey string `json:"api-key" validate:"required"`
 }
 
 type ReverseDNSRecord struct {
@@ -4535,12 +5033,41 @@ type ReverseDNSRecord struct {
 }
 
 type RevisionStamp struct {
-	AT  time.Time `json:"at" validate:"required"`
-	Seq int       `json:"seq" validate:"required,gte=0"`
+	// The timestamp recording exactly when this specific revision iteration occurred.
+	AT time.Time `json:"at" validate:"required"`
+	// Monotonically increasing sequencing value utilized for optimistic concurrency control locks.
+	Seq int `json:"seq" validate:"required,gte=0"`
+}
+
+// Rotate AI API key response
+type RotateAIAPIKeyResponse struct {
+	// Plaintext AI API key value
+	Value string `json:"value" validate:"required"`
 }
 
 type RotateKmsKeyResponse struct {
 	Rotation *KeyRotationConfig `json:"rotation" validate:"required"`
+}
+
+type RouteKind string
+
+const (
+	RouteKindSubnet RouteKind = "Subnet"
+	RouteKindVpc    RouteKind = "Vpc"
+)
+
+// Route
+type Route struct {
+	// Route description
+	Description string `json:"description,omitempty" validate:"omitempty,lte=4096"`
+	// Route destination CIDR
+	Destination string `json:"destination,omitempty"`
+	// Route ID
+	ID UUID `json:"id,omitempty"`
+	// Route kind
+	Kind RouteKind `json:"kind,omitempty"`
+	// Route target
+	Target string `json:"target,omitempty"`
 }
 
 // Scale AI deployment
@@ -4552,6 +5079,11 @@ type ScaleDeploymentRequest struct {
 type ScheduleKmsKeyDeletionRequest struct {
 	// Number of days to wait until deletion is final.
 	DelayDays int `json:"delay-days,omitempty" validate:"omitempty,gte=7,lte=30"`
+}
+
+type ScheduleKmsKeyDeletionResponse struct {
+	// Timestamp of the key deletion
+	DeleteAT time.Time `json:"delete-at,omitempty"`
 }
 
 // Security Group
@@ -4638,6 +5170,12 @@ type SecurityGroupRule struct {
 	SecurityGroup *SecurityGroupResource `json:"security-group,omitempty"`
 	// Start port of the range
 	StartPort int64 `json:"start-port,omitempty" validate:"omitempty,gte=1,lte=65535"`
+}
+
+// Request to set per-org Unit Of Measurement (UOM) consumption quota
+type SetOrgConsumptionQuotaRequest struct {
+	// Per-org Unit Of Measurement (UOM) consumption quota (UOM/min). Pass null to remove the limit. UOM represents weighted units across different AI workloads (e.g., tokens for LLMs, minutes for TTS, pages for OCR).
+	QuotaUomPerMinute int `json:"quota-uom-per-minute,omitempty" validate:"omitempty,gte=0"`
 }
 
 // Kubernetes Audit parameters
@@ -4733,6 +5271,8 @@ type SKSCluster struct {
 	Name string `json:"name,omitempty" validate:"omitempty,gte=1,lte=255"`
 	// Cluster Nodepools
 	Nodepools []SKSNodepool `json:"nodepools,omitempty"`
+	// SKS Cluster OpenID config map
+	Oidc *SKSOidc `json:"oidc"`
 	// Cluster state
 	State SKSClusterState `json:"state,omitempty"`
 	// Control plane Kubernetes version
@@ -4811,6 +5351,8 @@ type SKSNodepool struct {
 	Labels         SKSNodepoolLabels `json:"labels,omitempty"`
 	// Nodepool name
 	Name string `json:"name,omitempty" validate:"omitempty,gte=1,lte=255"`
+	// Nvidia MIG Profiles enabled
+	NvidiaMigProfiles *NvidiaMigProfiles `json:"nvidia-mig-profiles,omitempty"`
 	// Nodepool Private Networks
 	PrivateNetworks []PrivateNetwork `json:"private-networks,omitempty"`
 	// Nodepool public IP assignment of the Instances:
@@ -4939,11 +5481,44 @@ type SSHKeyRef struct {
 	Name string `json:"name,omitempty" validate:"omitempty,gte=1,lte=255"`
 }
 
+type SubnetAddressSpace string
+
+const (
+	SubnetAddressSpacePrivate SubnetAddressSpace = "private"
+)
+
+type SubnetAddressfamily string
+
+const (
+	SubnetAddressfamilyInet4 SubnetAddressfamily = "inet4"
+	SubnetAddressfamilyDual  SubnetAddressfamily = "dual"
+)
+
+// Subnet
+type Subnet struct {
+	// Subnet address space
+	AddressSpace SubnetAddressSpace `json:"address-space,omitempty"`
+	// Subnet address family
+	Addressfamily SubnetAddressfamily `json:"addressfamily,omitempty"`
+	// Subnet creation date
+	CreatedAT time.Time `json:"created-at,omitempty"`
+	// Subnet description
+	Description string `json:"description,omitempty" validate:"omitempty,lte=4096"`
+	// Subnet ID
+	ID UUID `json:"id,omitempty"`
+	// Subnet ipv4 CIDR
+	Ipv4Block string `json:"ipv4-block,omitempty"`
+	Labels    Labels `json:"labels,omitempty"`
+	// Subnet name
+	Name string `json:"name,omitempty" validate:"omitempty,gte=1,lte=255"`
+}
+
 type SuccessResponseStatus string
 
 const (
 	SuccessResponseStatusSuccess          SuccessResponseStatus = "success"
 	SuccessResponseStatusTargetRegistered SuccessResponseStatus = "target-registered"
+	SuccessResponseStatusAlreadyApplied   SuccessResponseStatus = "already-applied"
 )
 
 type SuccessResponse struct {
@@ -5018,6 +5593,22 @@ type UpdateAIAPIKeyRequest struct {
 	Scope string `json:"scope,omitempty"`
 }
 
+// Update AI API key response
+type UpdateAIAPIKeyResponse struct {
+	// Creation timestamp
+	CreatedAT time.Time `json:"created-at" validate:"required"`
+	// AI API key ID
+	ID UUID `json:"id" validate:"required"`
+	// Human-readable name for the AI API key
+	Name string `json:"name" validate:"required"`
+	// Organization UUID that owns this key
+	OrgUuid UUID `json:"org-uuid" validate:"required"`
+	// Key scope: 'public' for all deployments, or a specific deployment UUID
+	Scope string `json:"scope" validate:"required"`
+	// Last update timestamp
+	UpdatedAT time.Time `json:"updated-at" validate:"required"`
+}
+
 // Update AI deployment
 type UpdateDeploymentRequest struct {
 	// Optional extra inference engine server CLI args
@@ -5042,6 +5633,19 @@ type User struct {
 	Sso *bool `json:"sso,omitempty"`
 	// Two Factor Authentication enabled
 	TwoFactorAuthentication *bool `json:"two-factor-authentication,omitempty"`
+}
+
+// VPC
+type Vpc struct {
+	// VPC creation date
+	CreatedAT time.Time `json:"created-at,omitempty"`
+	// VPC description
+	Description string `json:"description,omitempty" validate:"omitempty,lte=4096"`
+	// VPC ID
+	ID     UUID   `json:"id,omitempty"`
+	Labels Labels `json:"labels,omitempty"`
+	// VPC name
+	Name string `json:"name,omitempty" validate:"omitempty,gte=1,lte=255"`
 }
 
 // Zone

--- a/vendor/github.com/exoscale/egoscale/v3/version.go
+++ b/vendor/github.com/exoscale/egoscale/v3/version.go
@@ -1,4 +1,4 @@
 package v3
 
 // Version represents the current egoscale v3 version.
-const Version = "v3.1.41"
+const Version = "v3.1.42"

--- a/vendor/github.com/exoscale/egoscale/v3/version.go
+++ b/vendor/github.com/exoscale/egoscale/v3/version.go
@@ -1,4 +1,4 @@
 package v3
 
 // Version represents the current egoscale v3 version.
-const Version = "v3.1.35"
+const Version = "v3.1.41"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -271,8 +271,8 @@ github.com/exoscale/egoscale/v2
 github.com/exoscale/egoscale/v2/api
 github.com/exoscale/egoscale/v2/oapi
 github.com/exoscale/egoscale/version
-# github.com/exoscale/egoscale/v3 v3.1.35
-## explicit; go 1.26
+# github.com/exoscale/egoscale/v3 v3.1.41
+## explicit; go 1.25
 github.com/exoscale/egoscale/v3
 github.com/exoscale/egoscale/v3/credentials
 # github.com/fatih/color v1.18.0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -271,7 +271,7 @@ github.com/exoscale/egoscale/v2
 github.com/exoscale/egoscale/v2/api
 github.com/exoscale/egoscale/v2/oapi
 github.com/exoscale/egoscale/version
-# github.com/exoscale/egoscale/v3 v3.1.41
+# github.com/exoscale/egoscale/v3 v3.1.42
 ## explicit; go 1.25
 github.com/exoscale/egoscale/v3
 github.com/exoscale/egoscale/v3/credentials


### PR DESCRIPTION
# Description

Add support for Nvidia MIG on SKS nodepools.

Diff (no vendored libs): [here](https://github.com/exoscale/terraform-provider-exoscale/pull/564/changes?show-vendored-files=false)

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [ ] Acceptance tests OK
* [ ] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing

On A30 on preprod with `nvidia_mig_profile = "2g.12gb"` on a nodepool using a local build, i get this node description (as expected):

```
% kubectl get nodes pool-76e9b-xthcj -o yaml |grep "nvidia.com/gpu" -C 5 
  allocatable:
    cpu: 11700m
    ephemeral-storage: "42228336973"
    hugepages-2Mi: "0"
    memory: 57071344Ki
    nvidia.com/gpu: "2"
    pods: "110"
  capacity:
    cpu: "12"
    ephemeral-storage: 50481016Ki
    hugepages-2Mi: "0"
    memory: 57583344Ki
    nvidia.com/gpu: "2"
    pods: "110"
  conditions:
  - lastHeartbeatTime: "2026-07-14T15:13:39Z"
    lastTransitionTime: "2026-07-14T15:13:39Z"
    message: Calico is running on this node
```