### PR TITLE
feat(sks_cluster): allow major.minor SKS version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+FEATURES:
+
+- `sks_cluster`: allows `major.minor` as input value for `version`, resolves to the latest patch version available on the platform
+
 ## 0.70.0
 
 IMPROVEMENTS:

--- a/exoscale/resource_exoscale_sks_cluster.go
+++ b/exoscale/resource_exoscale_sks_cluster.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -412,19 +413,13 @@ func resourceSKSClusterCreate(ctx context.Context, d *schema.ResourceData, meta 
 		createReq.Level = v3.CreateSKSClusterRequestLevel(v.(string))
 	}
 
-	version := d.Get(resSKSClusterAttrVersion).(string)
-	if version == "" {
-		versions, err := client.ListSKSClusterVersions(ctx)
-		if err != nil {
-			return diag.Errorf("error retrieving SKS versions: %s", err)
-		}
-		if len(versions.SKSClusterVersions) == 0 {
-			return diag.Errorf("ListSKSClusterVersions: API returned empty list")
-		}
+	resolvedVersion, err := resolveSKSClusterVersion(ctx, client, d.Get(resSKSClusterAttrVersion).(string))
 
-		version = versions.SKSClusterVersions[0]
+	if err != nil {
+		return diag.FromErr(err)
 	}
-	createReq.Version = version
+
+	createReq.Version = resolvedVersion
 
 	// Audit
 	if v, ok := d.GetOk(resSKSClusterAttrAudit(resSKSClusterAttrAuditEnabled)); ok && v.(bool) {
@@ -598,10 +593,14 @@ func resourceSKSClusterUpdate(ctx context.Context, d *schema.ResourceData, meta 
 	clusterID := v3.UUID(d.Id())
 
 	// First check if we need to upgrade cluster
-	if d.HasChange(resSKSClusterAttrVersion) {
-		v := d.Get(resSKSClusterAttrVersion).(string)
+	oldVersion, newVersion := d.GetChange(resSKSClusterAttrVersion)
+	resolvedNewVersion, err := resolveSKSClusterVersion(ctx, client, newVersion.(string))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	if resolvedNewVersion != oldVersion.(string) {
 		if err := await(ctx, client)(client.UpgradeSKSCluster(ctx, clusterID, v3.UpgradeSKSClusterRequest{
-			Version: v,
+			Version: resolvedNewVersion,
 		})); err != nil {
 			return diag.FromErr(err)
 		}
@@ -889,10 +888,15 @@ func resourceSKSClusterApply(_ context.Context, d *schema.ResourceData, sksClust
 		return err
 	}
 
-	if err := d.Set(resSKSClusterAttrVersion, sksCluster.Version); err != nil {
-		return err
+	if len(strings.Split(d.Get(resSKSClusterAttrVersion).(string), ".")) == 2 {
+		if err := d.Set(resSKSClusterAttrVersion, strings.Join(strings.Split(sksCluster.Version, ".")[:2], ".")); err != nil {
+			return err
+		}
+	} else {
+		if err := d.Set(resSKSClusterAttrVersion, sksCluster.Version); err != nil {
+			return err
+		}
 	}
-
 	if err := d.Set(resSKSClusterAttrEnableKubeProxy, defaultBool(sksCluster.EnableKubeProxy, true)); err != nil {
 		return err
 	}
@@ -983,4 +987,42 @@ func readClusterCertificates(ctx context.Context, client *v3.Client, clusterID v
 		ControlPlaneCA: string(controlPlaneCertificate),
 		KubeletCA:      string(kubeletCertificate),
 	}, nil
+}
+
+// Computes the major.minor.patch version of an SKS cluster from an resSKSClusterAttrVersion inputVersion
+// Defaults to latest version
+func resolveSKSClusterVersion(ctx context.Context, client *v3.Client, inputVersion string) (string, error) {
+
+	inputVersionLength := len(strings.Split(inputVersion, "."))
+	isMajorMinor := inputVersionLength == 2
+	isMajorMinorPatch := inputVersionLength == 3
+
+	if isMajorMinorPatch {
+		return inputVersion, nil
+	}
+
+	availableVersions, err := client.ListSKSClusterVersions(ctx)
+	if err != nil {
+		return "", err
+	}
+	if len(availableVersions.SKSClusterVersions) == 0 {
+		return "", fmt.Errorf("ListSKSClusterVersions: API returned empty list")
+	}
+
+	defaultVersion := availableVersions.SKSClusterVersions[0]
+
+	if len(inputVersion) == 0 {
+		return defaultVersion, nil
+	}
+
+	if isMajorMinor {
+		for _, v := range availableVersions.SKSClusterVersions {
+			if inputVersion == strings.Join(strings.Split(v, ".")[:2], ".") {
+				return v, nil
+			}
+		}
+		return "", fmt.Errorf("the SKS cluster version %s is not supported. Available versions: %s", inputVersion, strings.Join(availableVersions.SKSClusterVersions, ", "))
+	}
+
+	return "", fmt.Errorf("error resolving the provided SKS cluster version: %s. Available versions: %s", inputVersion, strings.Join(availableVersions.SKSClusterVersions, ", "))
 }

--- a/exoscale/resource_exoscale_sks_cluster_test.go
+++ b/exoscale/resource_exoscale_sks_cluster_test.go
@@ -1,10 +1,15 @@
 package exoscale
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -15,6 +20,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	egoscale "github.com/exoscale/egoscale/v3"
+	"github.com/exoscale/egoscale/v3/credentials"
 	"github.com/exoscale/terraform-provider-exoscale/pkg/utils"
 )
 
@@ -52,6 +58,9 @@ var (
 	// For re-enable audit test with new URL
 	testAccResourceSKSClusterAuditRemoteURLUpdated   = "https://audit-updated.example.exoscale.net"
 	testAccResourceSKSClusterAuditBearerTokenUpdated = "newsupersecretbearertoken"
+
+	// Fake cluster versions to mock
+	fakeClusterVersions = []string{"1.36.1", "1.35.2", "1.34.5"}
 
 	testAccResourceSKSClusterConfigCreate = fmt.Sprintf(`
 locals {
@@ -1130,6 +1139,93 @@ func TestRemoveAddonFromSet(t *testing.T) {
 
 			// Verify removed addon is not present
 			assert.False(t, resultMap[tt.shouldNotContain], "addon %s should not be in result", tt.shouldNotContain)
+		})
+	}
+}
+
+// Unit test resolve SKS Cluster versions
+
+type fakeSKSVersionsTransport struct {
+	versions []string
+}
+
+func (t *fakeSKSVersionsTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	body, err := json.Marshal(map[string]any{
+		"sks-cluster-versions": fakeClusterVersions,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(bytes.NewReader(body)),
+		Header:     make(http.Header),
+	}, nil
+}
+
+func TestResolveSKSClusterVersions(t *testing.T) {
+	t.Parallel()
+
+	fakeHttpClient := &http.Client{
+		Transport: &fakeSKSVersionsTransport{fakeClusterVersions},
+	}
+
+	client, err := egoscale.NewClient(
+		credentials.NewStaticCredentials("foo", "bar"),
+		egoscale.ClientOptWithEndpoint(egoscale.CHGva2),
+		egoscale.ClientOptWithHTTPClient(fakeHttpClient),
+	)
+	if err != nil {
+		t.Fatalf("failed to create egoscale dummy client: %v", err)
+	}
+
+	ctx := context.Background()
+
+	tests := []struct {
+		name            string
+		inputVersion    string
+		expectedVersion string
+		errorMsg        string
+	}{
+		{
+			name:            "major.minor resolves to corresponding major.minor.patch",
+			inputVersion:    strings.Join(strings.Split(fakeClusterVersions[1], ".")[:2], "."),
+			expectedVersion: fakeClusterVersions[1],
+			errorMsg:        "",
+		},
+		{
+			name:            "empty version resolves to latest version",
+			inputVersion:    "",
+			expectedVersion: fakeClusterVersions[0],
+			errorMsg:        "",
+		},
+		{
+			name:            "",
+			inputVersion:    fakeClusterVersions[1],
+			expectedVersion: fakeClusterVersions[1],
+			errorMsg:        "",
+		},
+		{
+			name:            "unsupported major.minor throws error",
+			inputVersion:    "1.2", // unsupported
+			expectedVersion: "",
+			errorMsg:        "the SKS cluster version 1.2 is not supported",
+		},
+		{
+			name:            "version fits no format",
+			inputVersion:    "foo", // bad format
+			expectedVersion: "",
+			errorMsg:        "error resolving the provided SKS cluster version: foo",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := resolveSKSClusterVersion(ctx, client, tt.inputVersion)
+			assert.Equal(t, tt.expectedVersion, result)
+			if tt.errorMsg != "" {
+				assert.ErrorContains(t, err, tt.errorMsg)
+			}
 		})
 	}
 }


### PR DESCRIPTION
# Description

Patch `major.minor` versions into `major.minor.patch` on apply

If no version is provided, use the latest available.

Saves to the state the minor or full patch version depending on the input.

This means that if specifying only major.minor and a new patch release is available, the user won't get it automatically.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Acceptance tests OK
* [x] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing

Unit testing the resolved full version that goes to the exoscale API