### PR TITLE
provider: honour EXOSCALE_API_ENDPOINT for v2 clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ FEATURES:
 BUG FIXES:
 
 - `compute_instance`: `ipv6` attribute is not ignored on instance update
-- provider: honour `EXOSCALE_API_ENDPOINT` for v2-backed resources and data sources
+- provider: honour `EXOSCALE_API_ENDPOINT` for v2-backed resources and data sources #576
 
 BREAKING CHANGES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ FEATURES:
 BUG FIXES:
 
 - `compute_instance`: `ipv6` attribute is not ignored on instance update
+- provider: honour `EXOSCALE_API_ENDPOINT` for v2-backed resources and data sources
 
 BREAKING CHANGES:
 

--- a/exoscale/client.go
+++ b/exoscale/client.go
@@ -61,9 +61,7 @@ func getClient(meta any) *exov2.Client {
 	// V2 client independently from the V1 client because of HTTP middleware
 	// (http.Transport) clashes.
 	// This can be removed once the only API used is V2.
-	clientExoV2, err := exov2.NewClient(
-		config.Key,
-		config.Secret,
+	opts := []exov2.ClientOpt{
 		exov2.ClientOptWithTimeout(config.Timeout),
 		exov2.ClientOptWithHTTPClient(func() *http.Client {
 			rc := retryablehttp.NewClient()
@@ -74,7 +72,10 @@ func getClient(meta any) *exov2.Client {
 			}
 			return hc
 		}()),
-	)
+	}
+	opts = append(opts, v2EndpointOpts()...)
+
+	clientExoV2, err := exov2.NewClient(config.Key, config.Secret, opts...)
 	if err != nil {
 		panic(fmt.Sprintf("unable to initialize Exoscale API V2 client: %v", err))
 	}

--- a/exoscale/client_test.go
+++ b/exoscale/client_test.go
@@ -1,9 +1,89 @@
 package exoscale
 
 import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
 	"testing"
+	"time"
+
+	exov2 "github.com/exoscale/egoscale/v2"
+
+	providerConfig "github.com/exoscale/terraform-provider-exoscale/pkg/provider/config"
 )
 
-func Test_getClient(t *testing.T) {
+const testV2APIEndpoint = "https://gateway.internal:8443/v2"
 
+type recordingTransport struct {
+	request *http.Request
+}
+
+func (t *recordingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	t.request = req
+
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader("{}")),
+	}, nil
+}
+
+func recordV2Request(t *testing.T, client *exov2.Client) *http.Request {
+	t.Helper()
+
+	transport := new(recordingTransport)
+	client.SetHTTPClient(&http.Client{Transport: transport})
+
+	if _, err := client.ListSSHKeys(context.Background(), "ch-gva-2"); err != nil {
+		t.Fatal(err)
+	}
+	if transport.request == nil {
+		t.Fatal("v2 client sent no request")
+	}
+
+	return transport.request
+}
+
+func TestV2ClientConstructorsHonourAPIEndpoint(t *testing.T) {
+	t.Setenv("EXOSCALE_API_ENDPOINT", testV2APIEndpoint)
+
+	config := providerConfig.BaseConfig{
+		Key:     "EXOxxxxxxxxxxxxxxxxxxxxxxxx",
+		Secret:  "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+		Timeout: time.Second,
+	}
+
+	for _, tt := range []struct {
+		name      string
+		newClient func() (*exov2.Client, error)
+	}{
+		{
+			name: "CreateClient",
+			newClient: func() (*exov2.Client, error) {
+				return CreateClient(&config)
+			},
+		},
+		{
+			name: "getClient",
+			newClient: func() (*exov2.Client, error) {
+				return getClient(map[string]any{"config": config}), nil
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			client, err := tt.newClient()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			req := recordV2Request(t, client)
+			if got, want := req.URL.String(), testV2APIEndpoint+"/ssh-key"; got != want {
+				t.Errorf("request URL = %q, want %q", got, want)
+			}
+			if got, want := req.Host, "gateway.internal:8443"; got != want {
+				t.Errorf("request host = %q, want %q", got, want)
+			}
+		})
+	}
 }

