### PR TITLE
test: skip failing EIP acceptance tests temporarily

### DIFF
--- a/exoscale/datasource_exoscale_elastic_ip_test.go
+++ b/exoscale/datasource_exoscale_elastic_ip_test.go
@@ -120,6 +120,7 @@ resource "exoscale_elastic_ip" "test6" {
 )
 
 func TestAccDataSourceElasticIP(t *testing.T) {
+	t.Skip("temporarily disabled due to IPv6 EIP label drift")
 	t.Parallel()
 
 	resource.Test(t, resource.TestCase{

--- a/exoscale/resource_exoscale_elastic_ip_test.go
+++ b/exoscale/resource_exoscale_elastic_ip_test.go
@@ -190,6 +190,7 @@ resource "exoscale_elastic_ip" "test6" {
 )
 
 func TestAccResourceElasticIP(t *testing.T) {
+	t.Skip("temporarily disabled due to IPv6 EIP label drift")
 	t.Parallel()
 
 	var (


### PR DESCRIPTION
Temporarily skip the two failing EIP acceptance tests while the IPv6 label drift is fixed.

Remove the two `t.Skip` lines to restore coverage.