### PR TITLE
Re-enable sks cluster test after API bug was fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ BUG FIXES:
 - fix: typo in security group rule import doc #559
 - dbaas: allows services with minor/patch version #563
 - improve acc test #563
+- Re-enable sks cluster test after API bug was fixed #568
 
 FEATURES:
 

--- a/exoscale/resource_exoscale_sks_cluster_test.go
+++ b/exoscale/resource_exoscale_sks_cluster_test.go
@@ -687,9 +687,7 @@ func TestAccResourceSKSClusterSKSClusterWithAudit(t *testing.T) {
 			},
 			{
 				// Re-enable audit with new URL and default backoff
-				Config:             testAccRessourceSKSClusterReEnableAuditWithNewURL,
-				PlanOnly:           true, // TODO: remove once sks-orch is fixed
-				ExpectNonEmptyPlan: true, // TODO: remove once sks-orch is fixed
+				Config: testAccRessourceSKSClusterReEnableAuditWithNewURL,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceSKSClusterExists(r, &sksCluster),
 					func(s *terraform.State) error {


### PR DESCRIPTION
# Description

API fix deployed, this PR re-enables test that was disabled in https://github.com/exoscale/terraform-provider-exoscale/pull/550

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Acceptance tests OK
* [ ] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing
```
]$ TF_ACC=1 go test ./... -run TestAccResourceSKSClusterSKSClusterWithAudit
?   	github.com/exoscale/terraform-provider-exoscale	[no test files]
ok  	github.com/exoscale/terraform-provider-exoscale/exoscale	142.848s
?   	github.com/exoscale/terraform-provider-exoscale/pkg/config	[no test files]
ok  	github.com/exoscale/terraform-provider-exoscale/pkg/filter	0.015s [no tests to run]
?   	github.com/exoscale/terraform-provider-exoscale/pkg/general	[no test files]
ok  	github.com/exoscale/terraform-provider-exoscale/pkg/list	0.060s [no tests to run]
?   	github.com/exoscale/terraform-provider-exoscale/pkg/provider	[no test files]
?   	github.com/exoscale/terraform-provider-exoscale/pkg/provider/config	[no test files]
ok  	github.com/exoscale/terraform-provider-exoscale/pkg/resources/anti_affinity_group	0.037s [no tests to run]
ok  	github.com/exoscale/terraform-provider-exoscale/pkg/resources/block_storage	0.048s [no tests to run]
ok  	github.com/exoscale/terraform-provider-exoscale/pkg/resources/database	0.047s [no tests to run]
ok  	github.com/exoscale/terraform-provider-exoscale/pkg/resources/iam	0.033s [no tests to run]
ok  	github.com/exoscale/terraform-provider-exoscale/pkg/resources/instance	0.035s [no tests to run]
ok  	github.com/exoscale/terraform-provider-exoscale/pkg/resources/instance_pool	0.029s [no tests to run]
ok  	github.com/exoscale/terraform-provider-exoscale/pkg/resources/kms	0.034s [no tests to run]
ok  	github.com/exoscale/terraform-provider-exoscale/pkg/resources/nlb_service	0.039s [no tests to run]
ok  	github.com/exoscale/terraform-provider-exoscale/pkg/resources/private_network	0.060s [no tests to run]
ok  	github.com/exoscale/terraform-provider-exoscale/pkg/resources/security_group	0.032s [no tests to run]
ok  	github.com/exoscale/terraform-provider-exoscale/pkg/resources/sos_bucket_policy	0.031s [no tests to run]
?   	github.com/exoscale/terraform-provider-exoscale/pkg/resources/zones	[no test files]
?   	github.com/exoscale/terraform-provider-exoscale/pkg/sos	[no test files]
?   	github.com/exoscale/terraform-provider-exoscale/pkg/testutils	[no test files]
ok  	github.com/exoscale/terraform-provider-exoscale/pkg/utils	0.023s [no tests to run]
?   	github.com/exoscale/terraform-provider-exoscale/pkg/validators	[no test files]
?   	github.com/exoscale/terraform-provider-exoscale/pkg/version	[no test files]
?   	github.com/exoscale/terraform-provider-exoscale/version	[no test files]
```