--- a/exoscale/provider.go
+++ b/exoscale/provider.go
@@ -116,9 +116,7 @@ func ConvertTimeout(timeout float64) time.Duration {
 }
 
 func CreateClient(baseConfig *providerConfig.BaseConfig) (*exov2.Client, error) {
-	return exov2.NewClient(
-		baseConfig.Key,
-		baseConfig.Secret,
+	opts := []exov2.ClientOpt{
 		exov2.ClientOptWithTimeout(baseConfig.Timeout),
 		exov2.ClientOptWithHTTPClient(func() *http.Client {
 			rc := retryablehttp.NewClient()
@@ -128,7 +126,29 @@ func CreateClient(baseConfig *providerConfig.BaseConfig) (*exov2.Client, error) 
 				hc.Transport = logging.NewSubsystemLoggingHTTPTransport("exoscale", hc.Transport)
 			}
 			return hc
-		}()))
+		}()),
+	}
+	opts = append(opts, v2EndpointOpts()...)
+
+	return exov2.NewClient(baseConfig.Key, baseConfig.Secret, opts...)
+}
+
+// v2EndpointOpts mirrors, for the egoscale v2 client, what both providers
+// already do for the v3 one: honour EXOSCALE_API_ENDPOINT. Without it a single
+// apply splits across two API hosts, since the v2 client falls back to
+// https://{environment}-{zone}.exoscale.com whatever the endpoint says.
+//
+// Note that egoscale's own per-request interceptor (setEndpointFromContext)
+// still rewrites the host from the zone context unless the configured host is
+// an IP literal, so a hostname endpoint needs the matching egoscale change to
+// be honoured end to end.
+func v2EndpointOpts() []exov2.ClientOpt {
+	ep := os.Getenv("EXOSCALE_API_ENDPOINT")
+	if ep == "" {
+		return nil
+	}
+
+	return []exov2.ClientOpt{exov2.ClientOptWithAPIEndpoint(ep)}
 }
 
 func ProviderConfigure(_ context.Context, d *schema.ResourceData) (any, diag.Diagnostics) {

--- a/exoscale/provider.go
+++ b/exoscale/provider.go
@@ -137,11 +137,6 @@ func CreateClient(baseConfig *providerConfig.BaseConfig) (*exov2.Client, error) 
 // already do for the v3 one: honour EXOSCALE_API_ENDPOINT. Without it a single
 // apply splits across two API hosts, since the v2 client falls back to
 // https://{environment}-{zone}.exoscale.com whatever the endpoint says.
-//
-// Note that egoscale's own per-request interceptor (setEndpointFromContext)
-// still rewrites the host from the zone context unless the configured host is
-// an IP literal, so a hostname endpoint needs the matching egoscale change to
-// be honoured end to end.
 func v2EndpointOpts() []exov2.ClientOpt {
 	ep := os.Getenv("EXOSCALE_API_ENDPOINT")
 	if ep == "" {

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.28.1
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.42
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.97.3
-	github.com/exoscale/egoscale v0.102.5-0.20260827090256-d3604f2613d3
+	github.com/exoscale/egoscale v0.102.5
 	github.com/exoscale/egoscale/v3 v3.1.42
 	github.com/google/go-cmp v0.7.0
 	github.com/hashicorp/go-cleanhttp v0.5.2

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.28.1
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.42
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.97.3
-	github.com/exoscale/egoscale v0.102.4
+	github.com/exoscale/egoscale v0.102.5-0.20260827090256-d3604f2613d3
 	github.com/exoscale/egoscale/v3 v3.1.42
 	github.com/google/go-cmp v0.7.0
 	github.com/hashicorp/go-cleanhttp v0.5.2

--- a/go.sum
+++ b/go.sum
@@ -105,8 +105,8 @@ github.com/deepmap/oapi-codegen v1.16.3 h1:GT9G86SbQtT1r8ZB+4Cybi9VGdu1P5ieNvNdE
 github.com/deepmap/oapi-codegen v1.16.3/go.mod h1:JD6ErqeX0nYnhdciLc61Konj3NBASREMlkHOgHn8WAM=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
-github.com/exoscale/egoscale v0.102.4 h1:GBKsZMIOzwBfSu+4ZmWka3Ejf2JLiaBDHp4CQUgvp2E=
-github.com/exoscale/egoscale v0.102.4/go.mod h1:ROSmPtle0wvf91iLZb09++N/9BH2Jo9XxIpAEumvocA=
+github.com/exoscale/egoscale v0.102.5-0.20260827090256-d3604f2613d3 h1:LMNGRcDU1c11M0YaFxuo6sIIsUiIujv6UKEN7QPqJ9M=
+github.com/exoscale/egoscale v0.102.5-0.20260827090256-d3604f2613d3/go.mod h1:dQew6hG9qVTtMm01z0+K1Y7vl9EKQkxOI2B/ps3qVSI=
 github.com/exoscale/egoscale/v3 v3.1.42 h1:KlFDdm2ga1RdCdKuKlzJxLmgJjWVcDbJxF0t6FDswzw=
 github.com/exoscale/egoscale/v3 v3.1.42/go.mod h1:DUTgeubl5msPAo3SKFed04AxNhyTNOrCTJHZDRYLR10=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=

--- a/go.sum
+++ b/go.sum
@@ -105,8 +105,8 @@ github.com/deepmap/oapi-codegen v1.16.3 h1:GT9G86SbQtT1r8ZB+4Cybi9VGdu1P5ieNvNdE
 github.com/deepmap/oapi-codegen v1.16.3/go.mod h1:JD6ErqeX0nYnhdciLc61Konj3NBASREMlkHOgHn8WAM=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
-github.com/exoscale/egoscale v0.102.5-0.20260827090256-d3604f2613d3 h1:LMNGRcDU1c11M0YaFxuo6sIIsUiIujv6UKEN7QPqJ9M=
-github.com/exoscale/egoscale v0.102.5-0.20260827090256-d3604f2613d3/go.mod h1:dQew6hG9qVTtMm01z0+K1Y7vl9EKQkxOI2B/ps3qVSI=
+github.com/exoscale/egoscale v0.102.5 h1:YH5xMi9bjETkO0NQ4dwnQmWsWvfIgrPZQ87jraiw3L0=
+github.com/exoscale/egoscale v0.102.5/go.mod h1:dQew6hG9qVTtMm01z0+K1Y7vl9EKQkxOI2B/ps3qVSI=
 github.com/exoscale/egoscale/v3 v3.1.42 h1:KlFDdm2ga1RdCdKuKlzJxLmgJjWVcDbJxF0t6FDswzw=
 github.com/exoscale/egoscale/v3 v3.1.42/go.mod h1:DUTgeubl5msPAo3SKFed04AxNhyTNOrCTJHZDRYLR10=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -161,9 +161,7 @@ func (p *ExoscaleProvider) Configure(ctx context.Context, req provider.Configure
 		SOSEndpoint: sosEndpoint,
 	}
 
-	clv2, err := exov2.NewClient(
-		baseConfig.Key,
-		baseConfig.Secret,
+	v2opts := []exov2.ClientOpt{
 		exov2.ClientOptWithTimeout(baseConfig.Timeout),
 		exov2.ClientOptWithHTTPClient(func() *http.Client {
 			rc := retryablehttp.NewClient()
@@ -173,7 +171,15 @@ func (p *ExoscaleProvider) Configure(ctx context.Context, req provider.Configure
 				hc.Transport = logging.NewSubsystemLoggingHTTPTransport("exoscale", hc.Transport)
 			}
 			return hc
-		}()))
+		}()),
+	}
+	// Honour EXOSCALE_API_ENDPOINT for the v2 client too, as the v3 one below
+	// already does. Without this a single apply splits across two API hosts.
+	if ep := os.Getenv("EXOSCALE_API_ENDPOINT"); ep != "" {
+		v2opts = append(v2opts, exov2.ClientOptWithAPIEndpoint(ep))
+	}
+
+	clv2, err := exov2.NewClient(baseConfig.Key, baseConfig.Secret, v2opts...)
 	if err != nil {
 		resp.Diagnostics.AddError(err.Error(), "")
 

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -1,0 +1,92 @@
+package provider
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	exov2 "github.com/exoscale/egoscale/v2"
+	frameworkprovider "github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+
+	providerConfig "github.com/exoscale/terraform-provider-exoscale/pkg/provider/config"
+)
+
+const testV2APIEndpoint = "https://gateway.internal:8443/v2"
+
+type recordingTransport struct {
+	request *http.Request
+}
+
+func (t *recordingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	t.request = req
+
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader("{}")),
+	}, nil
+}
+
+func recordV2Request(t *testing.T, client *exov2.Client) *http.Request {
+	t.Helper()
+
+	transport := new(recordingTransport)
+	client.SetHTTPClient(&http.Client{Transport: transport})
+
+	if _, err := client.ListSSHKeys(context.Background(), "ch-gva-2"); err != nil {
+		t.Fatal(err)
+	}
+	if transport.request == nil {
+		t.Fatal("v2 client sent no request")
+	}
+
+	return transport.request
+}
+
+func TestExoscaleProviderConfigureHonoursV2APIEndpoint(t *testing.T) {
+	t.Setenv("EXOSCALE_API_ENDPOINT", testV2APIEndpoint)
+
+	ctx := context.Background()
+	p := new(ExoscaleProvider)
+	schemaResp := new(frameworkprovider.SchemaResponse)
+	p.Schema(ctx, frameworkprovider.SchemaRequest{}, schemaResp)
+	if schemaResp.Diagnostics.HasError() {
+		t.Fatalf("provider schema diagnostics: %s", schemaResp.Diagnostics)
+	}
+
+	config := tftypes.NewValue(
+		schemaResp.Schema.Type().TerraformType(ctx),
+		map[string]tftypes.Value{
+			KeyAttrName:         tftypes.NewValue(tftypes.String, "EXOxxxxxxxxxxxxxxxxxxxxxxxx"),
+			SecretAttrName:      tftypes.NewValue(tftypes.String, "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"),
+			EnvironmentAttrName: tftypes.NewValue(tftypes.String, nil),
+			SOSEndpointAttrName: tftypes.NewValue(tftypes.String, nil),
+			TimeoutAttrName:     tftypes.NewValue(tftypes.Number, 1),
+		},
+	)
+
+	configureResp := new(frameworkprovider.ConfigureResponse)
+	p.Configure(ctx, frameworkprovider.ConfigureRequest{
+		Config: tfsdk.Config{Raw: config, Schema: schemaResp.Schema},
+	}, configureResp)
+	if configureResp.Diagnostics.HasError() {
+		t.Fatalf("provider configure diagnostics: %s", configureResp.Diagnostics)
+	}
+
+	providerData, ok := configureResp.ResourceData.(*providerConfig.ExoscaleProviderConfig)
+	if !ok {
+		t.Fatalf("provider data type = %T, want *config.ExoscaleProviderConfig", configureResp.ResourceData)
+	}
+
+	req := recordV2Request(t, providerData.ClientV2)
+	if got, want := req.URL.String(), testV2APIEndpoint+"/ssh-key"; got != want {
+		t.Errorf("request URL = %q, want %q", got, want)
+	}
+	if got, want := req.Host, "gateway.internal:8443"; got != want {
+		t.Errorf("request host = %q, want %q", got, want)
+	}
+}

