### PR TITLE
docs: sync v0.70.1 changelog to master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,20 @@ BUG FIXES:
 
 - dbaas: prevent context deadline during Crossplane observe #571
 - `compute_instance`: `ipv6` attribute is not ignored on instance update #574
-- provider: honour `EXOSCALE_API_ENDPOINT` for v2-backed resources and data sources #576
 
 BREAKING CHANGES:
 
 - `domain`: remove the unused, already-deprecated `token`, `state`, `auto_renew` and `expires_on` attributes, check the [migration guide](docs/guides/migration-of-domain-from-v0_70_x-to-v0_71_x.md) #575
+
+## 0.70.1
+
+BUG FIXES:
+
+- provider: honour `EXOSCALE_API_ENDPOINT` for v2-backed resources and data sources #576
+
+DEPENDENCIES:
+
+- Update vulnerable `golang.org/x/*` and `google.golang.org/grpc` dependencies
 
 ## 0.70.0
 


### PR DESCRIPTION
# Description

Record v0.70.1 on master after #578 is merged and the release is published.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [ ] Acceptance tests OK
* [ ] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing

Go 1.27 formatting, lint, vet, unit tests, vendoring, documentation generation, and `govulncheck` pass locally.