### PR TITLE
fix: prevent context deadline during crossplane observe

### DIFF
--- a/pkg/resources/database/resource_db_mysql.go
+++ b/pkg/resources/database/resource_db_mysql.go
@@ -174,17 +174,10 @@ func (p *MysqlDatabaseResource) Update(ctx context.Context, req resource.UpdateR
 
 // ReadResource reads resource from remote and populate the model accordingly
 func (data MysqlDatabaseResourceModel) ReadResource(ctx context.Context, client *v3.Client, diagnostics *diag.Diagnostics) (clearState bool) {
-	if _, err := waitForDBAASServiceReadyForFn(ctx, client.GetDBAASServiceMysql, data.Service.ValueString(), func(t *v3.DBAASServiceMysql) bool {
-		if t.State != v3.EnumServiceStateRunning {
-			return false
-		}
-		for _, db := range t.Databases {
-			if string(db) == data.DatabaseName.ValueString() {
-				return true
-			}
-		}
-		return false
-	}); err != nil {
+	svc, err := waitForDBAASServiceReadyForFn(ctx, client.GetDBAASServiceMysql, data.Service.ValueString(), func(t *v3.DBAASServiceMysql) bool {
+		return t.State == v3.EnumServiceStateRunning
+	})
+	if err != nil {
 		if errors.Is(err, v3.ErrNotFound) {
 			return true
 		}
@@ -192,7 +185,13 @@ func (data MysqlDatabaseResourceModel) ReadResource(ctx context.Context, client 
 		return false
 	}
 
-	return false
+	for _, db := range svc.Databases {
+		if string(db) == data.DatabaseName.ValueString() {
+			return false
+		}
+	}
+
+	return true
 }
 
 // CreateResource creates the resource according to the model, and then

--- a/pkg/resources/database/resource_user_mysql.go
+++ b/pkg/resources/database/resource_user_mysql.go
@@ -228,15 +228,7 @@ func (data *MysqlUserResourceModel) DeleteResource(ctx context.Context, client *
 func (data *MysqlUserResourceModel) ReadResource(ctx context.Context, client *exoscale.Client, diagnostics *diag.Diagnostics) (clearState bool) {
 
 	svc, err := waitForDBAASServiceReadyForFn(ctx, client.GetDBAASServiceMysql, data.Service.ValueString(), func(t *exoscale.DBAASServiceMysql) bool {
-		if t.State != exoscale.EnumServiceStateRunning {
-			return false
-		}
-		for _, user := range t.Users {
-			if user.Username == data.Username.ValueString() {
-				return true
-			}
-		}
-		return false
+		return t.State == exoscale.EnumServiceStateRunning && len(t.Users) > 0
 	})
 	if err != nil {
 		if errors.Is(err, exoscale.ErrNotFound) {


### PR DESCRIPTION
# Description
During crossplane provider observe stage, the context hit the deadline and returns an error. This fix is inspire by the postgresql resource behavior

## Checklist
(For exoscale contributors)

* [ ] Changelog updated (under *Unreleased* block)
* [X] Acceptance tests OK
* [ ] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing

```
$ TF_ACC=1 go test -timeout=90m -tags=testacc -parallel 20 ./pkg/resources/database/... -v
--- PASS: TestDatabase (0.00s)
    --- SKIP: TestDatabase/ResourceDBAASExternalIntegration (0.00s)
    --- PASS: TestDatabase/ResourceDBAASExternalEndpointDatadog (3.46s)
    --- PASS: TestDatabase/ResourceDBAASExternalEndpointRsyslog (4.16s)
    --- PASS: TestDatabase/ResourceDBAASExternalEndpointPrometheus (4.48s)
    --- PASS: TestDatabase/ResourceDBAASExternalEndpointOpensearch (5.01s)
    --- PASS: TestDatabase/ResourceDBAASExternalEndpointElasticsearch (5.49s)
    --- PASS: TestDatabase/ResourceValkey (8.98s)
    --- PASS: TestDatabase/ResourceGrafana (133.87s)
    --- PASS: TestDatabase/ResourceValkeyUser (175.29s)
    --- PASS: TestDatabase/ResourceOpensearch (266.61s)
    --- PASS: TestDatabase/ResourceKafka (299.27s)
    --- PASS: TestDatabase/ResourceMysql (309.79s)
    --- PASS: TestDatabase/ResourcePg (464.15s)
        --- PASS: TestDatabase/ResourcePg/create/shared_buffers_percentage (0.00s)
        --- PASS: TestDatabase/ResourcePg/create/work_mem (0.00s)
        --- PASS: TestDatabase/ResourcePg/create/variant (0.00s)
        --- PASS: TestDatabase/ResourcePg/update/shared_buffers_percentage (0.00s)
        --- PASS: TestDatabase/ResourcePg/update/work_mem (0.00s)
        --- PASS: TestDatabase/ResourcePg/update/variant (0.00s)
    --- PASS: TestDatabase/DataSourceURI (892.28s)
PASS
ok  	github.com/exoscale/terraform-provider-exoscale/pkg/resources/database	892.288s
```