--- a/vendor/github.com/exoscale/egoscale/v2/client.go
+++ b/vendor/github.com/exoscale/egoscale/v2/client.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"net"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -254,21 +253,22 @@ func setUserAgent(ctx context.Context, req *http.Request) error {
 	return nil
 }
 
-// setEndpointFromContext is an HTTP client request interceptor that overrides the "Host" header
-// with information from a request endpoint optionally set in the context instance. If none is
-// found or host is an IP address, the request is left untouched.
+// setEndpointFromContext is an HTTP client request interceptor that overrides a generic API
+// endpoint with information from a request endpoint optionally set in the context instance.
+// Custom API endpoints are left untouched.
 func setEndpointFromContext(ctx context.Context, req *http.Request) error {
-	h, _, err := net.SplitHostPort(req.Host)
-	if err != nil {
-		h = req.Host
+	v, ok := ctx.Value(api.ReqEndpoint{}).(api.ReqEndpoint)
+	if !ok {
+		return nil
 	}
-	if net.ParseIP(h) == nil {
-		v, ok := ctx.Value(api.ReqEndpoint{}).(api.ReqEndpoint)
-		if ok {
-			req.Host = v.Host()
-			req.URL.Host = v.Host()
-		}
+
+	origin := req.URL.Scheme + "://" + req.URL.Host + "/"
+	if origin != api.EndpointURL && origin != "https://"+v.Env()+".exoscale.com/" {
+		return nil
 	}
+
+	req.Host = v.Host()
+	req.URL.Host = v.Host()
 
 	return nil
 }

--- a/vendor/github.com/exoscale/egoscale/v2/oapi/oapi.gen.go
+++ b/vendor/github.com/exoscale/egoscale/v2/oapi/oapi.gen.go
@@ -685,6 +685,8 @@ const (
 	ZoneNameDeFra1 ZoneName = "de-fra-1"
 
 	ZoneNameDeMuc1 ZoneName = "de-muc-1"
+
+	ZoneNameHrZag1 ZoneName = "hr-zag-1"
 )
 
 // IAM Access Key

--- a/vendor/github.com/exoscale/egoscale/v2/v2.go
+++ b/vendor/github.com/exoscale/egoscale/v2/v2.go
@@ -1,5 +1,5 @@
 // Package v2 is the new Exoscale client API binding.
-// Reference: https://openapi-v2.exoscale.com/
+// Reference: https://community.exoscale.com/reference/api/
 package v2
 
 import (

--- a/vendor/github.com/exoscale/egoscale/version/version.go
+++ b/vendor/github.com/exoscale/egoscale/version/version.go
@@ -2,4 +2,4 @@
 package version
 
 // Version represents the current egoscale version.
-const Version = "0.102.3"
+const Version = "0.102.5"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -265,8 +265,8 @@ github.com/davecgh/go-spew/spew
 ## explicit; go 1.20
 github.com/deepmap/oapi-codegen/pkg/runtime
 github.com/deepmap/oapi-codegen/pkg/types
-# github.com/exoscale/egoscale v0.102.4
-## explicit; go 1.22
+# github.com/exoscale/egoscale v0.102.5-0.20260827090256-d3604f2613d3
+## explicit; go 1.26
 github.com/exoscale/egoscale/v2
 github.com/exoscale/egoscale/v2/api
 github.com/exoscale/egoscale/v2/oapi

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -265,7 +265,7 @@ github.com/davecgh/go-spew/spew
 ## explicit; go 1.20
 github.com/deepmap/oapi-codegen/pkg/runtime
 github.com/deepmap/oapi-codegen/pkg/types
-# github.com/exoscale/egoscale v0.102.5-0.20260827090256-d3604f2613d3
+# github.com/exoscale/egoscale v0.102.5
 ## explicit; go 1.26
 github.com/exoscale/egoscale/v2
 github.com/exoscale/egoscale/v2/api


### PR DESCRIPTION
# Description

Forward `EXOSCALE_API_ENDPOINT` to every v2 client constructor so one apply cannot split requests between the custom endpoint and public API. Uses [egoscale v0.102.5](https://github.com/exoscale/egoscale/releases/tag/v0.102.5), which contains [egoscale#806](https://github.com/exoscale/egoscale/pull/806), and fixes #573.

Thanks to [@stephrobert](https://github.com/stephrobert) for the detailed report, initial patch, and Feint-based reproduction.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [ ] Acceptance tests OK
* [ ] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing

Unit tests, a focused `TF_ACC=1` test, and Feint-backed Terraform lifecycles pass locally. The final `v0.102.5` dependency also passes local lint, vet, build, unit, documentation, and vulnerability checks. The [full acceptance run](https://github.com/exoscale/terraform-provider-exoscale/actions/runs/33088896111) remains red only on two Elastic IP failures also present on [master](https://github.com/exoscale/terraform-provider-exoscale/actions/runs/32711000158).

<details>
<summary>Local unit and Feint acceptance evidence</summary>

No real credentials were used. The Terraform runs used `http://localhost:4733/v2`. `localhost` is deliberate because the egoscale bug only preserved IP literals. A closed proxy made any request escaping to `*.exoscale.com` fail immediately.

The HTTP status codes in these traces come from the existing API contract, not this PR. We can align them with more conventional HTTP semantics separately.

### Revisions

```text
egoscale                         v0.102.5 (6f883354bb8c8e9c929aedf5c638913f120c07c6)
terraform-provider-exoscale     d5e58f99a898056e33f54dc9e3e4e0b3895dd158 (#576 head)
feint                            b9eea2d5c6435b117f074fac262c4f3d2507454b
Go                               1.26.5
Terraform                        1.14.8
```

### Unit tests

```console
$ make test
ok  github.com/exoscale/terraform-provider-exoscale/exoscale                         1.195s
ok  github.com/exoscale/terraform-provider-exoscale/pkg/filter                      1.062s
ok  github.com/exoscale/terraform-provider-exoscale/pkg/list                        1.199s
ok  github.com/exoscale/terraform-provider-exoscale/pkg/provider                    1.121s
ok  github.com/exoscale/terraform-provider-exoscale/pkg/resources/anti_affinity_group 1.202s
ok  github.com/exoscale/terraform-provider-exoscale/pkg/resources/block_storage     1.192s
ok  github.com/exoscale/terraform-provider-exoscale/pkg/resources/database          1.216s
ok  github.com/exoscale/terraform-provider-exoscale/pkg/resources/domain            1.416s
ok  github.com/exoscale/terraform-provider-exoscale/pkg/resources/iam               1.428s
ok  github.com/exoscale/terraform-provider-exoscale/pkg/resources/instance          1.298s
ok  github.com/exoscale/terraform-provider-exoscale/pkg/resources/instance_pool     1.291s
ok  github.com/exoscale/terraform-provider-exoscale/pkg/resources/kms               1.501s
ok  github.com/exoscale/terraform-provider-exoscale/pkg/resources/nlb_service       1.516s
ok  github.com/exoscale/terraform-provider-exoscale/pkg/resources/private_network   1.467s
ok  github.com/exoscale/terraform-provider-exoscale/pkg/resources/security_group    1.109s
ok  github.com/exoscale/terraform-provider-exoscale/pkg/resources/sos_bucket_policy 1.090s
ok  github.com/exoscale/terraform-provider-exoscale/pkg/utils                       1.077s
```

### Local build

```bash
git clone https://github.com/exoscale/terraform-provider-exoscale.git
git -C terraform-provider-exoscale checkout d5e58f99a898056e33f54dc9e3e4e0b3895dd158

git clone https://github.com/stephrobert/feint.git
git -C feint checkout b9eea2d5c6435b117f074fac262c4f3d2507454b

mkdir -p tfp e2e/minimal e2e/full
GOWORK=off go -C terraform-provider-exoscale build \
  -o "$PWD/tfp/terraform-provider-exoscale" .
GOWORK=off go -C feint build -o "$PWD/feint-bin" ./cmd/feint
```

The resulting provider contains the released egoscale module:

```text
dep github.com/exoscale/egoscale v0.102.5
build vcs.revision=d5e58f99a898056e33f54dc9e3e4e0b3895dd158
build vcs.modified=false
```

Terraform used that binary through a development override:

```bash
cat > dev.tfrc <<EOF
provider_installation {
  dev_overrides {
    "exoscale/exoscale" = "$PWD/tfp"
  }
  direct {}
}
EOF
```

### Focused acceptance test

The test's out-of-band destroy checker constructs an egoscale client without the provider endpoint. Feint's mapped forward proxy kept those checker calls local too. Its CA was temporary and removed when the proxy exited. The proxy and test commands run in separate shells.

```bash
FEINT_EXOSCALE_ALLOW_TERRAFORM=1 ./feint-bin start \
  --addr 127.0.0.1:4733 --vm off --contracts "$PWD/feint/contracts"

mkdir -p proxy-tmp
TMPDIR="$PWD/proxy-tmp" ./feint-bin proxy \
  --addr 127.0.0.1:4734 --record acceptance.jsonl \
  --forward 'api-ch-gva-2.exoscale.com=http://127.0.0.1:4733'

proxy_ca=("$PWD"/proxy-tmp/feint-intercept-ca-*.pem)
export FEINT_PROXY_CA="${proxy_ca[0]}"
TF_ACC=1 \
EXOSCALE_API_ENDPOINT=http://localhost:4733/v2 \
EXOSCALE_API_KEY=EXOfake EXOSCALE_API_SECRET=fake \
HTTPS_PROXY=http://127.0.0.1:4734 SSL_CERT_FILE="$FEINT_PROXY_CA" \
HTTP_PROXY=http://127.0.0.1:9 ALL_PROXY=http://127.0.0.1:9 \
NO_PROXY=localhost,127.0.0.1 \
GOWORK=off go -C terraform-provider-exoscale test \
  -timeout=10m -tags=testacc -parallel=1 -count=1 \
  -run '^TestAccResourceSSHKey$' -v ./exoscale
```

`FEINT_PROXY_CA` above is the temporary path printed by `feint proxy`.

```text
=== RUN   TestAccResourceSSHKey
--- PASS: TestAccResourceSSHKey (3.87s)
PASS
ok  github.com/exoscale/terraform-provider-exoscale/exoscale  3.894s
```

Feint observed the complete create/read/delete lifecycle locally:

```text
POST   /v2/ssh-key                                      200
GET    /v2/ssh-key/test-terraform-exoscale-...          200
DELETE /v2/ssh-key/test-terraform-exoscale-...          200
GET    /v2/operation/...                                200
GET    /v2/ssh-key/test-terraform-exoscale-...          404
```

### Mixed v2/v3 Terraform acceptance

The focused configuration creates a v3-backed security group and a v2-backed SSH key in one apply:

```hcl
terraform {
  required_providers {
    exoscale = {
      source = "exoscale/exoscale"
    }
  }
}

provider "exoscale" {
  key    = "EXOfake"
  secret = "fake"
}

resource "exoscale_security_group" "v3_side" {
  name = "endpoint-e2e"
}

resource "exoscale_ssh_key" "v2_side" {
  name       = "endpoint-e2e"
  public_key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPZaMYEkbZavx3g1cAZs4pQNXbGXAq53TSBW1DZ84dch probe"
}
```

```bash
export TF_CLI_CONFIG_FILE="$PWD/dev.tfrc"
terraform -chdir=e2e/minimal init -backend=false -no-color

export EXOSCALE_API_ENDPOINT=http://localhost:4733/v2
export EXOSCALE_API_KEY=EXOfake EXOSCALE_API_SECRET=fake
export HTTPS_PROXY=http://127.0.0.1:9
export HTTP_PROXY=$HTTPS_PROXY ALL_PROXY=$HTTPS_PROXY
export NO_PROXY=localhost,127.0.0.1

terraform -chdir=e2e/minimal apply -auto-approve -no-color
terraform -chdir=e2e/minimal plan -detailed-exitcode -no-color
terraform -chdir=e2e/minimal destroy -auto-approve -no-color
```

```text
Plan: 2 to add, 0 to change, 0 to destroy.
exoscale_security_group.v3_side: Creation complete after 0s [id=...]
exoscale_ssh_key.v2_side: Creation complete after 0s [id=endpoint-e2e]
Apply complete! Resources: 2 added, 0 changed, 0 destroyed.

POST /v2/ssh-key       -> 200
POST /v2/security-group -> 200

No changes. Your infrastructure matches the configuration.
Destroy complete! Resources: 2 destroyed.
```

### Full Feint Exoscale stack

The same locally-built provider then ran Feint's complete Exoscale Terraform stack. Its 15 resources cover SSH keys, security groups and rules, private networks, anti-affinity groups, block storage and snapshots, Elastic IPs, instances, instance pools, and load balancers.

```bash
cp feint/examples/stacks/exoscale/main.tf e2e/full/main.tf
cp e2e/minimal/.terraform.lock.hcl e2e/full/.terraform.lock.hcl

terraform -chdir=e2e/full apply -auto-approve -no-color
# Persist two data-source-derived outputs. This changes no resources.
terraform -chdir=e2e/full apply -auto-approve -no-color
terraform -chdir=e2e/full plan -detailed-exitcode -no-color
terraform -chdir=e2e/full destroy -auto-approve -no-color
```

```text
Plan: 15 to add, 0 to change, 0 to destroy.
Apply complete! Resources: 15 added, 0 changed, 0 destroyed.
Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
No changes. Your infrastructure matches the configuration.
Destroy complete! Resources: 15 destroyed.
```

The detailed plan returned exit code 0.

Before destroy, Feint reported 34 Exoscale routes driven by the provider. The creation and attachment trace included:

```text
POST /v2/ssh-key                                      -> 200
POST /v2/security-group                               -> 200
POST /v2/private-network                              -> 200
POST /v2/block-storage                                -> 200
POST /v2/instance-pool                                -> 200
POST /v2/instance                                     -> 200
PUT  /v2/elastic-ip/...:attach                        -> 200
PUT  /v2/private-network/...:attach                   -> 200
PUT  /v2/block-storage/...:attach                     -> 200
POST /v2/load-balancer/.../service                    -> 200
```

Because outbound HTTP and HTTPS used the closed proxy at `127.0.0.1:9`, these successful lifecycles also confirm that neither client escaped to the public API.

```bash
./feint-bin stop --addr 127.0.0.1:4733
```

</details>
