### PR TITLE
feat(sc-196424): add SKS nodepool kubelet max-pods support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## UNRELEASED
+
+FEATURES:
+
+- `sks_nodepool`: add `kubelet_max_pods` attribute to set the maximum number of pods per node on the underlying instance pool (resource + data sources)
+
 ## 0.71.0
 
 IMPROVEMENTS:

--- a/docs/data-sources/sks_nodepool.md
+++ b/docs/data-sources/sks_nodepool.md
@@ -32,6 +32,7 @@ description: |-
 - `instance_type` (String) The managed compute instances type (`<family>.<size>`, e.g. `standard.medium`; use the [Exoscale CLI](https://github.com/exoscale/cli/) - `exo compute instance-type list` - for the list of available types).
 - `ipv6` (Boolean) Enable IPV6 for the nodepool nodes
 - `kubelet_image_gc` (Block Set) Configuration for this nodepool's kubelet image garbage collector (see [below for nested schema](#nestedblock--kubelet_image_gc))
+- `kubelet_max_pods` (Number) The maximum number of pods per node (default is 110).
 - `labels` (Map of String) A map of key/value labels.
 - `name` (String)
 - `nvidia_mig_profile` (String) The NVIDIA [Multi-Instance GPU (MIG)](https://docs.nvidia.com/datacenter/tesla/mig-user-guide/) profile to enable on the managed GPUs. The GPU family is inferred from `instance_type`: `gpua30.*` accepts `2g.12gb`, `1g.6gb+me`, `1g.6gb`, `2g.12gb+me`, `4g.24gb`; `gpurtx6000pro.*` accepts `1g.24gb-me`, `1g.24gb`, `2g.48gb-me`, `2g.48gb`, `4g.96gb+gfx`, `1g.24gb+me`, `2g.48gb+me.all`, `1g.24gb+gfx`, `1g.24gb+me.all`, `4g.96gb`, `2g.48gb+gfx`.

--- a/docs/data-sources/sks_nodepool_list.md
+++ b/docs/data-sources/sks_nodepool_list.md
@@ -31,6 +31,7 @@ description: |-
 - `instance_prefix` (String) Match against this string. If you supply a string that begins and ends with a "/" it will be matched as a regex.
 - `instance_type` (String) Match against this string. If you supply a string that begins and ends with a "/" it will be matched as a regex.
 - `ipv6` (Boolean) Match against this bool
+- `kubelet_max_pods` (Number) Match against this int
 - `labels` (Map of String) Match against key/values. Keys are matched exactly, while values may be matched as a regex if you supply a string that begins and ends with "/"
 - `name` (String) Match against this string. If you supply a string that begins and ends with a "/" it will be matched as a regex.
 - `nvidia_mig_profile` (String) Match against this string. If you supply a string that begins and ends with a "/" it will be matched as a regex.
@@ -62,6 +63,7 @@ Read-Only:
 - `instance_type` (String)
 - `ipv6` (Boolean)
 - `kubelet_image_gc` (Set of Object) (see [below for nested schema](#nestedobjatt--nodepools--kubelet_image_gc))
+- `kubelet_max_pods` (Number)
 - `labels` (Map of String)
 - `name` (String)
 - `nvidia_mig_profile` (String)

--- a/docs/resources/sks_nodepool.md
+++ b/docs/resources/sks_nodepool.md
@@ -50,6 +50,7 @@ directory for complete configuration examples.
 - `instance_prefix` (String) The string used to prefix the managed instances name (default `pool`).
 - `ipv6` (Boolean) Enable IPV6 for the nodepool nodes
 - `kubelet_image_gc` (Block Set) Configuration for this nodepool's kubelet image garbage collector (see [below for nested schema](#nestedblock--kubelet_image_gc))
+- `kubelet_max_pods` (Number) The maximum number of pods per node (default is 110).
 - `labels` (Map of String) A map of key/value labels.
 - `nvidia_mig_profile` (String) The NVIDIA [Multi-Instance GPU (MIG)](https://docs.nvidia.com/datacenter/tesla/mig-user-guide/) profile to enable on the managed GPUs. The GPU family is inferred from `instance_type`: `gpua30.*` accepts `2g.12gb`, `1g.6gb+me`, `1g.6gb`, `2g.12gb+me`, `4g.24gb`; `gpurtx6000pro.*` accepts `1g.24gb-me`, `1g.24gb`, `2g.48gb-me`, `2g.48gb`, `4g.96gb+gfx`, `1g.24gb+me`, `2g.48gb+me.all`, `1g.24gb+gfx`, `1g.24gb+me.all`, `4g.96gb`, `2g.48gb+gfx`.
 - `private_network_ids` (Set of String) A list of [exoscale_private_network](./private_network.md) (IDs) to be attached to the managed instances.

--- a/exoscale/datasource_exoscale_sks_nodepool.go
+++ b/exoscale/datasource_exoscale_sks_nodepool.go
@@ -72,6 +72,9 @@ func nodepoolToDataMap(nodepool *v3.SKSNodepool) general.TerraformObject {
 	if nodepool.DeployTarget != nil {
 		ret[resSKSNodepoolAttrDeployTargetID] = nodepool.DeployTarget.ID.String()
 	}
+	if nodepool.KubeletMaxPods != nil {
+		ret[resSKSNodepoolAttrKubeletMaxPods] = int(*nodepool.KubeletMaxPods)
+	}
 	if nodepool.InstancePool != nil {
 		ret[resSKSNodepoolAttrInstancePoolID] = nodepool.InstancePool.ID.String()
 	}

--- a/exoscale/resource_exoscale_sks_nodepool.go
+++ b/exoscale/resource_exoscale_sks_nodepool.go
@@ -36,6 +36,7 @@ const (
 	resSKSNodepoolAttrKubeletGCMinAge        = "min_age"
 	resSKSNodepoolAttrKubeletGCHighThreshold = "high_threshold"
 	resSKSNodepoolAttrKubeletGCLowThreshold  = "low_threshold"
+	resSKSNodepoolAttrKubeletMaxPods         = "kubelet_max_pods"
 	resSKSNodepoolAttrLabels                 = "labels"
 	resSKSNodepoolAttrID                     = "id"
 	resSKSNodepoolAttrName                   = "name"
@@ -134,6 +135,12 @@ func resourceSKSNodepool() *schema.Resource {
 					},
 				},
 			},
+		},
+		resSKSNodepoolAttrKubeletMaxPods: {
+			Type:        schema.TypeInt,
+			Optional:    true,
+			Computed:    true,
+			Description: "The maximum number of pods per node (default is 110).",
 		},
 		resSKSNodepoolAttrLabels: {
 			Type:        schema.TypeMap,
@@ -355,6 +362,11 @@ func resourceSKSNodepoolCreate(ctx context.Context, d *schema.ResourceData, meta
 		sksNodepoolCreate.KubeletImageGC = sksNodepoolKubeletGc
 	}
 
+	if v, ok := d.GetOk(resSKSNodepoolAttrKubeletMaxPods); ok {
+		i := int64(v.(int))
+		sksNodepoolCreate.KubeletMaxPods = &i
+	}
+
 	if l, ok := d.GetOk(resSKSNodepoolAttrLabels); ok {
 		labels := make(map[string]string)
 		for k, v := range l.(map[string]any) {
@@ -528,6 +540,7 @@ func resourceSKSNodepoolUpdate(ctx context.Context, d *schema.ResourceData, meta
 		DiskSize:           sksNp.DiskSize,
 		InstancePrefix:     sksNp.InstancePrefix,
 		InstanceType:       sksNp.InstanceType,
+		KubeletMaxPods:     sksNp.KubeletMaxPods,
 		Labels:             sksNp.Labels,
 		Name:               sksNp.Name,
 		NvidiaMigProfiles:  sksNp.NvidiaMigProfiles,
@@ -640,6 +653,13 @@ func resourceSKSNodepoolUpdate(ctx context.Context, d *schema.ResourceData, meta
 			sksNodepoolKubeletGc.HighThreshold = sksNodepoolKubeletGcHighThresholdInt64
 		}
 		sksNodepoolUpdate.KubeletImageGC = sksNodepoolKubeletGc
+		updated = true
+	}
+
+	if d.HasChange(resSKSNodepoolAttrKubeletMaxPods) {
+		v, _ := d.GetOk(resSKSNodepoolAttrKubeletMaxPods)
+		i := int64(v.(int))
+		sksNodepoolUpdate.KubeletMaxPods = &i
 		updated = true
 	}
 
@@ -825,6 +845,12 @@ func resourceSKSNodepoolApply(
 			return err
 		}
 
+	}
+
+	if sksNodepool.KubeletMaxPods != nil {
+		if err := d.Set(resSKSNodepoolAttrKubeletMaxPods, int(*sksNodepool.KubeletMaxPods)); err != nil {
+			return err
+		}
 	}
 
 	if err := d.Set(resSKSNodepoolAttrLabels, sksNodepool.Labels); err != nil {

--- a/exoscale/resource_exoscale_sks_nodepool_test.go
+++ b/exoscale/resource_exoscale_sks_nodepool_test.go
@@ -35,6 +35,7 @@ var (
 	testAccResourceSKSNodepoolKubeletImageGCMinAgeUpdated              = "5m"
 	testAccResourceSKSNodepoolKubeletImageGCHighThresholdUpdated int64 = 85
 	testAccResourceSKSNodepoolKubeletImageGCLowThresholdUpdated  int64 = 75
+	testAccResourceSKSNodepoolKubeletMaxPods                     int64 = 210
 	testAccResourceSKSNodepoolLabelValue                               = acctest.RandomWithPrefix(testPrefix)
 	testAccResourceSKSNodepoolLabelValueUpdated                        = testAccResourceSKSNodepoolLabelValue + "-updated"
 	testAccResourceSKSNodepoolName                                     = acctest.RandomWithPrefix(testPrefix)
@@ -85,6 +86,7 @@ resource "exoscale_sks_nodepool" "test" {
 	high_threshold = %d
 	low_threshold = %d
   }
+  kubelet_max_pods = %d
 }
 `,
 		testZoneName,
@@ -102,6 +104,7 @@ resource "exoscale_sks_nodepool" "test" {
 		testAccResourceSKSNodepoolKubeletImageGCMinAge,
 		testAccResourceSKSNodepoolKubeletImageGCHighThreshold,
 		testAccResourceSKSNodepoolKubeletImageGCLowThreshold,
+		testAccResourceSKSNodepoolKubeletMaxPods,
 	)
 
 	testAccResourceSKSNodepoolConfigUpdate = fmt.Sprintf(`
@@ -314,6 +317,7 @@ func TestAccResourceSKSNodepool(t *testing.T) {
 						resSKSNodepoolAttrKubeletGC + ".0." + resSKSNodepoolAttrKubeletGCMinAge:        validateString(testAccResourceSKSNodepoolKubeletImageGCMinAge),
 						resSKSNodepoolAttrKubeletGC + ".0." + resSKSNodepoolAttrKubeletGCHighThreshold: validateString(fmt.Sprint(testAccResourceSKSNodepoolKubeletImageGCHighThreshold)),
 						resSKSNodepoolAttrKubeletGC + ".0." + resSKSNodepoolAttrKubeletGCLowThreshold:  validateString(fmt.Sprint(testAccResourceSKSNodepoolKubeletImageGCLowThreshold)),
+						resSKSNodepoolAttrKubeletMaxPods:                                               validateString(fmt.Sprint(testAccResourceSKSNodepoolKubeletMaxPods)),
 						resSKSNodepoolAttrLabels + ".test":                                             validateString(testAccResourceSKSNodepoolLabelValue),
 						resSKSNodepoolAttrName:                                                         validateString(testAccResourceSKSNodepoolName),
 						resSKSNodepoolAttrSize:                                                         validateString(fmt.Sprint(testAccResourceSKSNodepoolSize)),
@@ -370,6 +374,7 @@ func TestAccResourceSKSNodepool(t *testing.T) {
 						resSKSNodepoolAttrKubeletGC + ".0." + resSKSNodepoolAttrKubeletGCMinAge:        validateString(testAccResourceSKSNodepoolKubeletImageGCMinAge),
 						resSKSNodepoolAttrKubeletGC + ".0." + resSKSNodepoolAttrKubeletGCHighThreshold: validateString(fmt.Sprint(testAccResourceSKSNodepoolKubeletImageGCHighThreshold)),
 						resSKSNodepoolAttrKubeletGC + ".0." + resSKSNodepoolAttrKubeletGCLowThreshold:  validateString(fmt.Sprint(testAccResourceSKSNodepoolKubeletImageGCLowThreshold)),
+						resSKSNodepoolAttrKubeletMaxPods:                                               validateString(fmt.Sprint(testAccResourceSKSNodepoolKubeletMaxPods)),
 						resSKSNodepoolAttrLabels + ".test":                                             validateString(testAccResourceSKSNodepoolLabelValueUpdated),
 						resSKSNodepoolAttrName:                                                         validateString(testAccResourceSKSNodepoolNameUpdated),
 						resSKSNodepoolAttrPrivateNetworkIDs + ".#":                                     validateString("1"),
@@ -415,6 +420,7 @@ func TestAccResourceSKSNodepool(t *testing.T) {
 							resSKSNodepoolAttrKubeletGC + ".0." + resSKSNodepoolAttrKubeletGCMinAge:        validateString(testAccResourceSKSNodepoolKubeletImageGCMinAge),
 							resSKSNodepoolAttrKubeletGC + ".0." + resSKSNodepoolAttrKubeletGCHighThreshold: validateString(fmt.Sprint(testAccResourceSKSNodepoolKubeletImageGCHighThreshold)),
 							resSKSNodepoolAttrKubeletGC + ".0." + resSKSNodepoolAttrKubeletGCLowThreshold:  validateString(fmt.Sprint(testAccResourceSKSNodepoolKubeletImageGCLowThreshold)),
+							resSKSNodepoolAttrKubeletMaxPods:                                               validateString(fmt.Sprint(testAccResourceSKSNodepoolKubeletMaxPods)),
 							resSKSNodepoolAttrLabels + ".test":                                             validateString(testAccResourceSKSNodepoolLabelValueUpdated),
 							resSKSNodepoolAttrName:                                                         validateString(testAccResourceSKSNodepoolNameUpdated),
 							resSKSNodepoolAttrPrivateNetworkIDs + ".#":                                     validateString("1"),

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.42
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.97.3
 	github.com/exoscale/egoscale v0.102.5
-	github.com/exoscale/egoscale/v3 v3.1.42
+	github.com/exoscale/egoscale/v3 v3.1.49
 	github.com/google/go-cmp v0.7.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-cty v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -107,8 +107,8 @@ github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
 github.com/exoscale/egoscale v0.102.5 h1:YH5xMi9bjETkO0NQ4dwnQmWsWvfIgrPZQ87jraiw3L0=
 github.com/exoscale/egoscale v0.102.5/go.mod h1:dQew6hG9qVTtMm01z0+K1Y7vl9EKQkxOI2B/ps3qVSI=
-github.com/exoscale/egoscale/v3 v3.1.42 h1:KlFDdm2ga1RdCdKuKlzJxLmgJjWVcDbJxF0t6FDswzw=
-github.com/exoscale/egoscale/v3 v3.1.42/go.mod h1:DUTgeubl5msPAo3SKFed04AxNhyTNOrCTJHZDRYLR10=
+github.com/exoscale/egoscale/v3 v3.1.49 h1:Bsc+1OiztFb2rOAPLjNGLvNqxsnFzVjO9x4x0dp12t4=
+github.com/exoscale/egoscale/v3 v3.1.49/go.mod h1:DUTgeubl5msPAo3SKFed04AxNhyTNOrCTJHZDRYLR10=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=

--- a/vendor/github.com/exoscale/egoscale/v3/errors.go
+++ b/vendor/github.com/exoscale/egoscale/v3/errors.go
@@ -121,11 +121,12 @@ type APIErrorEntry struct {
 func (e *APIError) Error() string {
 	return fmt.Sprintf("%s: %s", e.sentinel.Error(), e.Message)
 }
-
 func (e *APIError) Unwrap() error { return e.sentinel }
 
 func handleHTTPErrorResp(resp *http.Response) error {
 	if resp.StatusCode >= 400 && resp.StatusCode <= 599 {
+		defer resp.Body.Close() // prevent connection leak on error responses
+
 		var res struct {
 			Message string          `json:"message"`
 			Error   string          `json:"error"`

--- a/vendor/github.com/exoscale/egoscale/v3/operations.go
+++ b/vendor/github.com/exoscale/egoscale/v3/operations.go
@@ -69,7 +69,7 @@ func (c Client) ListAIAPIKeys(ctx context.Context) (*ListAIAPIKeysResponse, erro
 
 	bodyresp := new(ListAIAPIKeysResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListAIAPIKeys: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListAIAPIKeys: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -81,7 +81,7 @@ func (c Client) CreateAIAPIKey(ctx context.Context, req CreateAIAPIKeyRequest) (
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateAIAPIKey: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateAIAPIKey: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -120,7 +120,7 @@ func (c Client) CreateAIAPIKey(ctx context.Context, req CreateAIAPIKeyRequest) (
 
 	bodyresp := new(CreateAIAPIKeyResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateAIAPIKey: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateAIAPIKey: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -164,7 +164,7 @@ func (c Client) DeleteAIAPIKey(ctx context.Context, id UUID) (*Operation, error)
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteAIAPIKey: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteAIAPIKey: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -208,146 +208,7 @@ func (c Client) GetAIAPIKey(ctx context.Context, id UUID) (*GetAIAPIKeyResponse,
 
 	bodyresp := new(GetAIAPIKeyResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetAIAPIKey: prepare Json response: %w", err)
-	}
-
-	return bodyresp, nil
-}
-
-// Update AI API key name and/or scope
-func (c Client) UpdateAIAPIKey(ctx context.Context, id UUID, req UpdateAIAPIKeyRequest) (*UpdateAIAPIKeyResponse, error) {
-	path := fmt.Sprintf("/ai/api-key/%v", id)
-
-	body, err := prepareJSONBody(req)
-	if err != nil {
-		return nil, fmt.Errorf("UpdateAIAPIKey: prepare Json body: %w", err)
-	}
-
-	request, err := http.NewRequestWithContext(ctx, "PATCH", c.serverEndpoint+path, body)
-	if err != nil {
-		return nil, fmt.Errorf("UpdateAIAPIKey: new request: %w", err)
-	}
-
-	request.Header.Add("User-Agent", c.getUserAgent())
-
-	request.Header.Add("Content-Type", "application/json")
-
-	if err := c.executeRequestInterceptors(ctx, request); err != nil {
-		return nil, fmt.Errorf("UpdateAIAPIKey: execute request editors: %w", err)
-	}
-
-	if err := c.signRequest(request); err != nil {
-		return nil, fmt.Errorf("UpdateAIAPIKey: sign request: %w", err)
-	}
-
-	if c.trace {
-		dumpRequest(request, "update-ai-api-key")
-	}
-
-	response, err := c.httpClient.Do(request)
-	if err != nil {
-		return nil, fmt.Errorf("UpdateAIAPIKey: http client do: %w", err)
-	}
-
-	if c.trace {
-		dumpResponse(response)
-	}
-
-	if err := handleHTTPErrorResp(response); err != nil {
-		return nil, fmt.Errorf("UpdateAIAPIKey: http response: %w", err)
-	}
-
-	bodyresp := new(UpdateAIAPIKeyResponse)
-	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateAIAPIKey: prepare Json response: %w", err)
-	}
-
-	return bodyresp, nil
-}
-
-// Reveal AI API key plaintext value
-func (c Client) RevealAIAPIKey(ctx context.Context, id UUID) (*RevealAIAPIKeyResponse, error) {
-	path := fmt.Sprintf("/ai/api-key/%v/reveal", id)
-
-	request, err := http.NewRequestWithContext(ctx, "GET", c.serverEndpoint+path, nil)
-	if err != nil {
-		return nil, fmt.Errorf("RevealAIAPIKey: new request: %w", err)
-	}
-
-	request.Header.Add("User-Agent", c.getUserAgent())
-
-	if err := c.executeRequestInterceptors(ctx, request); err != nil {
-		return nil, fmt.Errorf("RevealAIAPIKey: execute request editors: %w", err)
-	}
-
-	if err := c.signRequest(request); err != nil {
-		return nil, fmt.Errorf("RevealAIAPIKey: sign request: %w", err)
-	}
-
-	if c.trace {
-		dumpRequest(request, "reveal-ai-api-key")
-	}
-
-	response, err := c.httpClient.Do(request)
-	if err != nil {
-		return nil, fmt.Errorf("RevealAIAPIKey: http client do: %w", err)
-	}
-
-	if c.trace {
-		dumpResponse(response)
-	}
-
-	if err := handleHTTPErrorResp(response); err != nil {
-		return nil, fmt.Errorf("RevealAIAPIKey: http response: %w", err)
-	}
-
-	bodyresp := new(RevealAIAPIKeyResponse)
-	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("RevealAIAPIKey: prepare Json response: %w", err)
-	}
-
-	return bodyresp, nil
-}
-
-// Rotate AI API key value
-func (c Client) RotateAIAPIKey(ctx context.Context, id UUID) (*RotateAIAPIKeyResponse, error) {
-	path := fmt.Sprintf("/ai/api-key/%v/rotate", id)
-
-	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, nil)
-	if err != nil {
-		return nil, fmt.Errorf("RotateAIAPIKey: new request: %w", err)
-	}
-
-	request.Header.Add("User-Agent", c.getUserAgent())
-
-	if err := c.executeRequestInterceptors(ctx, request); err != nil {
-		return nil, fmt.Errorf("RotateAIAPIKey: execute request editors: %w", err)
-	}
-
-	if err := c.signRequest(request); err != nil {
-		return nil, fmt.Errorf("RotateAIAPIKey: sign request: %w", err)
-	}
-
-	if c.trace {
-		dumpRequest(request, "rotate-ai-api-key")
-	}
-
-	response, err := c.httpClient.Do(request)
-	if err != nil {
-		return nil, fmt.Errorf("RotateAIAPIKey: http client do: %w", err)
-	}
-
-	if c.trace {
-		dumpResponse(response)
-	}
-
-	if err := handleHTTPErrorResp(response); err != nil {
-		return nil, fmt.Errorf("RotateAIAPIKey: http response: %w", err)
-	}
-
-	bodyresp := new(RotateAIAPIKeyResponse)
-	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("RotateAIAPIKey: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetAIAPIKey: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -426,7 +287,7 @@ func (c Client) ListDeployments(ctx context.Context, opts ...ListDeploymentsOpt)
 
 	bodyresp := new(ListDeploymentsResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListDeployments: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListDeployments: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -438,7 +299,7 @@ func (c Client) CreateDeployment(ctx context.Context, req CreateDeploymentReques
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateDeployment: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateDeployment: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -477,7 +338,7 @@ func (c Client) CreateDeployment(ctx context.Context, req CreateDeploymentReques
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateDeployment: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateDeployment: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -521,7 +382,7 @@ func (c Client) DeleteDeployment(ctx context.Context, id UUID) (*Operation, erro
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteDeployment: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteDeployment: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -565,7 +426,7 @@ func (c Client) GetDeployment(ctx context.Context, id UUID) (*GetDeploymentRespo
 
 	bodyresp := new(GetDeploymentResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDeployment: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDeployment: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -577,7 +438,7 @@ func (c Client) UpdateDeployment(ctx context.Context, id UUID, req UpdateDeploym
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateDeployment: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateDeployment: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PATCH", c.serverEndpoint+path, body)
@@ -616,7 +477,7 @@ func (c Client) UpdateDeployment(ctx context.Context, id UUID, req UpdateDeploym
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateDeployment: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateDeployment: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -660,7 +521,7 @@ func (c Client) RevealDeploymentAPIKey(ctx context.Context, id UUID) (*RevealDep
 
 	bodyresp := new(RevealDeploymentAPIKeyResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("RevealDeploymentAPIKey: prepare Json response: %w", err)
+		return nil, fmt.Errorf("RevealDeploymentAPIKey: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -726,7 +587,7 @@ func (c Client) GetDeploymentLogs(ctx context.Context, id UUID, opts ...GetDeplo
 
 	bodyresp := new(GetDeploymentLogsResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDeploymentLogs: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDeploymentLogs: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -738,7 +599,7 @@ func (c Client) ScaleDeployment(ctx context.Context, id UUID, req ScaleDeploymen
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("ScaleDeployment: prepare Json body: %w", err)
+		return nil, fmt.Errorf("ScaleDeployment: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -777,7 +638,7 @@ func (c Client) ScaleDeployment(ctx context.Context, id UUID, req ScaleDeploymen
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ScaleDeployment: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ScaleDeployment: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -837,7 +698,7 @@ func (c Client) GetInferenceEngineHelp(ctx context.Context, opts ...GetInference
 
 	bodyresp := new(GetInferenceEngineHelpResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetInferenceEngineHelp: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetInferenceEngineHelp: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -881,7 +742,7 @@ func (c Client) ListAIInstanceTypes(ctx context.Context) (*ListAIInstanceTypesRe
 
 	bodyresp := new(ListAIInstanceTypesResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListAIInstanceTypes: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListAIInstanceTypes: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -906,16 +767,8 @@ func (l ListModelsResponse) FindListModelsResponseEntry(nameOrID string) (ListMo
 	return ListModelsResponseEntry{}, fmt.Errorf("%q not found in ListModelsResponse: %w", nameOrID, ErrNotFound)
 }
 
-type ListModelsOpt func(url.Values)
-
-func ListModelsWithVisibility(visibility string) ListModelsOpt {
-	return func(q url.Values) {
-		q.Add("visibility", fmt.Sprint(visibility))
-	}
-}
-
 // List Models
-func (c Client) ListModels(ctx context.Context, opts ...ListModelsOpt) (*ListModelsResponse, error) {
+func (c Client) ListModels(ctx context.Context) (*ListModelsResponse, error) {
 	path := "/ai/model"
 
 	request, err := http.NewRequestWithContext(ctx, "GET", c.serverEndpoint+path, nil)
@@ -924,14 +777,6 @@ func (c Client) ListModels(ctx context.Context, opts ...ListModelsOpt) (*ListMod
 	}
 
 	request.Header.Add("User-Agent", c.getUserAgent())
-
-	if len(opts) > 0 {
-		q := request.URL.Query()
-		for _, opt := range opts {
-			opt(q)
-		}
-		request.URL.RawQuery = q.Encode()
-	}
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("ListModels: execute request editors: %w", err)
@@ -960,7 +805,7 @@ func (c Client) ListModels(ctx context.Context, opts ...ListModelsOpt) (*ListMod
 
 	bodyresp := new(ListModelsResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListModels: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListModels: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -974,7 +819,7 @@ func (c Client) CreateModel(ctx context.Context, req CreateModelRequest) (*Opera
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateModel: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateModel: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -1013,7 +858,7 @@ func (c Client) CreateModel(ctx context.Context, req CreateModelRequest) (*Opera
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateModel: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateModel: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -1057,7 +902,7 @@ func (c Client) DeleteModel(ctx context.Context, id UUID) (*Operation, error) {
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteModel: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteModel: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -1101,7 +946,7 @@ func (c Client) GetModel(ctx context.Context, id UUID) (*GetModelResponse, error
 
 	bodyresp := new(GetModelResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetModel: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetModel: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -1145,7 +990,7 @@ func (c Client) GetUserOrgConsumptionQuota(ctx context.Context) (*OrgConsumption
 
 	bodyresp := new(OrgConsumptionQuotaResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetUserOrgConsumptionQuota: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetUserOrgConsumptionQuota: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -1212,7 +1057,7 @@ func (c Client) ListAntiAffinityGroups(ctx context.Context) (*ListAntiAffinityGr
 
 	bodyresp := new(ListAntiAffinityGroupsResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListAntiAffinityGroups: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListAntiAffinityGroups: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -1231,7 +1076,7 @@ func (c Client) CreateAntiAffinityGroup(ctx context.Context, req CreateAntiAffin
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateAntiAffinityGroup: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateAntiAffinityGroup: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -1270,7 +1115,7 @@ func (c Client) CreateAntiAffinityGroup(ctx context.Context, req CreateAntiAffin
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateAntiAffinityGroup: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateAntiAffinityGroup: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -1314,7 +1159,7 @@ func (c Client) DeleteAntiAffinityGroup(ctx context.Context, id UUID) (*Operatio
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteAntiAffinityGroup: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteAntiAffinityGroup: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -1358,7 +1203,7 @@ func (c Client) GetAntiAffinityGroup(ctx context.Context, id UUID) (*AntiAffinit
 
 	bodyresp := new(AntiAffinityGroup)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetAntiAffinityGroup: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetAntiAffinityGroup: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -1424,7 +1269,7 @@ func (c Client) ListAPIKeys(ctx context.Context) (*ListAPIKeysResponse, error) {
 
 	bodyresp := new(ListAPIKeysResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListAPIKeys: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListAPIKeys: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -1442,7 +1287,7 @@ func (c Client) CreateAPIKey(ctx context.Context, req CreateAPIKeyRequest) (*IAM
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateAPIKey: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateAPIKey: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -1481,7 +1326,7 @@ func (c Client) CreateAPIKey(ctx context.Context, req CreateAPIKeyRequest) (*IAM
 
 	bodyresp := new(IAMAPIKeyCreated)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateAPIKey: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateAPIKey: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -1524,7 +1369,7 @@ func (c Client) DeleteAPIKey(ctx context.Context, id string) (*Operation, error)
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteAPIKey: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteAPIKey: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -1567,7 +1412,7 @@ func (c Client) GetAPIKey(ctx context.Context, id string) (*IAMAPIKey, error) {
 
 	bodyresp := new(IAMAPIKey)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetAPIKey: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetAPIKey: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -1650,7 +1495,7 @@ func (c Client) ListBlockStorageVolumes(ctx context.Context, opts ...ListBlockSt
 
 	bodyresp := new(ListBlockStorageVolumesResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListBlockStorageVolumes: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListBlockStorageVolumes: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -1673,7 +1518,7 @@ func (c Client) CreateBlockStorageVolume(ctx context.Context, req CreateBlockSto
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateBlockStorageVolume: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateBlockStorageVolume: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -1712,7 +1557,7 @@ func (c Client) CreateBlockStorageVolume(ctx context.Context, req CreateBlockSto
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateBlockStorageVolume: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateBlockStorageVolume: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -1779,7 +1624,7 @@ func (c Client) ListBlockStorageSnapshots(ctx context.Context) (*ListBlockStorag
 
 	bodyresp := new(ListBlockStorageSnapshotsResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListBlockStorageSnapshots: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListBlockStorageSnapshots: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -1823,7 +1668,7 @@ func (c Client) DeleteBlockStorageSnapshot(ctx context.Context, id UUID) (*Opera
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteBlockStorageSnapshot: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteBlockStorageSnapshot: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -1867,7 +1712,7 @@ func (c Client) GetBlockStorageSnapshot(ctx context.Context, id UUID) (*BlockSto
 
 	bodyresp := new(BlockStorageSnapshot)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetBlockStorageSnapshot: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetBlockStorageSnapshot: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -1885,7 +1730,7 @@ func (c Client) UpdateBlockStorageSnapshot(ctx context.Context, id UUID, req Upd
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateBlockStorageSnapshot: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateBlockStorageSnapshot: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -1924,7 +1769,7 @@ func (c Client) UpdateBlockStorageSnapshot(ctx context.Context, id UUID, req Upd
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateBlockStorageSnapshot: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateBlockStorageSnapshot: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -1968,7 +1813,7 @@ func (c Client) DeleteBlockStorageVolume(ctx context.Context, id UUID) (*Operati
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteBlockStorageVolume: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteBlockStorageVolume: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -2012,7 +1857,7 @@ func (c Client) GetBlockStorageVolume(ctx context.Context, id UUID) (*BlockStora
 
 	bodyresp := new(BlockStorageVolume)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetBlockStorageVolume: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetBlockStorageVolume: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -2030,7 +1875,7 @@ func (c Client) UpdateBlockStorageVolume(ctx context.Context, id UUID, req Updat
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateBlockStorageVolume: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateBlockStorageVolume: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -2069,7 +1914,7 @@ func (c Client) UpdateBlockStorageVolume(ctx context.Context, id UUID, req Updat
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateBlockStorageVolume: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateBlockStorageVolume: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -2086,7 +1931,7 @@ func (c Client) AttachBlockStorageVolumeToInstance(ctx context.Context, id UUID,
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("AttachBlockStorageVolumeToInstance: prepare Json body: %w", err)
+		return nil, fmt.Errorf("AttachBlockStorageVolumeToInstance: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -2125,7 +1970,7 @@ func (c Client) AttachBlockStorageVolumeToInstance(ctx context.Context, id UUID,
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("AttachBlockStorageVolumeToInstance: prepare Json response: %w", err)
+		return nil, fmt.Errorf("AttachBlockStorageVolumeToInstance: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -2143,7 +1988,7 @@ func (c Client) CreateBlockStorageSnapshot(ctx context.Context, id UUID, req Cre
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateBlockStorageSnapshot: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateBlockStorageSnapshot: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -2182,7 +2027,7 @@ func (c Client) CreateBlockStorageSnapshot(ctx context.Context, id UUID, req Cre
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateBlockStorageSnapshot: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateBlockStorageSnapshot: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -2226,7 +2071,7 @@ func (c Client) DetachBlockStorageVolume(ctx context.Context, id UUID) (*Operati
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DetachBlockStorageVolume: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DetachBlockStorageVolume: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -2243,7 +2088,7 @@ func (c Client) ResizeBlockStorageVolume(ctx context.Context, id UUID, req Resiz
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("ResizeBlockStorageVolume: prepare Json body: %w", err)
+		return nil, fmt.Errorf("ResizeBlockStorageVolume: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -2282,7 +2127,7 @@ func (c Client) ResizeBlockStorageVolume(ctx context.Context, id UUID, req Resiz
 
 	bodyresp := new(BlockStorageVolume)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ResizeBlockStorageVolume: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ResizeBlockStorageVolume: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -2332,7 +2177,7 @@ func (c Client) GetConsoleProxyURL(ctx context.Context, id UUID) (*GetConsolePro
 
 	bodyresp := new(GetConsoleProxyURLResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetConsoleProxyURL: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetConsoleProxyURL: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -2380,7 +2225,7 @@ func (c Client) GetDBAASCACertificate(ctx context.Context) (*GetDBAASCACertifica
 
 	bodyresp := new(GetDBAASCACertificateResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDBAASCACertificate: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDBAASCACertificate: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -2423,7 +2268,7 @@ func (c Client) DeleteDBAASServiceClickhouse(ctx context.Context, name string) (
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteDBAASServiceClickhouse: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteDBAASServiceClickhouse: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -2466,7 +2311,7 @@ func (c Client) GetDBAASServiceClickhouse(ctx context.Context, name string) (*DB
 
 	bodyresp := new(DBAASServiceClickhouse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDBAASServiceClickhouse: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDBAASServiceClickhouse: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -2516,7 +2361,7 @@ func (c Client) CreateDBAASServiceClickhouse(ctx context.Context, name string, r
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateDBAASServiceClickhouse: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateDBAASServiceClickhouse: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -2555,7 +2400,7 @@ func (c Client) CreateDBAASServiceClickhouse(ctx context.Context, name string, r
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateDBAASServiceClickhouse: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateDBAASServiceClickhouse: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -2602,7 +2447,7 @@ func (c Client) UpdateDBAASServiceClickhouse(ctx context.Context, name string, r
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateDBAASServiceClickhouse: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASServiceClickhouse: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -2641,7 +2486,7 @@ func (c Client) UpdateDBAASServiceClickhouse(ctx context.Context, name string, r
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateDBAASServiceClickhouse: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASServiceClickhouse: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -2684,7 +2529,7 @@ func (c Client) StartDBAASClickhouseMaintenance(ctx context.Context, name string
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("StartDBAASClickhouseMaintenance: prepare Json response: %w", err)
+		return nil, fmt.Errorf("StartDBAASClickhouseMaintenance: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -2727,7 +2572,93 @@ func (c Client) GetDBAASClickhouseAclConfig(ctx context.Context, serviceName str
 
 	bodyresp := new(DBAASClickhouseAclConfig)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDBAASClickhouseAclConfig: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDBAASClickhouseAclConfig: prepare JSON response: %w", err)
+	}
+
+	return bodyresp, nil
+}
+
+func (c Client) ListDBAASClickhouseRoles(ctx context.Context, serviceName string) (*DBAASClickhouseRoles, error) {
+	path := fmt.Sprintf("/dbaas-clickhouse/%v/role", serviceName)
+
+	request, err := http.NewRequestWithContext(ctx, "GET", c.serverEndpoint+path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("ListDBAASClickhouseRoles: new request: %w", err)
+	}
+
+	request.Header.Add("User-Agent", c.getUserAgent())
+
+	if err := c.executeRequestInterceptors(ctx, request); err != nil {
+		return nil, fmt.Errorf("ListDBAASClickhouseRoles: execute request editors: %w", err)
+	}
+
+	if err := c.signRequest(request); err != nil {
+		return nil, fmt.Errorf("ListDBAASClickhouseRoles: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "list-dbaas-clickhouse-roles")
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("ListDBAASClickhouseRoles: http client do: %w", err)
+	}
+
+	if c.trace {
+		dumpResponse(response)
+	}
+
+	if err := handleHTTPErrorResp(response); err != nil {
+		return nil, fmt.Errorf("ListDBAASClickhouseRoles: http response: %w", err)
+	}
+
+	bodyresp := new(DBAASClickhouseRoles)
+	if err := prepareJSONResponse(response, bodyresp); err != nil {
+		return nil, fmt.Errorf("ListDBAASClickhouseRoles: prepare JSON response: %w", err)
+	}
+
+	return bodyresp, nil
+}
+
+func (c Client) DeleteDBAASClickhouseRole(ctx context.Context, serviceName string, roleUuid UUID) (*Operation, error) {
+	path := fmt.Sprintf("/dbaas-clickhouse/%v/role/%v", serviceName, roleUuid)
+
+	request, err := http.NewRequestWithContext(ctx, "DELETE", c.serverEndpoint+path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("DeleteDBAASClickhouseRole: new request: %w", err)
+	}
+
+	request.Header.Add("User-Agent", c.getUserAgent())
+
+	if err := c.executeRequestInterceptors(ctx, request); err != nil {
+		return nil, fmt.Errorf("DeleteDBAASClickhouseRole: execute request editors: %w", err)
+	}
+
+	if err := c.signRequest(request); err != nil {
+		return nil, fmt.Errorf("DeleteDBAASClickhouseRole: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "delete-dbaas-clickhouse-role")
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("DeleteDBAASClickhouseRole: http client do: %w", err)
+	}
+
+	if c.trace {
+		dumpResponse(response)
+	}
+
+	if err := handleHTTPErrorResp(response); err != nil {
+		return nil, fmt.Errorf("DeleteDBAASClickhouseRole: http response: %w", err)
+	}
+
+	bodyresp := new(Operation)
+	if err := prepareJSONResponse(response, bodyresp); err != nil {
+		return nil, fmt.Errorf("DeleteDBAASClickhouseRole: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -2770,7 +2701,7 @@ func (c Client) ListDBAASClickhouseUsers(ctx context.Context, serviceName string
 
 	bodyresp := new(DBAASClickhouseUsers)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListDBAASClickhouseUsers: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListDBAASClickhouseUsers: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -2788,7 +2719,7 @@ func (c Client) CreateDBAASClickhouseUser(ctx context.Context, serviceName strin
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateDBAASClickhouseUser: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateDBAASClickhouseUser: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -2827,14 +2758,14 @@ func (c Client) CreateDBAASClickhouseUser(ctx context.Context, serviceName strin
 
 	bodyresp := new(DBAASUserClickhouseSecrets)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateDBAASClickhouseUser: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateDBAASClickhouseUser: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
 }
 
-func (c Client) DeleteDBAASClickhouseUser(ctx context.Context, serviceName string, username string) (*Operation, error) {
-	path := fmt.Sprintf("/dbaas-clickhouse/%v/user/%v", serviceName, username)
+func (c Client) DeleteDBAASClickhouseUser(ctx context.Context, serviceName string, userUuid UUID) (*Operation, error) {
+	path := fmt.Sprintf("/dbaas-clickhouse/%v/user/%v", serviceName, userUuid)
 
 	request, err := http.NewRequestWithContext(ctx, "DELETE", c.serverEndpoint+path, nil)
 	if err != nil {
@@ -2870,7 +2801,7 @@ func (c Client) DeleteDBAASClickhouseUser(ctx context.Context, serviceName strin
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteDBAASClickhouseUser: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteDBAASClickhouseUser: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -2885,7 +2816,7 @@ func (c Client) ResetDBAASClickhouseUserPassword(ctx context.Context, serviceNam
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("ResetDBAASClickhouseUserPassword: prepare Json body: %w", err)
+		return nil, fmt.Errorf("ResetDBAASClickhouseUserPassword: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -2924,7 +2855,7 @@ func (c Client) ResetDBAASClickhouseUserPassword(ctx context.Context, serviceNam
 
 	bodyresp := new(DBAASUserClickhouseSecrets)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ResetDBAASClickhouseUserPassword: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ResetDBAASClickhouseUserPassword: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -2967,7 +2898,7 @@ func (c Client) RevealDBAASClickhouseUserPassword(ctx context.Context, serviceNa
 
 	bodyresp := new(DBAASUserClickhouseSecrets)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("RevealDBAASClickhouseUserPassword: prepare Json response: %w", err)
+		return nil, fmt.Errorf("RevealDBAASClickhouseUserPassword: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -3011,7 +2942,7 @@ func (c Client) DeleteDBAASExternalEndpointDatadog(ctx context.Context, endpoint
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteDBAASExternalEndpointDatadog: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteDBAASExternalEndpointDatadog: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -3055,7 +2986,7 @@ func (c Client) GetDBAASExternalEndpointDatadog(ctx context.Context, endpointID 
 
 	bodyresp := new(DBAASExternalEndpointDatadogOutput)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDBAASExternalEndpointDatadog: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDBAASExternalEndpointDatadog: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -3067,7 +2998,7 @@ func (c Client) UpdateDBAASExternalEndpointDatadog(ctx context.Context, endpoint
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateDBAASExternalEndpointDatadog: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASExternalEndpointDatadog: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -3106,7 +3037,7 @@ func (c Client) UpdateDBAASExternalEndpointDatadog(ctx context.Context, endpoint
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateDBAASExternalEndpointDatadog: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASExternalEndpointDatadog: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -3118,7 +3049,7 @@ func (c Client) CreateDBAASExternalEndpointDatadog(ctx context.Context, name str
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateDBAASExternalEndpointDatadog: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateDBAASExternalEndpointDatadog: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -3157,7 +3088,7 @@ func (c Client) CreateDBAASExternalEndpointDatadog(ctx context.Context, name str
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateDBAASExternalEndpointDatadog: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateDBAASExternalEndpointDatadog: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -3201,7 +3132,7 @@ func (c Client) DeleteDBAASExternalEndpointElasticsearch(ctx context.Context, en
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteDBAASExternalEndpointElasticsearch: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteDBAASExternalEndpointElasticsearch: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -3245,7 +3176,7 @@ func (c Client) GetDBAASExternalEndpointElasticsearch(ctx context.Context, endpo
 
 	bodyresp := new(DBAASEndpointElasticsearchOutput)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDBAASExternalEndpointElasticsearch: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDBAASExternalEndpointElasticsearch: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -3257,7 +3188,7 @@ func (c Client) UpdateDBAASExternalEndpointElasticsearch(ctx context.Context, en
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateDBAASExternalEndpointElasticsearch: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASExternalEndpointElasticsearch: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -3296,7 +3227,7 @@ func (c Client) UpdateDBAASExternalEndpointElasticsearch(ctx context.Context, en
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateDBAASExternalEndpointElasticsearch: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASExternalEndpointElasticsearch: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -3308,7 +3239,7 @@ func (c Client) CreateDBAASExternalEndpointElasticsearch(ctx context.Context, na
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateDBAASExternalEndpointElasticsearch: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateDBAASExternalEndpointElasticsearch: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -3347,7 +3278,7 @@ func (c Client) CreateDBAASExternalEndpointElasticsearch(ctx context.Context, na
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateDBAASExternalEndpointElasticsearch: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateDBAASExternalEndpointElasticsearch: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -3391,7 +3322,7 @@ func (c Client) DeleteDBAASExternalEndpointOpensearch(ctx context.Context, endpo
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteDBAASExternalEndpointOpensearch: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteDBAASExternalEndpointOpensearch: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -3435,7 +3366,7 @@ func (c Client) GetDBAASExternalEndpointOpensearch(ctx context.Context, endpoint
 
 	bodyresp := new(DBAASEndpointOpensearchOutput)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDBAASExternalEndpointOpensearch: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDBAASExternalEndpointOpensearch: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -3447,7 +3378,7 @@ func (c Client) UpdateDBAASExternalEndpointOpensearch(ctx context.Context, endpo
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateDBAASExternalEndpointOpensearch: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASExternalEndpointOpensearch: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -3486,7 +3417,7 @@ func (c Client) UpdateDBAASExternalEndpointOpensearch(ctx context.Context, endpo
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateDBAASExternalEndpointOpensearch: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASExternalEndpointOpensearch: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -3498,7 +3429,7 @@ func (c Client) CreateDBAASExternalEndpointOpensearch(ctx context.Context, name 
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateDBAASExternalEndpointOpensearch: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateDBAASExternalEndpointOpensearch: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -3537,7 +3468,7 @@ func (c Client) CreateDBAASExternalEndpointOpensearch(ctx context.Context, name 
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateDBAASExternalEndpointOpensearch: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateDBAASExternalEndpointOpensearch: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -3581,7 +3512,7 @@ func (c Client) DeleteDBAASExternalEndpointPrometheus(ctx context.Context, endpo
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteDBAASExternalEndpointPrometheus: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteDBAASExternalEndpointPrometheus: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -3625,7 +3556,7 @@ func (c Client) GetDBAASExternalEndpointPrometheus(ctx context.Context, endpoint
 
 	bodyresp := new(DBAASEndpointExternalPrometheusOutput)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDBAASExternalEndpointPrometheus: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDBAASExternalEndpointPrometheus: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -3637,7 +3568,7 @@ func (c Client) UpdateDBAASExternalEndpointPrometheus(ctx context.Context, endpo
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateDBAASExternalEndpointPrometheus: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASExternalEndpointPrometheus: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -3676,7 +3607,7 @@ func (c Client) UpdateDBAASExternalEndpointPrometheus(ctx context.Context, endpo
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateDBAASExternalEndpointPrometheus: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASExternalEndpointPrometheus: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -3688,7 +3619,7 @@ func (c Client) CreateDBAASExternalEndpointPrometheus(ctx context.Context, name 
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateDBAASExternalEndpointPrometheus: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateDBAASExternalEndpointPrometheus: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -3727,7 +3658,7 @@ func (c Client) CreateDBAASExternalEndpointPrometheus(ctx context.Context, name 
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateDBAASExternalEndpointPrometheus: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateDBAASExternalEndpointPrometheus: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -3771,7 +3702,7 @@ func (c Client) DeleteDBAASExternalEndpointRsyslog(ctx context.Context, endpoint
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteDBAASExternalEndpointRsyslog: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteDBAASExternalEndpointRsyslog: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -3815,7 +3746,7 @@ func (c Client) GetDBAASExternalEndpointRsyslog(ctx context.Context, endpointID 
 
 	bodyresp := new(DBAASExternalEndpointRsyslogOutput)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDBAASExternalEndpointRsyslog: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDBAASExternalEndpointRsyslog: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -3827,7 +3758,7 @@ func (c Client) UpdateDBAASExternalEndpointRsyslog(ctx context.Context, endpoint
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateDBAASExternalEndpointRsyslog: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASExternalEndpointRsyslog: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -3866,7 +3797,7 @@ func (c Client) UpdateDBAASExternalEndpointRsyslog(ctx context.Context, endpoint
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateDBAASExternalEndpointRsyslog: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASExternalEndpointRsyslog: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -3878,7 +3809,7 @@ func (c Client) CreateDBAASExternalEndpointRsyslog(ctx context.Context, name str
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateDBAASExternalEndpointRsyslog: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateDBAASExternalEndpointRsyslog: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -3917,7 +3848,7 @@ func (c Client) CreateDBAASExternalEndpointRsyslog(ctx context.Context, name str
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateDBAASExternalEndpointRsyslog: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateDBAASExternalEndpointRsyslog: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -3971,7 +3902,7 @@ func (c Client) ListDBAASExternalEndpointTypes(ctx context.Context) (*ListDBAASE
 
 	bodyresp := new(ListDBAASExternalEndpointTypesResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListDBAASExternalEndpointTypes: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListDBAASExternalEndpointTypes: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -3989,7 +3920,7 @@ func (c Client) AttachDBAASServiceToEndpoint(ctx context.Context, sourceServiceN
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("AttachDBAASServiceToEndpoint: prepare Json body: %w", err)
+		return nil, fmt.Errorf("AttachDBAASServiceToEndpoint: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -4028,7 +3959,7 @@ func (c Client) AttachDBAASServiceToEndpoint(ctx context.Context, sourceServiceN
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("AttachDBAASServiceToEndpoint: prepare Json response: %w", err)
+		return nil, fmt.Errorf("AttachDBAASServiceToEndpoint: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -4045,7 +3976,7 @@ func (c Client) DetachDBAASServiceFromEndpoint(ctx context.Context, sourceServic
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("DetachDBAASServiceFromEndpoint: prepare Json body: %w", err)
+		return nil, fmt.Errorf("DetachDBAASServiceFromEndpoint: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -4084,7 +4015,7 @@ func (c Client) DetachDBAASServiceFromEndpoint(ctx context.Context, sourceServic
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DetachDBAASServiceFromEndpoint: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DetachDBAASServiceFromEndpoint: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -4151,7 +4082,7 @@ func (c Client) ListDBAASExternalEndpoints(ctx context.Context) (*ListDBAASExter
 
 	bodyresp := new(ListDBAASExternalEndpointsResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListDBAASExternalEndpoints: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListDBAASExternalEndpoints: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -4199,7 +4130,7 @@ func (c Client) GetDBAASExternalIntegrationSettingsDatadog(ctx context.Context, 
 
 	bodyresp := new(GetDBAASExternalIntegrationSettingsDatadogResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDBAASExternalIntegrationSettingsDatadog: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDBAASExternalIntegrationSettingsDatadog: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -4215,7 +4146,7 @@ func (c Client) UpdateDBAASExternalIntegrationSettingsDatadog(ctx context.Contex
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateDBAASExternalIntegrationSettingsDatadog: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASExternalIntegrationSettingsDatadog: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -4254,7 +4185,7 @@ func (c Client) UpdateDBAASExternalIntegrationSettingsDatadog(ctx context.Contex
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateDBAASExternalIntegrationSettingsDatadog: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASExternalIntegrationSettingsDatadog: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -4298,7 +4229,7 @@ func (c Client) GetDBAASExternalIntegration(ctx context.Context, integrationID U
 
 	bodyresp := new(DBAASExternalIntegration)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDBAASExternalIntegration: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDBAASExternalIntegration: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -4346,7 +4277,7 @@ func (c Client) ListDBAASExternalIntegrations(ctx context.Context, serviceName s
 
 	bodyresp := new(ListDBAASExternalIntegrationsResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListDBAASExternalIntegrations: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListDBAASExternalIntegrations: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -4389,7 +4320,7 @@ func (c Client) DeleteDBAASServiceGrafana(ctx context.Context, name string) (*Op
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteDBAASServiceGrafana: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteDBAASServiceGrafana: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -4432,7 +4363,7 @@ func (c Client) GetDBAASServiceGrafana(ctx context.Context, name string) (*DBAAS
 
 	bodyresp := new(DBAASServiceGrafana)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDBAASServiceGrafana: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDBAASServiceGrafana: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -4479,7 +4410,7 @@ func (c Client) CreateDBAASServiceGrafana(ctx context.Context, name string, req 
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateDBAASServiceGrafana: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateDBAASServiceGrafana: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -4518,7 +4449,7 @@ func (c Client) CreateDBAASServiceGrafana(ctx context.Context, name string, req 
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateDBAASServiceGrafana: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateDBAASServiceGrafana: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -4563,7 +4494,7 @@ func (c Client) UpdateDBAASServiceGrafana(ctx context.Context, name string, req 
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateDBAASServiceGrafana: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASServiceGrafana: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -4602,7 +4533,7 @@ func (c Client) UpdateDBAASServiceGrafana(ctx context.Context, name string, req 
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateDBAASServiceGrafana: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASServiceGrafana: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -4645,7 +4576,7 @@ func (c Client) StartDBAASGrafanaMaintenance(ctx context.Context, name string) (
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("StartDBAASGrafanaMaintenance: prepare Json response: %w", err)
+		return nil, fmt.Errorf("StartDBAASGrafanaMaintenance: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -4661,7 +4592,7 @@ func (c Client) ResetDBAASGrafanaUserPassword(ctx context.Context, serviceName s
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("ResetDBAASGrafanaUserPassword: prepare Json body: %w", err)
+		return nil, fmt.Errorf("ResetDBAASGrafanaUserPassword: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -4700,7 +4631,7 @@ func (c Client) ResetDBAASGrafanaUserPassword(ctx context.Context, serviceName s
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ResetDBAASGrafanaUserPassword: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ResetDBAASGrafanaUserPassword: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -4743,7 +4674,7 @@ func (c Client) RevealDBAASGrafanaUserPassword(ctx context.Context, serviceName 
 
 	bodyresp := new(DBAASUserGrafanaSecrets)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("RevealDBAASGrafanaUserPassword: prepare Json response: %w", err)
+		return nil, fmt.Errorf("RevealDBAASGrafanaUserPassword: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -4763,7 +4694,7 @@ func (c Client) CreateDBAASIntegration(ctx context.Context, req CreateDBAASInteg
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateDBAASIntegration: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateDBAASIntegration: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -4802,7 +4733,7 @@ func (c Client) CreateDBAASIntegration(ctx context.Context, req CreateDBAASInteg
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateDBAASIntegration: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateDBAASIntegration: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -4859,7 +4790,7 @@ func (c Client) ListDBAASIntegrationSettings(ctx context.Context, integrationTyp
 
 	bodyresp := new(ListDBAASIntegrationSettingsResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListDBAASIntegrationSettings: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListDBAASIntegrationSettings: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -4907,7 +4838,7 @@ func (c Client) ListDBAASIntegrationTypes(ctx context.Context) (*ListDBAASIntegr
 
 	bodyresp := new(ListDBAASIntegrationTypesResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListDBAASIntegrationTypes: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListDBAASIntegrationTypes: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -4951,7 +4882,7 @@ func (c Client) DeleteDBAASIntegration(ctx context.Context, id UUID) (*Operation
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteDBAASIntegration: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteDBAASIntegration: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -4995,7 +4926,7 @@ func (c Client) GetDBAASIntegration(ctx context.Context, id UUID) (*DBAASIntegra
 
 	bodyresp := new(DBAASIntegration)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDBAASIntegration: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDBAASIntegration: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -5012,7 +4943,7 @@ func (c Client) UpdateDBAASIntegration(ctx context.Context, id UUID, req UpdateD
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateDBAASIntegration: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASIntegration: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -5051,7 +4982,7 @@ func (c Client) UpdateDBAASIntegration(ctx context.Context, id UUID, req UpdateD
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateDBAASIntegration: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASIntegration: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -5094,7 +5025,7 @@ func (c Client) DeleteDBAASServiceKafka(ctx context.Context, name string) (*Oper
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteDBAASServiceKafka: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteDBAASServiceKafka: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -5137,7 +5068,7 @@ func (c Client) GetDBAASServiceKafka(ctx context.Context, name string) (*DBAASSe
 
 	bodyresp := new(DBAASServiceKafka)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDBAASServiceKafka: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDBAASServiceKafka: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -5207,7 +5138,7 @@ func (c Client) CreateDBAASServiceKafka(ctx context.Context, name string, req Cr
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateDBAASServiceKafka: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateDBAASServiceKafka: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -5246,7 +5177,7 @@ func (c Client) CreateDBAASServiceKafka(ctx context.Context, name string, req Cr
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateDBAASServiceKafka: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateDBAASServiceKafka: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -5316,7 +5247,7 @@ func (c Client) UpdateDBAASServiceKafka(ctx context.Context, name string, req Up
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateDBAASServiceKafka: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASServiceKafka: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -5355,7 +5286,7 @@ func (c Client) UpdateDBAASServiceKafka(ctx context.Context, name string, req Up
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateDBAASServiceKafka: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASServiceKafka: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -5398,7 +5329,7 @@ func (c Client) GetDBAASKafkaAclConfig(ctx context.Context, name string) (*DBAAS
 
 	bodyresp := new(DBAASKafkaAcls)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDBAASKafkaAclConfig: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDBAASKafkaAclConfig: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -5441,7 +5372,7 @@ func (c Client) StartDBAASKafkaMaintenance(ctx context.Context, name string) (*O
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("StartDBAASKafkaMaintenance: prepare Json response: %w", err)
+		return nil, fmt.Errorf("StartDBAASKafkaMaintenance: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -5452,7 +5383,7 @@ func (c Client) CreateDBAASKafkaSchemaRegistryAclConfig(ctx context.Context, nam
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateDBAASKafkaSchemaRegistryAclConfig: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateDBAASKafkaSchemaRegistryAclConfig: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -5491,7 +5422,7 @@ func (c Client) CreateDBAASKafkaSchemaRegistryAclConfig(ctx context.Context, nam
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateDBAASKafkaSchemaRegistryAclConfig: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateDBAASKafkaSchemaRegistryAclConfig: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -5534,7 +5465,7 @@ func (c Client) DeleteDBAASKafkaSchemaRegistryAclConfig(ctx context.Context, nam
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteDBAASKafkaSchemaRegistryAclConfig: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteDBAASKafkaSchemaRegistryAclConfig: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -5545,7 +5476,7 @@ func (c Client) CreateDBAASKafkaTopicAclConfig(ctx context.Context, name string,
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateDBAASKafkaTopicAclConfig: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateDBAASKafkaTopicAclConfig: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -5584,7 +5515,7 @@ func (c Client) CreateDBAASKafkaTopicAclConfig(ctx context.Context, name string,
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateDBAASKafkaTopicAclConfig: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateDBAASKafkaTopicAclConfig: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -5627,7 +5558,7 @@ func (c Client) DeleteDBAASKafkaTopicAclConfig(ctx context.Context, name string,
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteDBAASKafkaTopicAclConfig: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteDBAASKafkaTopicAclConfig: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -5670,7 +5601,7 @@ func (c Client) RevealDBAASKafkaConnectPassword(ctx context.Context, serviceName
 
 	bodyresp := new(DBAASUserKafkaConnectSecrets)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("RevealDBAASKafkaConnectPassword: prepare Json response: %w", err)
+		return nil, fmt.Errorf("RevealDBAASKafkaConnectPassword: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -5685,7 +5616,7 @@ func (c Client) CreateDBAASKafkaUser(ctx context.Context, serviceName string, re
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateDBAASKafkaUser: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateDBAASKafkaUser: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -5724,7 +5655,7 @@ func (c Client) CreateDBAASKafkaUser(ctx context.Context, serviceName string, re
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateDBAASKafkaUser: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateDBAASKafkaUser: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -5767,7 +5698,7 @@ func (c Client) DeleteDBAASKafkaUser(ctx context.Context, serviceName string, us
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteDBAASKafkaUser: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteDBAASKafkaUser: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -5783,7 +5714,7 @@ func (c Client) ResetDBAASKafkaUserPassword(ctx context.Context, serviceName str
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("ResetDBAASKafkaUserPassword: prepare Json body: %w", err)
+		return nil, fmt.Errorf("ResetDBAASKafkaUserPassword: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -5822,7 +5753,7 @@ func (c Client) ResetDBAASKafkaUserPassword(ctx context.Context, serviceName str
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ResetDBAASKafkaUserPassword: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ResetDBAASKafkaUserPassword: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -5865,7 +5796,7 @@ func (c Client) RevealDBAASKafkaUserPassword(ctx context.Context, serviceName st
 
 	bodyresp := new(DBAASUserKafkaSecrets)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("RevealDBAASKafkaUserPassword: prepare Json response: %w", err)
+		return nil, fmt.Errorf("RevealDBAASKafkaUserPassword: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -5909,7 +5840,7 @@ func (c Client) GetDBAASMigrationStatus(ctx context.Context, name string) (*DBAA
 
 	bodyresp := new(DBAASMigrationStatus)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDBAASMigrationStatus: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDBAASMigrationStatus: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -5952,7 +5883,7 @@ func (c Client) DeleteDBAASServiceMysql(ctx context.Context, name string) (*Oper
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteDBAASServiceMysql: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteDBAASServiceMysql: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -5996,7 +5927,7 @@ func (c Client) GetDBAASServiceMysql(ctx context.Context, name string) (*DBAASSe
 
 	bodyresp := new(DBAASServiceMysql)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDBAASServiceMysql: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDBAASServiceMysql: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -6098,7 +6029,7 @@ func (c Client) CreateDBAASServiceMysql(ctx context.Context, name string, req Cr
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateDBAASServiceMysql: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateDBAASServiceMysql: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -6137,7 +6068,7 @@ func (c Client) CreateDBAASServiceMysql(ctx context.Context, name string, req Cr
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateDBAASServiceMysql: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateDBAASServiceMysql: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -6216,7 +6147,7 @@ func (c Client) UpdateDBAASServiceMysql(ctx context.Context, name string, req Up
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateDBAASServiceMysql: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASServiceMysql: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -6255,7 +6186,7 @@ func (c Client) UpdateDBAASServiceMysql(ctx context.Context, name string, req Up
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateDBAASServiceMysql: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASServiceMysql: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -6298,7 +6229,7 @@ func (c Client) EnableDBAASMysqlWrites(ctx context.Context, name string) (*Opera
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("EnableDBAASMysqlWrites: prepare Json response: %w", err)
+		return nil, fmt.Errorf("EnableDBAASMysqlWrites: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -6341,7 +6272,7 @@ func (c Client) StartDBAASMysqlMaintenance(ctx context.Context, name string) (*O
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("StartDBAASMysqlMaintenance: prepare Json response: %w", err)
+		return nil, fmt.Errorf("StartDBAASMysqlMaintenance: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -6384,7 +6315,7 @@ func (c Client) StopDBAASMysqlMigration(ctx context.Context, name string) (*Oper
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("StopDBAASMysqlMigration: prepare Json response: %w", err)
+		return nil, fmt.Errorf("StopDBAASMysqlMigration: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -6399,7 +6330,7 @@ func (c Client) CreateDBAASMysqlDatabase(ctx context.Context, serviceName string
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateDBAASMysqlDatabase: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateDBAASMysqlDatabase: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -6438,7 +6369,7 @@ func (c Client) CreateDBAASMysqlDatabase(ctx context.Context, serviceName string
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateDBAASMysqlDatabase: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateDBAASMysqlDatabase: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -6481,7 +6412,7 @@ func (c Client) DeleteDBAASMysqlDatabase(ctx context.Context, serviceName string
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteDBAASMysqlDatabase: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteDBAASMysqlDatabase: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -6497,7 +6428,7 @@ func (c Client) CreateDBAASMysqlUser(ctx context.Context, serviceName string, re
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateDBAASMysqlUser: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateDBAASMysqlUser: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -6536,7 +6467,7 @@ func (c Client) CreateDBAASMysqlUser(ctx context.Context, serviceName string, re
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateDBAASMysqlUser: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateDBAASMysqlUser: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -6579,7 +6510,7 @@ func (c Client) DeleteDBAASMysqlUser(ctx context.Context, serviceName string, us
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteDBAASMysqlUser: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteDBAASMysqlUser: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -6596,7 +6527,7 @@ func (c Client) ResetDBAASMysqlUserPassword(ctx context.Context, serviceName str
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("ResetDBAASMysqlUserPassword: prepare Json body: %w", err)
+		return nil, fmt.Errorf("ResetDBAASMysqlUserPassword: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -6635,7 +6566,7 @@ func (c Client) ResetDBAASMysqlUserPassword(ctx context.Context, serviceName str
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ResetDBAASMysqlUserPassword: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ResetDBAASMysqlUserPassword: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -6678,7 +6609,7 @@ func (c Client) RevealDBAASMysqlUserPassword(ctx context.Context, serviceName st
 
 	bodyresp := new(DBAASUserMysqlSecrets)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("RevealDBAASMysqlUserPassword: prepare Json response: %w", err)
+		return nil, fmt.Errorf("RevealDBAASMysqlUserPassword: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -6721,7 +6652,7 @@ func (c Client) DeleteDBAASServiceOpensearch(ctx context.Context, name string) (
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteDBAASServiceOpensearch: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteDBAASServiceOpensearch: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -6765,7 +6696,7 @@ func (c Client) GetDBAASServiceOpensearch(ctx context.Context, name string) (*DB
 
 	bodyresp := new(DBAASServiceOpensearch)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDBAASServiceOpensearch: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDBAASServiceOpensearch: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -6862,7 +6793,7 @@ func (c Client) CreateDBAASServiceOpensearch(ctx context.Context, name string, r
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateDBAASServiceOpensearch: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateDBAASServiceOpensearch: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -6901,7 +6832,7 @@ func (c Client) CreateDBAASServiceOpensearch(ctx context.Context, name string, r
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateDBAASServiceOpensearch: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateDBAASServiceOpensearch: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -6995,7 +6926,7 @@ func (c Client) UpdateDBAASServiceOpensearch(ctx context.Context, name string, r
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateDBAASServiceOpensearch: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASServiceOpensearch: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -7034,7 +6965,7 @@ func (c Client) UpdateDBAASServiceOpensearch(ctx context.Context, name string, r
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateDBAASServiceOpensearch: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASServiceOpensearch: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -7077,7 +7008,7 @@ func (c Client) GetDBAASOpensearchAclConfig(ctx context.Context, name string) (*
 
 	bodyresp := new(DBAASOpensearchAclConfig)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDBAASOpensearchAclConfig: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDBAASOpensearchAclConfig: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -7088,7 +7019,7 @@ func (c Client) UpdateDBAASOpensearchAclConfig(ctx context.Context, name string,
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateDBAASOpensearchAclConfig: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASOpensearchAclConfig: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -7127,7 +7058,7 @@ func (c Client) UpdateDBAASOpensearchAclConfig(ctx context.Context, name string,
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateDBAASOpensearchAclConfig: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASOpensearchAclConfig: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -7170,7 +7101,7 @@ func (c Client) StartDBAASOpensearchMaintenance(ctx context.Context, name string
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("StartDBAASOpensearchMaintenance: prepare Json response: %w", err)
+		return nil, fmt.Errorf("StartDBAASOpensearchMaintenance: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -7185,7 +7116,7 @@ func (c Client) CreateDBAASOpensearchUser(ctx context.Context, serviceName strin
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateDBAASOpensearchUser: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateDBAASOpensearchUser: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -7224,7 +7155,7 @@ func (c Client) CreateDBAASOpensearchUser(ctx context.Context, serviceName strin
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateDBAASOpensearchUser: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateDBAASOpensearchUser: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -7267,7 +7198,7 @@ func (c Client) DeleteDBAASOpensearchUser(ctx context.Context, serviceName strin
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteDBAASOpensearchUser: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteDBAASOpensearchUser: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -7283,7 +7214,7 @@ func (c Client) ResetDBAASOpensearchUserPassword(ctx context.Context, serviceNam
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("ResetDBAASOpensearchUserPassword: prepare Json body: %w", err)
+		return nil, fmt.Errorf("ResetDBAASOpensearchUserPassword: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -7322,7 +7253,7 @@ func (c Client) ResetDBAASOpensearchUserPassword(ctx context.Context, serviceNam
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ResetDBAASOpensearchUserPassword: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ResetDBAASOpensearchUserPassword: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -7365,7 +7296,7 @@ func (c Client) RevealDBAASOpensearchUserPassword(ctx context.Context, serviceNa
 
 	bodyresp := new(DBAASUserOpensearchSecrets)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("RevealDBAASOpensearchUserPassword: prepare Json response: %w", err)
+		return nil, fmt.Errorf("RevealDBAASOpensearchUserPassword: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -7408,7 +7339,7 @@ func (c Client) DeleteDBAASServicePG(ctx context.Context, name string) (*Operati
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteDBAASServicePG: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteDBAASServicePG: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -7452,7 +7383,7 @@ func (c Client) GetDBAASServicePG(ctx context.Context, name string) (*DBAASServi
 
 	bodyresp := new(DBAASServicePG)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDBAASServicePG: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDBAASServicePG: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -7565,7 +7496,7 @@ func (c Client) CreateDBAASServicePG(ctx context.Context, name string, req Creat
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateDBAASServicePG: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateDBAASServicePG: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -7604,7 +7535,7 @@ func (c Client) CreateDBAASServicePG(ctx context.Context, name string, req Creat
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateDBAASServicePG: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateDBAASServicePG: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -7695,7 +7626,7 @@ func (c Client) UpdateDBAASServicePG(ctx context.Context, name string, req Updat
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateDBAASServicePG: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASServicePG: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -7734,7 +7665,7 @@ func (c Client) UpdateDBAASServicePG(ctx context.Context, name string, req Updat
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateDBAASServicePG: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASServicePG: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -7777,7 +7708,7 @@ func (c Client) StartDBAASPGMaintenance(ctx context.Context, name string) (*Oper
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("StartDBAASPGMaintenance: prepare Json response: %w", err)
+		return nil, fmt.Errorf("StartDBAASPGMaintenance: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -7820,7 +7751,7 @@ func (c Client) StopDBAASPGMigration(ctx context.Context, name string) (*Operati
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("StopDBAASPGMigration: prepare Json response: %w", err)
+		return nil, fmt.Errorf("StopDBAASPGMigration: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -7840,7 +7771,7 @@ func (c Client) CreateDBAASPGConnectionPool(ctx context.Context, serviceName str
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateDBAASPGConnectionPool: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateDBAASPGConnectionPool: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -7879,7 +7810,7 @@ func (c Client) CreateDBAASPGConnectionPool(ctx context.Context, serviceName str
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateDBAASPGConnectionPool: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateDBAASPGConnectionPool: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -7923,7 +7854,7 @@ func (c Client) DeleteDBAASPGConnectionPool(ctx context.Context, serviceName str
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteDBAASPGConnectionPool: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteDBAASPGConnectionPool: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -7942,7 +7873,7 @@ func (c Client) UpdateDBAASPGConnectionPool(ctx context.Context, serviceName str
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateDBAASPGConnectionPool: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASPGConnectionPool: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -7981,7 +7912,7 @@ func (c Client) UpdateDBAASPGConnectionPool(ctx context.Context, serviceName str
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateDBAASPGConnectionPool: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASPGConnectionPool: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -8000,7 +7931,7 @@ func (c Client) CreateDBAASPGDatabase(ctx context.Context, serviceName string, r
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateDBAASPGDatabase: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateDBAASPGDatabase: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -8039,7 +7970,7 @@ func (c Client) CreateDBAASPGDatabase(ctx context.Context, serviceName string, r
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateDBAASPGDatabase: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateDBAASPGDatabase: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -8082,7 +8013,7 @@ func (c Client) DeleteDBAASPGDatabase(ctx context.Context, serviceName string, d
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteDBAASPGDatabase: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteDBAASPGDatabase: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -8098,7 +8029,7 @@ func (c Client) CreateDBAASPostgresUser(ctx context.Context, serviceName string,
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateDBAASPostgresUser: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateDBAASPostgresUser: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -8137,7 +8068,7 @@ func (c Client) CreateDBAASPostgresUser(ctx context.Context, serviceName string,
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateDBAASPostgresUser: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateDBAASPostgresUser: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -8180,7 +8111,7 @@ func (c Client) DeleteDBAASPostgresUser(ctx context.Context, serviceName string,
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteDBAASPostgresUser: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteDBAASPostgresUser: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -8195,7 +8126,7 @@ func (c Client) UpdateDBAASPostgresAllowReplication(ctx context.Context, service
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateDBAASPostgresAllowReplication: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASPostgresAllowReplication: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -8234,7 +8165,7 @@ func (c Client) UpdateDBAASPostgresAllowReplication(ctx context.Context, service
 
 	bodyresp := new(DBAASPostgresUsers)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateDBAASPostgresAllowReplication: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASPostgresAllowReplication: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -8250,7 +8181,7 @@ func (c Client) ResetDBAASPostgresUserPassword(ctx context.Context, serviceName 
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("ResetDBAASPostgresUserPassword: prepare Json body: %w", err)
+		return nil, fmt.Errorf("ResetDBAASPostgresUserPassword: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -8289,7 +8220,7 @@ func (c Client) ResetDBAASPostgresUserPassword(ctx context.Context, serviceName 
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ResetDBAASPostgresUserPassword: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ResetDBAASPostgresUserPassword: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -8332,7 +8263,7 @@ func (c Client) RevealDBAASPostgresUserPassword(ctx context.Context, serviceName
 
 	bodyresp := new(DBAASUserPostgresSecrets)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("RevealDBAASPostgresUserPassword: prepare Json response: %w", err)
+		return nil, fmt.Errorf("RevealDBAASPostgresUserPassword: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -8348,7 +8279,7 @@ func (c Client) CreateDBAASPGUpgradeCheck(ctx context.Context, service string, r
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateDBAASPGUpgradeCheck: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateDBAASPGUpgradeCheck: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -8387,7 +8318,7 @@ func (c Client) CreateDBAASPGUpgradeCheck(ctx context.Context, service string, r
 
 	bodyresp := new(DBAASTask)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateDBAASPGUpgradeCheck: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateDBAASPGUpgradeCheck: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -8454,7 +8385,7 @@ func (c Client) ListDBAASServices(ctx context.Context) (*ListDBAASServicesRespon
 
 	bodyresp := new(ListDBAASServicesResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListDBAASServices: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListDBAASServices: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -8474,7 +8405,7 @@ func (c Client) GetDBAASServiceLogs(ctx context.Context, serviceName string, req
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("GetDBAASServiceLogs: prepare Json body: %w", err)
+		return nil, fmt.Errorf("GetDBAASServiceLogs: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -8513,7 +8444,7 @@ func (c Client) GetDBAASServiceLogs(ctx context.Context, serviceName string, req
 
 	bodyresp := new(DBAASServiceLogs)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDBAASServiceLogs: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDBAASServiceLogs: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -8544,7 +8475,7 @@ func (c Client) GetDBAASServiceMetrics(ctx context.Context, serviceName string, 
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("GetDBAASServiceMetrics: prepare Json body: %w", err)
+		return nil, fmt.Errorf("GetDBAASServiceMetrics: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -8583,7 +8514,7 @@ func (c Client) GetDBAASServiceMetrics(ctx context.Context, serviceName string, 
 
 	bodyresp := new(GetDBAASServiceMetricsResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDBAASServiceMetrics: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDBAASServiceMetrics: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -8650,7 +8581,7 @@ func (c Client) ListDBAASServiceTypes(ctx context.Context) (*ListDBAASServiceTyp
 
 	bodyresp := new(ListDBAASServiceTypesResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListDBAASServiceTypes: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListDBAASServiceTypes: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -8694,7 +8625,7 @@ func (c Client) GetDBAASServiceType(ctx context.Context, serviceTypeName string)
 
 	bodyresp := new(DBAASServiceType)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDBAASServiceType: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDBAASServiceType: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -8738,7 +8669,7 @@ func (c Client) DeleteDBAASService(ctx context.Context, name string) (*Operation
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteDBAASService: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteDBAASService: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -8798,7 +8729,7 @@ func (c Client) GetDBAASSettingsClickhouse(ctx context.Context) (*GetDBAASSettin
 
 	bodyresp := new(GetDBAASSettingsClickhouseResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDBAASSettingsClickhouse: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDBAASSettingsClickhouse: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -8859,7 +8790,7 @@ func (c Client) GetDBAASSettingsGrafana(ctx context.Context) (*GetDBAASSettingsG
 
 	bodyresp := new(GetDBAASSettingsGrafanaResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDBAASSettingsGrafana: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDBAASSettingsGrafana: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -8950,7 +8881,7 @@ func (c Client) GetDBAASSettingsKafka(ctx context.Context) (*GetDBAASSettingsKaf
 
 	bodyresp := new(GetDBAASSettingsKafkaResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDBAASSettingsKafka: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDBAASSettingsKafka: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -9011,7 +8942,7 @@ func (c Client) GetDBAASSettingsMysql(ctx context.Context) (*GetDBAASSettingsMys
 
 	bodyresp := new(GetDBAASSettingsMysqlResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDBAASSettingsMysql: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDBAASSettingsMysql: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -9072,7 +9003,7 @@ func (c Client) GetDBAASSettingsOpensearch(ctx context.Context) (*GetDBAASSettin
 
 	bodyresp := new(GetDBAASSettingsOpensearchResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDBAASSettingsOpensearch: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDBAASSettingsOpensearch: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -9163,7 +9094,7 @@ func (c Client) GetDBAASSettingsPG(ctx context.Context) (*GetDBAASSettingsPGResp
 
 	bodyresp := new(GetDBAASSettingsPGResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDBAASSettingsPG: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDBAASSettingsPG: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -9224,7 +9155,7 @@ func (c Client) GetDBAASSettingsThanos(ctx context.Context) (*GetDBAASSettingsTh
 
 	bodyresp := new(GetDBAASSettingsThanosResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDBAASSettingsThanos: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDBAASSettingsThanos: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -9285,7 +9216,7 @@ func (c Client) GetDBAASSettingsValkey(ctx context.Context) (*GetDBAASSettingsVa
 
 	bodyresp := new(GetDBAASSettingsValkeyResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDBAASSettingsValkey: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDBAASSettingsValkey: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -9305,7 +9236,7 @@ func (c Client) CreateDBAASTaskMigrationCheck(ctx context.Context, service strin
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateDBAASTaskMigrationCheck: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateDBAASTaskMigrationCheck: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -9344,7 +9275,7 @@ func (c Client) CreateDBAASTaskMigrationCheck(ctx context.Context, service strin
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateDBAASTaskMigrationCheck: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateDBAASTaskMigrationCheck: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -9388,7 +9319,7 @@ func (c Client) GetDBAASTask(ctx context.Context, service string, id UUID) (*DBA
 
 	bodyresp := new(DBAASTask)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDBAASTask: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDBAASTask: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -9431,7 +9362,7 @@ func (c Client) DeleteDBAASServiceThanos(ctx context.Context, name string) (*Ope
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteDBAASServiceThanos: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteDBAASServiceThanos: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -9475,7 +9406,7 @@ func (c Client) GetDBAASServiceThanos(ctx context.Context, name string) (*DBAASS
 
 	bodyresp := new(DBAASServiceThanos)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDBAASServiceThanos: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDBAASServiceThanos: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -9521,7 +9452,7 @@ func (c Client) CreateDBAASServiceThanos(ctx context.Context, name string, req C
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateDBAASServiceThanos: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateDBAASServiceThanos: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -9560,7 +9491,7 @@ func (c Client) CreateDBAASServiceThanos(ctx context.Context, name string, req C
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateDBAASServiceThanos: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateDBAASServiceThanos: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -9606,7 +9537,7 @@ func (c Client) UpdateDBAASServiceThanos(ctx context.Context, name string, req U
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateDBAASServiceThanos: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASServiceThanos: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -9645,7 +9576,7 @@ func (c Client) UpdateDBAASServiceThanos(ctx context.Context, name string, req U
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateDBAASServiceThanos: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASServiceThanos: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -9688,7 +9619,7 @@ func (c Client) StartDBAASThanosMaintenance(ctx context.Context, name string) (*
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("StartDBAASThanosMaintenance: prepare Json response: %w", err)
+		return nil, fmt.Errorf("StartDBAASThanosMaintenance: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -9731,7 +9662,7 @@ func (c Client) RevealDBAASThanosUserPassword(ctx context.Context, serviceName s
 
 	bodyresp := new(DBAASUserThanosSecrets)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("RevealDBAASThanosUserPassword: prepare Json response: %w", err)
+		return nil, fmt.Errorf("RevealDBAASThanosUserPassword: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -9774,7 +9705,7 @@ func (c Client) DeleteDBAASServiceValkey(ctx context.Context, name string) (*Ope
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteDBAASServiceValkey: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteDBAASServiceValkey: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -9818,7 +9749,7 @@ func (c Client) GetDBAASServiceValkey(ctx context.Context, name string) (*DBAASS
 
 	bodyresp := new(DBAASServiceValkey)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDBAASServiceValkey: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDBAASServiceValkey: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -9890,7 +9821,7 @@ func (c Client) CreateDBAASServiceValkey(ctx context.Context, name string, req C
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateDBAASServiceValkey: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateDBAASServiceValkey: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -9929,7 +9860,7 @@ func (c Client) CreateDBAASServiceValkey(ctx context.Context, name string, req C
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateDBAASServiceValkey: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateDBAASServiceValkey: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -9998,7 +9929,7 @@ func (c Client) UpdateDBAASServiceValkey(ctx context.Context, name string, req U
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateDBAASServiceValkey: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASServiceValkey: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -10037,7 +9968,7 @@ func (c Client) UpdateDBAASServiceValkey(ctx context.Context, name string, req U
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateDBAASServiceValkey: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASServiceValkey: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -10080,7 +10011,7 @@ func (c Client) StartDBAASValkeyMaintenance(ctx context.Context, name string) (*
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("StartDBAASValkeyMaintenance: prepare Json response: %w", err)
+		return nil, fmt.Errorf("StartDBAASValkeyMaintenance: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -10123,7 +10054,7 @@ func (c Client) StopDBAASValkeyMigration(ctx context.Context, name string) (*Ope
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("StopDBAASValkeyMigration: prepare Json response: %w", err)
+		return nil, fmt.Errorf("StopDBAASValkeyMigration: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -10166,7 +10097,7 @@ func (c Client) ListDBAASValkeyUsers(ctx context.Context, serviceName string) (*
 
 	bodyresp := new(DBAASValkeyUsers)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListDBAASValkeyUsers: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListDBAASValkeyUsers: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -10182,7 +10113,7 @@ func (c Client) CreateDBAASValkeyUser(ctx context.Context, serviceName string, r
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateDBAASValkeyUser: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateDBAASValkeyUser: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -10221,7 +10152,7 @@ func (c Client) CreateDBAASValkeyUser(ctx context.Context, serviceName string, r
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateDBAASValkeyUser: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateDBAASValkeyUser: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -10264,7 +10195,7 @@ func (c Client) DeleteDBAASValkeyUser(ctx context.Context, serviceName string, u
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteDBAASValkeyUser: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteDBAASValkeyUser: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -10279,7 +10210,7 @@ func (c Client) UpdateDBAASValkeyUserAccessControl(ctx context.Context, serviceN
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateDBAASValkeyUserAccessControl: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASValkeyUserAccessControl: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -10318,7 +10249,7 @@ func (c Client) UpdateDBAASValkeyUserAccessControl(ctx context.Context, serviceN
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateDBAASValkeyUserAccessControl: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASValkeyUserAccessControl: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -10334,7 +10265,7 @@ func (c Client) ResetDBAASValkeyUserPassword(ctx context.Context, serviceName st
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("ResetDBAASValkeyUserPassword: prepare Json body: %w", err)
+		return nil, fmt.Errorf("ResetDBAASValkeyUserPassword: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -10373,7 +10304,7 @@ func (c Client) ResetDBAASValkeyUserPassword(ctx context.Context, serviceName st
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ResetDBAASValkeyUserPassword: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ResetDBAASValkeyUserPassword: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -10416,7 +10347,7 @@ func (c Client) RevealDBAASValkeyUserPassword(ctx context.Context, serviceName s
 
 	bodyresp := new(DBAASUserValkeySecrets)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("RevealDBAASValkeyUserPassword: prepare Json response: %w", err)
+		return nil, fmt.Errorf("RevealDBAASValkeyUserPassword: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -10483,7 +10414,7 @@ func (c Client) ListDeployTargets(ctx context.Context) (*ListDeployTargetsRespon
 
 	bodyresp := new(ListDeployTargetsResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListDeployTargets: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListDeployTargets: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -10527,7 +10458,7 @@ func (c Client) GetDeployTarget(ctx context.Context, id UUID) (*DeployTarget, er
 
 	bodyresp := new(DeployTarget)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDeployTarget: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDeployTarget: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -10594,7 +10525,7 @@ func (c Client) ListDNSDomains(ctx context.Context) (*ListDNSDomainsResponse, er
 
 	bodyresp := new(ListDNSDomainsResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListDNSDomains: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListDNSDomains: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -10612,7 +10543,7 @@ func (c Client) CreateDNSDomain(ctx context.Context, req CreateDNSDomainRequest)
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateDNSDomain: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateDNSDomain: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -10651,7 +10582,7 @@ func (c Client) CreateDNSDomain(ctx context.Context, req CreateDNSDomainRequest)
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateDNSDomain: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateDNSDomain: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -10718,7 +10649,7 @@ func (c Client) ListDNSDomainRecords(ctx context.Context, domainID UUID) (*ListD
 
 	bodyresp := new(ListDNSDomainRecordsResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListDNSDomainRecords: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListDNSDomainRecords: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -10762,7 +10693,7 @@ func (c Client) CreateDNSDomainRecord(ctx context.Context, domainID UUID, req Cr
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateDNSDomainRecord: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateDNSDomainRecord: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -10801,7 +10732,7 @@ func (c Client) CreateDNSDomainRecord(ctx context.Context, domainID UUID, req Cr
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateDNSDomainRecord: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateDNSDomainRecord: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -10845,7 +10776,7 @@ func (c Client) DeleteDNSDomainRecord(ctx context.Context, domainID UUID, record
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteDNSDomainRecord: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteDNSDomainRecord: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -10889,7 +10820,7 @@ func (c Client) GetDNSDomainRecord(ctx context.Context, domainID UUID, recordID 
 
 	bodyresp := new(DNSDomainRecord)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDNSDomainRecord: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDNSDomainRecord: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -10912,7 +10843,7 @@ func (c Client) UpdateDNSDomainRecord(ctx context.Context, domainID UUID, record
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateDNSDomainRecord: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateDNSDomainRecord: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -10951,7 +10882,7 @@ func (c Client) UpdateDNSDomainRecord(ctx context.Context, domainID UUID, record
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateDNSDomainRecord: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateDNSDomainRecord: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -10995,7 +10926,7 @@ func (c Client) DeleteDNSDomain(ctx context.Context, id UUID) (*Operation, error
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteDNSDomain: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteDNSDomain: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -11039,7 +10970,7 @@ func (c Client) GetDNSDomain(ctx context.Context, id UUID) (*DNSDomain, error) {
 
 	bodyresp := new(DNSDomain)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDNSDomain: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDNSDomain: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -11087,7 +11018,7 @@ func (c Client) GetDNSDomainZoneFile(ctx context.Context, id UUID) (*GetDNSDomai
 
 	bodyresp := new(GetDNSDomainZoneFileResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDNSDomainZoneFile: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDNSDomainZoneFile: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -11154,7 +11085,7 @@ func (c Client) ListElasticIPS(ctx context.Context) (*ListElasticIPSResponse, er
 
 	bodyresp := new(ListElasticIPSResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListElasticIPS: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListElasticIPS: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -11183,7 +11114,7 @@ func (c Client) CreateElasticIP(ctx context.Context, req CreateElasticIPRequest)
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateElasticIP: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateElasticIP: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -11222,7 +11153,7 @@ func (c Client) CreateElasticIP(ctx context.Context, req CreateElasticIPRequest)
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateElasticIP: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateElasticIP: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -11266,7 +11197,7 @@ func (c Client) DeleteElasticIP(ctx context.Context, id UUID) (*Operation, error
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteElasticIP: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteElasticIP: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -11310,7 +11241,7 @@ func (c Client) GetElasticIP(ctx context.Context, id UUID) (*ElasticIP, error) {
 
 	bodyresp := new(ElasticIP)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetElasticIP: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetElasticIP: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -11330,7 +11261,7 @@ func (c Client) UpdateElasticIP(ctx context.Context, id UUID, req UpdateElasticI
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateElasticIP: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateElasticIP: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -11369,7 +11300,7 @@ func (c Client) UpdateElasticIP(ctx context.Context, id UUID, req UpdateElasticI
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateElasticIP: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateElasticIP: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -11419,7 +11350,7 @@ func (c Client) ResetElasticIPField(ctx context.Context, id UUID, field ResetEla
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ResetElasticIPField: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ResetElasticIPField: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -11436,7 +11367,7 @@ func (c Client) AttachInstanceToElasticIP(ctx context.Context, id UUID, req Atta
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("AttachInstanceToElasticIP: prepare Json body: %w", err)
+		return nil, fmt.Errorf("AttachInstanceToElasticIP: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -11475,7 +11406,7 @@ func (c Client) AttachInstanceToElasticIP(ctx context.Context, id UUID, req Atta
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("AttachInstanceToElasticIP: prepare Json response: %w", err)
+		return nil, fmt.Errorf("AttachInstanceToElasticIP: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -11492,7 +11423,7 @@ func (c Client) DetachInstanceFromElasticIP(ctx context.Context, id UUID, req De
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("DetachInstanceFromElasticIP: prepare Json body: %w", err)
+		return nil, fmt.Errorf("DetachInstanceFromElasticIP: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -11531,7 +11462,7 @@ func (c Client) DetachInstanceFromElasticIP(ctx context.Context, id UUID, req De
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DetachInstanceFromElasticIP: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DetachInstanceFromElasticIP: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -11575,7 +11506,137 @@ func (c Client) GetEnvImpact(ctx context.Context, period string) (*EnvImpactRepo
 
 	bodyresp := new(EnvImpactReport)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetEnvImpact: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetEnvImpact: prepare JSON response: %w", err)
+	}
+
+	return bodyresp, nil
+}
+
+type GetImpactEstimateResponseImpact map[string]ImpactValueWithUnit
+
+type GetImpactEstimateResponse struct {
+	// Map of SKUs to their different impact indicators
+	Impact map[string]GetImpactEstimateResponseImpact `json:"impact" validate:"required"`
+}
+
+type GetImpactEstimateRequest struct {
+	Metadata map[string]any `json:"metadata,omitempty"`
+	// Product SKU, e.g. compute:ch-gva-2:instance:standard:medium; can also include wildcards, e.g. compute:*:instance:standard:* for all standard instances in all zones
+	Sku string `json:"sku" validate:"required"`
+}
+
+// [BETA] Returns an estimate of the impact of a unit of usage of one or more products, e.g. the impact of using a standard medium instance for one hour in ch-gva-2
+func (c Client) GetImpactEstimate(ctx context.Context, req GetImpactEstimateRequest) (*GetImpactEstimateResponse, error) {
+	path := "/environmental-impact/estimate"
+
+	body, err := prepareJSONBody(req)
+	if err != nil {
+		return nil, fmt.Errorf("GetImpactEstimate: prepare JSON body: %w", err)
+	}
+
+	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
+	if err != nil {
+		return nil, fmt.Errorf("GetImpactEstimate: new request: %w", err)
+	}
+
+	request.Header.Add("User-Agent", c.getUserAgent())
+
+	request.Header.Add("Content-Type", "application/json")
+
+	if err := c.executeRequestInterceptors(ctx, request); err != nil {
+		return nil, fmt.Errorf("GetImpactEstimate: execute request editors: %w", err)
+	}
+
+	if err := c.signRequest(request); err != nil {
+		return nil, fmt.Errorf("GetImpactEstimate: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "get-impact-estimate")
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("GetImpactEstimate: http client do: %w", err)
+	}
+
+	if c.trace {
+		dumpResponse(response)
+	}
+
+	if err := handleHTTPErrorResp(response); err != nil {
+		return nil, fmt.Errorf("GetImpactEstimate: http response: %w", err)
+	}
+
+	bodyresp := new(GetImpactEstimateResponse)
+	if err := prepareJSONResponse(response, bodyresp); err != nil {
+		return nil, fmt.Errorf("GetImpactEstimate: prepare JSON response: %w", err)
+	}
+
+	return bodyresp, nil
+}
+
+type GetImpactReportOpt func(url.Values)
+
+func GetImpactReportWithFrom(from string) GetImpactReportOpt {
+	return func(q url.Values) {
+		q.Add("from", fmt.Sprint(from))
+	}
+}
+
+func GetImpactReportWithTo(to string) GetImpactReportOpt {
+	return func(q url.Values) {
+		q.Add("to", fmt.Sprint(to))
+	}
+}
+
+// [BETA] Returns a breakdown of the impact of your organization's usage over the given period
+func (c Client) GetImpactReport(ctx context.Context, opts ...GetImpactReportOpt) (*ImpactBreakdown, error) {
+	path := "/environmental-impact/report"
+
+	request, err := http.NewRequestWithContext(ctx, "GET", c.serverEndpoint+path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("GetImpactReport: new request: %w", err)
+	}
+
+	request.Header.Add("User-Agent", c.getUserAgent())
+
+	if len(opts) > 0 {
+		q := request.URL.Query()
+		for _, opt := range opts {
+			opt(q)
+		}
+		request.URL.RawQuery = q.Encode()
+	}
+
+	if err := c.executeRequestInterceptors(ctx, request); err != nil {
+		return nil, fmt.Errorf("GetImpactReport: execute request editors: %w", err)
+	}
+
+	if err := c.signRequest(request); err != nil {
+		return nil, fmt.Errorf("GetImpactReport: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "get-impact-report")
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("GetImpactReport: http client do: %w", err)
+	}
+
+	if c.trace {
+		dumpResponse(response)
+	}
+
+	if err := handleHTTPErrorResp(response); err != nil {
+		return nil, fmt.Errorf("GetImpactReport: http response: %w", err)
+	}
+
+	bodyresp := new(ImpactBreakdown)
+	if err := prepareJSONResponse(response, bodyresp); err != nil {
+		return nil, fmt.Errorf("GetImpactReport: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -11643,7 +11704,7 @@ func (c Client) ListEvents(ctx context.Context, opts ...ListEventsOpt) ([]Event,
 
 	bodyresp := []Event{}
 	if err := prepareJSONResponse(response, &bodyresp); err != nil {
-		return nil, fmt.Errorf("ListEvents: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListEvents: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -11687,7 +11748,7 @@ func (c Client) GetIAMOrganizationPolicy(ctx context.Context) (*IAMPolicy, error
 
 	bodyresp := new(IAMPolicy)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetIAMOrganizationPolicy: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetIAMOrganizationPolicy: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -11699,7 +11760,7 @@ func (c Client) UpdateIAMOrganizationPolicy(ctx context.Context, req IAMPolicy) 
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateIAMOrganizationPolicy: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateIAMOrganizationPolicy: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -11738,7 +11799,7 @@ func (c Client) UpdateIAMOrganizationPolicy(ctx context.Context, req IAMPolicy) 
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateIAMOrganizationPolicy: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateIAMOrganizationPolicy: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -11782,7 +11843,7 @@ func (c Client) ResetIAMOrganizationPolicy(ctx context.Context) (*Operation, err
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ResetIAMOrganizationPolicy: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ResetIAMOrganizationPolicy: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -11849,7 +11910,7 @@ func (c Client) ListIAMRoles(ctx context.Context) (*ListIAMRolesResponse, error)
 
 	bodyresp := new(ListIAMRolesResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListIAMRoles: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListIAMRoles: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -11879,7 +11940,7 @@ func (c Client) CreateIAMRole(ctx context.Context, req CreateIAMRoleRequest) (*O
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateIAMRole: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateIAMRole: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -11918,7 +11979,7 @@ func (c Client) CreateIAMRole(ctx context.Context, req CreateIAMRoleRequest) (*O
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateIAMRole: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateIAMRole: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -11962,7 +12023,7 @@ func (c Client) DeleteIAMRole(ctx context.Context, id UUID) (*Operation, error) 
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteIAMRole: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteIAMRole: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -12006,7 +12067,7 @@ func (c Client) GetIAMRole(ctx context.Context, id UUID) (*IAMRole, error) {
 
 	bodyresp := new(IAMRole)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetIAMRole: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetIAMRole: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -12030,7 +12091,7 @@ func (c Client) UpdateIAMRole(ctx context.Context, id UUID, req UpdateIAMRoleReq
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateIAMRole: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateIAMRole: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -12069,7 +12130,7 @@ func (c Client) UpdateIAMRole(ctx context.Context, id UUID, req UpdateIAMRoleReq
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateIAMRole: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateIAMRole: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -12085,6 +12146,8 @@ type AssumeIAMRoleResponse struct {
 }
 
 type AssumeIAMRoleRequest struct {
+	// Organization ID target of the assume role action
+	OrgID UUID `json:"org-id,omitempty"`
 	// TTL in seconds for the generated access key (cannot exceed the max TTL defined in the targeted assume role)
 	Ttl int64 `json:"ttl" validate:"required,gt=0"`
 }
@@ -12095,7 +12158,7 @@ func (c Client) AssumeIAMRole(ctx context.Context, id UUID, req AssumeIAMRoleReq
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("AssumeIAMRole: prepare Json body: %w", err)
+		return nil, fmt.Errorf("AssumeIAMRole: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -12134,7 +12197,7 @@ func (c Client) AssumeIAMRole(ctx context.Context, id UUID, req AssumeIAMRoleReq
 
 	bodyresp := new(AssumeIAMRoleResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("AssumeIAMRole: prepare Json response: %w", err)
+		return nil, fmt.Errorf("AssumeIAMRole: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -12146,7 +12209,7 @@ func (c Client) UpdateIAMRolePolicy(ctx context.Context, id UUID, req IAMPolicy)
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateIAMRolePolicy: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateIAMRolePolicy: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -12185,7 +12248,7 @@ func (c Client) UpdateIAMRolePolicy(ctx context.Context, id UUID, req IAMPolicy)
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateIAMRolePolicy: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateIAMRolePolicy: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -12333,7 +12396,7 @@ func (c Client) ListInstances(ctx context.Context, opts ...ListInstancesOpt) (*L
 
 	bodyresp := new(ListInstancesResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListInstances: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListInstances: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -12380,7 +12443,7 @@ func (c Client) CreateInstance(ctx context.Context, req CreateInstanceRequest) (
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateInstance: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateInstance: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -12419,7 +12482,7 @@ func (c Client) CreateInstance(ctx context.Context, req CreateInstanceRequest) (
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateInstance: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateInstance: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -12486,7 +12549,7 @@ func (c Client) ListInstancePools(ctx context.Context) (*ListInstancePoolsRespon
 
 	bodyresp := new(ListInstancePoolsResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListInstancePools: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListInstancePools: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -12548,7 +12611,7 @@ func (c Client) CreateInstancePool(ctx context.Context, req CreateInstancePoolRe
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateInstancePool: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateInstancePool: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -12587,7 +12650,7 @@ func (c Client) CreateInstancePool(ctx context.Context, req CreateInstancePoolRe
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateInstancePool: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateInstancePool: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -12631,7 +12694,7 @@ func (c Client) DeleteInstancePool(ctx context.Context, id UUID) (*Operation, er
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteInstancePool: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteInstancePool: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -12675,7 +12738,7 @@ func (c Client) GetInstancePool(ctx context.Context, id UUID) (*InstancePool, er
 
 	bodyresp := new(InstancePool)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetInstancePool: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetInstancePool: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -12734,7 +12797,7 @@ func (c Client) UpdateInstancePool(ctx context.Context, id UUID, req UpdateInsta
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateInstancePool: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateInstancePool: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -12773,7 +12836,7 @@ func (c Client) UpdateInstancePool(ctx context.Context, id UUID, req UpdateInsta
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateInstancePool: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateInstancePool: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -12832,7 +12895,7 @@ func (c Client) ResetInstancePoolField(ctx context.Context, id UUID, field Reset
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ResetInstancePoolField: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ResetInstancePoolField: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -12848,7 +12911,7 @@ func (c Client) EvictInstancePoolMembers(ctx context.Context, id UUID, req Evict
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("EvictInstancePoolMembers: prepare Json body: %w", err)
+		return nil, fmt.Errorf("EvictInstancePoolMembers: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -12887,7 +12950,7 @@ func (c Client) EvictInstancePoolMembers(ctx context.Context, id UUID, req Evict
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("EvictInstancePoolMembers: prepare Json response: %w", err)
+		return nil, fmt.Errorf("EvictInstancePoolMembers: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -12904,7 +12967,7 @@ func (c Client) ScaleInstancePool(ctx context.Context, id UUID, req ScaleInstanc
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("ScaleInstancePool: prepare Json body: %w", err)
+		return nil, fmt.Errorf("ScaleInstancePool: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -12943,7 +13006,7 @@ func (c Client) ScaleInstancePool(ctx context.Context, id UUID, req ScaleInstanc
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ScaleInstancePool: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ScaleInstancePool: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -13010,7 +13073,7 @@ func (c Client) ListInstanceTypes(ctx context.Context) (*ListInstanceTypesRespon
 
 	bodyresp := new(ListInstanceTypesResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListInstanceTypes: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListInstanceTypes: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -13054,7 +13117,7 @@ func (c Client) GetInstanceType(ctx context.Context, id UUID) (*InstanceType, er
 
 	bodyresp := new(InstanceType)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetInstanceType: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetInstanceType: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -13098,7 +13161,7 @@ func (c Client) DeleteInstance(ctx context.Context, id UUID) (*Operation, error)
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteInstance: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteInstance: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -13142,7 +13205,7 @@ func (c Client) GetInstance(ctx context.Context, id UUID) (*Instance, error) {
 
 	bodyresp := new(Instance)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetInstance: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetInstance: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -13165,7 +13228,7 @@ func (c Client) UpdateInstance(ctx context.Context, id UUID, req UpdateInstanceR
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateInstance: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateInstance: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -13204,7 +13267,7 @@ func (c Client) UpdateInstance(ctx context.Context, id UUID, req UpdateInstanceR
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateInstance: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateInstance: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -13254,7 +13317,7 @@ func (c Client) ResetInstanceField(ctx context.Context, id UUID, field ResetInst
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ResetInstanceField: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ResetInstanceField: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -13298,7 +13361,7 @@ func (c Client) AddInstanceProtection(ctx context.Context, id UUID) (*Operation,
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("AddInstanceProtection: prepare Json response: %w", err)
+		return nil, fmt.Errorf("AddInstanceProtection: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -13342,7 +13405,7 @@ func (c Client) CreateSnapshot(ctx context.Context, id UUID) (*Operation, error)
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateSnapshot: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateSnapshot: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -13386,7 +13449,7 @@ func (c Client) EnableTpm(ctx context.Context, id UUID) (*Operation, error) {
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("EnableTpm: prepare Json response: %w", err)
+		return nil, fmt.Errorf("EnableTpm: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -13434,7 +13497,7 @@ func (c Client) RevealInstancePassword(ctx context.Context, id UUID) (*InstanceP
 
 	bodyresp := new(InstancePassword)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("RevealInstancePassword: prepare Json response: %w", err)
+		return nil, fmt.Errorf("RevealInstancePassword: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -13478,7 +13541,7 @@ func (c Client) RebootInstance(ctx context.Context, id UUID) (*Operation, error)
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("RebootInstance: prepare Json response: %w", err)
+		return nil, fmt.Errorf("RebootInstance: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -13522,7 +13585,7 @@ func (c Client) RemoveInstanceProtection(ctx context.Context, id UUID) (*Operati
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("RemoveInstanceProtection: prepare Json response: %w", err)
+		return nil, fmt.Errorf("RemoveInstanceProtection: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -13541,7 +13604,7 @@ func (c Client) ResetInstance(ctx context.Context, id UUID, req ResetInstanceReq
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("ResetInstance: prepare Json body: %w", err)
+		return nil, fmt.Errorf("ResetInstance: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -13580,7 +13643,7 @@ func (c Client) ResetInstance(ctx context.Context, id UUID, req ResetInstanceReq
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ResetInstance: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ResetInstance: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -13624,7 +13687,7 @@ func (c Client) ResetInstancePassword(ctx context.Context, id UUID) (*Operation,
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ResetInstancePassword: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ResetInstancePassword: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -13641,7 +13704,7 @@ func (c Client) ResizeInstanceDisk(ctx context.Context, id UUID, req ResizeInsta
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("ResizeInstanceDisk: prepare Json body: %w", err)
+		return nil, fmt.Errorf("ResizeInstanceDisk: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -13680,7 +13743,7 @@ func (c Client) ResizeInstanceDisk(ctx context.Context, id UUID, req ResizeInsta
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ResizeInstanceDisk: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ResizeInstanceDisk: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -13697,7 +13760,7 @@ func (c Client) ScaleInstance(ctx context.Context, id UUID, req ScaleInstanceReq
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("ScaleInstance: prepare Json body: %w", err)
+		return nil, fmt.Errorf("ScaleInstance: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -13736,7 +13799,7 @@ func (c Client) ScaleInstance(ctx context.Context, id UUID, req ScaleInstanceReq
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ScaleInstance: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ScaleInstance: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -13760,7 +13823,7 @@ func (c Client) StartInstance(ctx context.Context, id UUID, req StartInstanceReq
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("StartInstance: prepare Json body: %w", err)
+		return nil, fmt.Errorf("StartInstance: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -13799,7 +13862,7 @@ func (c Client) StartInstance(ctx context.Context, id UUID, req StartInstanceReq
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("StartInstance: prepare Json response: %w", err)
+		return nil, fmt.Errorf("StartInstance: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -13843,7 +13906,7 @@ func (c Client) StopInstance(ctx context.Context, id UUID) (*Operation, error) {
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("StopInstance: prepare Json response: %w", err)
+		return nil, fmt.Errorf("StopInstance: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -13861,7 +13924,7 @@ func (c Client) RevertInstanceToSnapshot(ctx context.Context, instanceID UUID, r
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("RevertInstanceToSnapshot: prepare Json body: %w", err)
+		return nil, fmt.Errorf("RevertInstanceToSnapshot: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -13900,7 +13963,7 @@ func (c Client) RevertInstanceToSnapshot(ctx context.Context, instanceID UUID, r
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("RevertInstanceToSnapshot: prepare Json response: %w", err)
+		return nil, fmt.Errorf("RevertInstanceToSnapshot: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -13963,19 +14026,19 @@ func (c Client) ListKmsKeys(ctx context.Context) (*ListKmsKeysResponse, error) {
 
 	bodyresp := new(ListKmsKeysResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListKmsKeys: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListKmsKeys: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
 }
 
-// Create a customer-managed unique KMS Key in your organization. A KMS Key is a logical represention of a cryptographic key material. It also includes metadata such as a UUID, a name and its state.
+// Create a customer-managed unique KMS Key in your organization. A KMS Key is a logical representation of a cryptographic key material. It also includes metadata such as a UUID, a name and its state.
 func (c Client) CreateKmsKey(ctx context.Context, req CreateKmsKeyRequest) (*CreateKmsKeyResponse, error) {
 	path := "/kms-key"
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateKmsKey: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateKmsKey: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -14014,7 +14077,7 @@ func (c Client) CreateKmsKey(ctx context.Context, req CreateKmsKeyRequest) (*Cre
 
 	bodyresp := new(CreateKmsKeyResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateKmsKey: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateKmsKey: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -14058,7 +14121,7 @@ func (c Client) GetKmsKey(ctx context.Context, id UUID) (*GetKmsKeyResponse, err
 
 	bodyresp := new(GetKmsKeyResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetKmsKey: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetKmsKey: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -14102,7 +14165,7 @@ func (c Client) CancelKmsKeyDeletion(ctx context.Context, id UUID) (*SuccessResp
 
 	bodyresp := new(SuccessResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CancelKmsKeyDeletion: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CancelKmsKeyDeletion: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -14114,7 +14177,7 @@ func (c Client) Decrypt(ctx context.Context, id UUID, req DecryptRequest) (*Decr
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("Decrypt: prepare Json body: %w", err)
+		return nil, fmt.Errorf("Decrypt: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -14153,7 +14216,7 @@ func (c Client) Decrypt(ctx context.Context, id UUID, req DecryptRequest) (*Decr
 
 	bodyresp := new(DecryptResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("Decrypt: prepare Json response: %w", err)
+		return nil, fmt.Errorf("Decrypt: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -14197,7 +14260,7 @@ func (c Client) DisableKmsKey(ctx context.Context, id UUID) (*SuccessResponse, e
 
 	bodyresp := new(SuccessResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DisableKmsKey: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DisableKmsKey: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -14241,13 +14304,13 @@ func (c Client) DisableKmsKeyRotation(ctx context.Context, id UUID) (*DisableKms
 
 	bodyresp := new(DisableKmsKeyRotationResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DisableKmsKeyRotation: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DisableKmsKeyRotation: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
 }
 
-// Enables a KMS Key by setting its stated to "enabled". It restores the ability to fully use the KMS key for cryptographic operations and key lifecycle operations.
+// Enables a KMS Key by setting its state to "enabled". It restores the ability to fully use the KMS key for cryptographic operations and key lifecycle operations.
 func (c Client) EnableKmsKey(ctx context.Context, id UUID) (*SuccessResponse, error) {
 	path := fmt.Sprintf("/kms-key/%v/enable", id)
 
@@ -14285,7 +14348,7 @@ func (c Client) EnableKmsKey(ctx context.Context, id UUID) (*SuccessResponse, er
 
 	bodyresp := new(SuccessResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("EnableKmsKey: prepare Json response: %w", err)
+		return nil, fmt.Errorf("EnableKmsKey: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -14297,7 +14360,7 @@ func (c Client) EnableKmsKeyRotation(ctx context.Context, id UUID, req EnableKms
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("EnableKmsKeyRotation: prepare Json body: %w", err)
+		return nil, fmt.Errorf("EnableKmsKeyRotation: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -14336,7 +14399,7 @@ func (c Client) EnableKmsKeyRotation(ctx context.Context, id UUID, req EnableKms
 
 	bodyresp := new(EnableKmsKeyRotationResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("EnableKmsKeyRotation: prepare Json response: %w", err)
+		return nil, fmt.Errorf("EnableKmsKeyRotation: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -14348,7 +14411,7 @@ func (c Client) Encrypt(ctx context.Context, id UUID, req EncryptRequest) (*Encr
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("Encrypt: prepare Json body: %w", err)
+		return nil, fmt.Errorf("Encrypt: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -14387,7 +14450,7 @@ func (c Client) Encrypt(ctx context.Context, id UUID, req EncryptRequest) (*Encr
 
 	bodyresp := new(EncryptResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("Encrypt: prepare Json response: %w", err)
+		return nil, fmt.Errorf("Encrypt: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -14399,7 +14462,7 @@ func (c Client) GenerateDataKey(ctx context.Context, id UUID, req GenerateDataKe
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("GenerateDataKey: prepare Json body: %w", err)
+		return nil, fmt.Errorf("GenerateDataKey: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -14438,7 +14501,7 @@ func (c Client) GenerateDataKey(ctx context.Context, id UUID, req GenerateDataKe
 
 	bodyresp := new(GenerateDataKeyResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GenerateDataKey: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GenerateDataKey: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -14482,7 +14545,7 @@ func (c Client) ListKmsKeyRotations(ctx context.Context, id UUID) (*ListKmsKeyRo
 
 	bodyresp := new(ListKmsKeyRotationsResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListKmsKeyRotations: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListKmsKeyRotations: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -14494,7 +14557,7 @@ func (c Client) ReEncrypt(ctx context.Context, id UUID, req ReEncryptRequest) (*
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("ReEncrypt: prepare Json body: %w", err)
+		return nil, fmt.Errorf("ReEncrypt: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -14533,7 +14596,7 @@ func (c Client) ReEncrypt(ctx context.Context, id UUID, req ReEncryptRequest) (*
 
 	bodyresp := new(ReEncryptResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ReEncrypt: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ReEncrypt: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -14545,7 +14608,7 @@ func (c Client) ReplicateKmsKey(ctx context.Context, id UUID, req ReplicateKmsKe
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("ReplicateKmsKey: prepare Json body: %w", err)
+		return nil, fmt.Errorf("ReplicateKmsKey: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -14584,7 +14647,7 @@ func (c Client) ReplicateKmsKey(ctx context.Context, id UUID, req ReplicateKmsKe
 
 	bodyresp := new(SuccessResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ReplicateKmsKey: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ReplicateKmsKey: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -14628,7 +14691,7 @@ func (c Client) RotateKmsKey(ctx context.Context, id UUID) (*RotateKmsKeyRespons
 
 	bodyresp := new(RotateKmsKeyResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("RotateKmsKey: prepare Json response: %w", err)
+		return nil, fmt.Errorf("RotateKmsKey: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -14640,7 +14703,7 @@ func (c Client) ScheduleKmsKeyDeletion(ctx context.Context, id UUID, req Schedul
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("ScheduleKmsKeyDeletion: prepare Json body: %w", err)
+		return nil, fmt.Errorf("ScheduleKmsKeyDeletion: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -14679,7 +14742,7 @@ func (c Client) ScheduleKmsKeyDeletion(ctx context.Context, id UUID, req Schedul
 
 	bodyresp := new(ScheduleKmsKeyDeletionResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ScheduleKmsKeyDeletion: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ScheduleKmsKeyDeletion: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -14723,7 +14786,7 @@ func (c Client) GetLiveBalance(ctx context.Context) (*LiveBalance, error) {
 
 	bodyresp := new(LiveBalance)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetLiveBalance: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetLiveBalance: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -14790,7 +14853,7 @@ func (c Client) ListLoadBalancers(ctx context.Context) (*ListLoadBalancersRespon
 
 	bodyresp := new(ListLoadBalancersResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListLoadBalancers: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListLoadBalancers: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -14810,7 +14873,7 @@ func (c Client) CreateLoadBalancer(ctx context.Context, req CreateLoadBalancerRe
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateLoadBalancer: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateLoadBalancer: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -14849,7 +14912,7 @@ func (c Client) CreateLoadBalancer(ctx context.Context, req CreateLoadBalancerRe
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateLoadBalancer: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateLoadBalancer: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -14893,7 +14956,7 @@ func (c Client) DeleteLoadBalancer(ctx context.Context, id UUID) (*Operation, er
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteLoadBalancer: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteLoadBalancer: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -14937,7 +15000,7 @@ func (c Client) GetLoadBalancer(ctx context.Context, id UUID) (*LoadBalancer, er
 
 	bodyresp := new(LoadBalancer)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetLoadBalancer: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetLoadBalancer: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -14957,7 +15020,7 @@ func (c Client) UpdateLoadBalancer(ctx context.Context, id UUID, req UpdateLoadB
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateLoadBalancer: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateLoadBalancer: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -14996,7 +15059,7 @@ func (c Client) UpdateLoadBalancer(ctx context.Context, id UUID, req UpdateLoadB
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateLoadBalancer: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateLoadBalancer: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -15042,7 +15105,7 @@ func (c Client) AddServiceToLoadBalancer(ctx context.Context, id UUID, req AddSe
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("AddServiceToLoadBalancer: prepare Json body: %w", err)
+		return nil, fmt.Errorf("AddServiceToLoadBalancer: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -15081,7 +15144,7 @@ func (c Client) AddServiceToLoadBalancer(ctx context.Context, id UUID, req AddSe
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("AddServiceToLoadBalancer: prepare Json response: %w", err)
+		return nil, fmt.Errorf("AddServiceToLoadBalancer: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -15125,7 +15188,7 @@ func (c Client) DeleteLoadBalancerService(ctx context.Context, id UUID, serviceI
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteLoadBalancerService: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteLoadBalancerService: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -15169,7 +15232,7 @@ func (c Client) GetLoadBalancerService(ctx context.Context, id UUID, serviceID U
 
 	bodyresp := new(LoadBalancerService)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetLoadBalancerService: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetLoadBalancerService: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -15213,7 +15276,7 @@ func (c Client) UpdateLoadBalancerService(ctx context.Context, id UUID, serviceI
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateLoadBalancerService: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateLoadBalancerService: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -15252,7 +15315,7 @@ func (c Client) UpdateLoadBalancerService(ctx context.Context, id UUID, serviceI
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateLoadBalancerService: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateLoadBalancerService: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -15302,7 +15365,7 @@ func (c Client) ResetLoadBalancerServiceField(ctx context.Context, id UUID, serv
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ResetLoadBalancerServiceField: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ResetLoadBalancerServiceField: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -15353,7 +15416,7 @@ func (c Client) ResetLoadBalancerField(ctx context.Context, id UUID, field Reset
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ResetLoadBalancerField: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ResetLoadBalancerField: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -15397,7 +15460,7 @@ func (c Client) GetOperation(ctx context.Context, id UUID) (*Operation, error) {
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetOperation: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetOperation: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -15441,7 +15504,7 @@ func (c Client) GetOrganization(ctx context.Context) (*Organization, error) {
 
 	bodyresp := new(Organization)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetOrganization: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetOrganization: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -15508,7 +15571,7 @@ func (c Client) ListPrivateNetworks(ctx context.Context) (*ListPrivateNetworksRe
 
 	bodyresp := new(ListPrivateNetworksResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListPrivateNetworks: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListPrivateNetworks: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -15536,7 +15599,7 @@ func (c Client) CreatePrivateNetwork(ctx context.Context, req CreatePrivateNetwo
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreatePrivateNetwork: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreatePrivateNetwork: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -15575,7 +15638,7 @@ func (c Client) CreatePrivateNetwork(ctx context.Context, req CreatePrivateNetwo
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreatePrivateNetwork: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreatePrivateNetwork: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -15619,7 +15682,7 @@ func (c Client) DeletePrivateNetwork(ctx context.Context, id UUID) (*Operation, 
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeletePrivateNetwork: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeletePrivateNetwork: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -15663,7 +15726,7 @@ func (c Client) GetPrivateNetwork(ctx context.Context, id UUID) (*PrivateNetwork
 
 	bodyresp := new(PrivateNetwork)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetPrivateNetwork: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetPrivateNetwork: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -15691,7 +15754,7 @@ func (c Client) UpdatePrivateNetwork(ctx context.Context, id UUID, req UpdatePri
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdatePrivateNetwork: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdatePrivateNetwork: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -15730,7 +15793,7 @@ func (c Client) UpdatePrivateNetwork(ctx context.Context, id UUID, req UpdatePri
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdatePrivateNetwork: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdatePrivateNetwork: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -15780,7 +15843,7 @@ func (c Client) ResetPrivateNetworkField(ctx context.Context, id UUID, field Res
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ResetPrivateNetworkField: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ResetPrivateNetworkField: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -15805,7 +15868,7 @@ func (c Client) AttachInstanceToPrivateNetwork(ctx context.Context, id UUID, req
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("AttachInstanceToPrivateNetwork: prepare Json body: %w", err)
+		return nil, fmt.Errorf("AttachInstanceToPrivateNetwork: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -15844,7 +15907,7 @@ func (c Client) AttachInstanceToPrivateNetwork(ctx context.Context, id UUID, req
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("AttachInstanceToPrivateNetwork: prepare Json response: %w", err)
+		return nil, fmt.Errorf("AttachInstanceToPrivateNetwork: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -15861,7 +15924,7 @@ func (c Client) DetachInstanceFromPrivateNetwork(ctx context.Context, id UUID, r
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("DetachInstanceFromPrivateNetwork: prepare Json body: %w", err)
+		return nil, fmt.Errorf("DetachInstanceFromPrivateNetwork: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -15900,7 +15963,7 @@ func (c Client) DetachInstanceFromPrivateNetwork(ctx context.Context, id UUID, r
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DetachInstanceFromPrivateNetwork: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DetachInstanceFromPrivateNetwork: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -15923,7 +15986,7 @@ func (c Client) UpdatePrivateNetworkInstanceIP(ctx context.Context, id UUID, req
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdatePrivateNetworkInstanceIP: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdatePrivateNetworkInstanceIP: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -15962,7 +16025,7 @@ func (c Client) UpdatePrivateNetworkInstanceIP(ctx context.Context, id UUID, req
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdatePrivateNetworkInstanceIP: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdatePrivateNetworkInstanceIP: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -16010,7 +16073,7 @@ func (c Client) ListQuotas(ctx context.Context) (*ListQuotasResponse, error) {
 
 	bodyresp := new(ListQuotasResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListQuotas: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListQuotas: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -16054,7 +16117,7 @@ func (c Client) GetQuota(ctx context.Context, entity string) (*Quota, error) {
 
 	bodyresp := new(Quota)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetQuota: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetQuota: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -16098,7 +16161,7 @@ func (c Client) DeleteReverseDNSElasticIP(ctx context.Context, id UUID) (*Operat
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteReverseDNSElasticIP: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteReverseDNSElasticIP: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -16142,7 +16205,7 @@ func (c Client) GetReverseDNSElasticIP(ctx context.Context, id UUID) (*ReverseDN
 
 	bodyresp := new(ReverseDNSRecord)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetReverseDNSElasticIP: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetReverseDNSElasticIP: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -16158,7 +16221,7 @@ func (c Client) UpdateReverseDNSElasticIP(ctx context.Context, id UUID, req Upda
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateReverseDNSElasticIP: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateReverseDNSElasticIP: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -16197,7 +16260,7 @@ func (c Client) UpdateReverseDNSElasticIP(ctx context.Context, id UUID, req Upda
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateReverseDNSElasticIP: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateReverseDNSElasticIP: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -16241,7 +16304,7 @@ func (c Client) DeleteReverseDNSInstance(ctx context.Context, id UUID) (*Operati
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteReverseDNSInstance: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteReverseDNSInstance: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -16285,7 +16348,7 @@ func (c Client) GetReverseDNSInstance(ctx context.Context, id UUID) (*ReverseDNS
 
 	bodyresp := new(ReverseDNSRecord)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetReverseDNSInstance: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetReverseDNSInstance: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -16301,7 +16364,7 @@ func (c Client) UpdateReverseDNSInstance(ctx context.Context, id UUID, req Updat
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateReverseDNSInstance: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateReverseDNSInstance: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -16340,7 +16403,7 @@ func (c Client) UpdateReverseDNSInstance(ctx context.Context, id UUID, req Updat
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateReverseDNSInstance: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateReverseDNSInstance: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -16433,7 +16496,7 @@ func (c Client) ListSecurityGroups(ctx context.Context, opts ...ListSecurityGrou
 
 	bodyresp := new(ListSecurityGroupsResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListSecurityGroups: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListSecurityGroups: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -16452,7 +16515,7 @@ func (c Client) CreateSecurityGroup(ctx context.Context, req CreateSecurityGroup
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateSecurityGroup: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateSecurityGroup: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -16491,7 +16554,7 @@ func (c Client) CreateSecurityGroup(ctx context.Context, req CreateSecurityGroup
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateSecurityGroup: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateSecurityGroup: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -16535,7 +16598,7 @@ func (c Client) DeleteSecurityGroup(ctx context.Context, id UUID) (*Operation, e
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteSecurityGroup: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteSecurityGroup: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -16579,7 +16642,7 @@ func (c Client) GetSecurityGroup(ctx context.Context, id UUID) (*SecurityGroup, 
 
 	bodyresp := new(SecurityGroup)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetSecurityGroup: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetSecurityGroup: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -16603,6 +16666,7 @@ type AddRuleToSecurityGroupRequestProtocol string
 const (
 	AddRuleToSecurityGroupRequestProtocolTCP    AddRuleToSecurityGroupRequestProtocol = "tcp"
 	AddRuleToSecurityGroupRequestProtocolEsp    AddRuleToSecurityGroupRequestProtocol = "esp"
+	AddRuleToSecurityGroupRequestProtocolAll    AddRuleToSecurityGroupRequestProtocol = "all"
 	AddRuleToSecurityGroupRequestProtocolICMP   AddRuleToSecurityGroupRequestProtocol = "icmp"
 	AddRuleToSecurityGroupRequestProtocolUDP    AddRuleToSecurityGroupRequestProtocol = "udp"
 	AddRuleToSecurityGroupRequestProtocolGre    AddRuleToSecurityGroupRequestProtocol = "gre"
@@ -16636,7 +16700,7 @@ func (c Client) AddRuleToSecurityGroup(ctx context.Context, id UUID, req AddRule
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("AddRuleToSecurityGroup: prepare Json body: %w", err)
+		return nil, fmt.Errorf("AddRuleToSecurityGroup: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -16675,7 +16739,7 @@ func (c Client) AddRuleToSecurityGroup(ctx context.Context, id UUID, req AddRule
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("AddRuleToSecurityGroup: prepare Json response: %w", err)
+		return nil, fmt.Errorf("AddRuleToSecurityGroup: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -16719,7 +16783,7 @@ func (c Client) DeleteRuleFromSecurityGroup(ctx context.Context, id UUID, ruleID
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteRuleFromSecurityGroup: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteRuleFromSecurityGroup: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -16736,7 +16800,7 @@ func (c Client) AddExternalSourceToSecurityGroup(ctx context.Context, id UUID, r
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("AddExternalSourceToSecurityGroup: prepare Json body: %w", err)
+		return nil, fmt.Errorf("AddExternalSourceToSecurityGroup: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -16775,7 +16839,7 @@ func (c Client) AddExternalSourceToSecurityGroup(ctx context.Context, id UUID, r
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("AddExternalSourceToSecurityGroup: prepare Json response: %w", err)
+		return nil, fmt.Errorf("AddExternalSourceToSecurityGroup: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -16792,7 +16856,7 @@ func (c Client) AttachInstanceToSecurityGroup(ctx context.Context, id UUID, req 
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("AttachInstanceToSecurityGroup: prepare Json body: %w", err)
+		return nil, fmt.Errorf("AttachInstanceToSecurityGroup: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -16831,7 +16895,7 @@ func (c Client) AttachInstanceToSecurityGroup(ctx context.Context, id UUID, req 
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("AttachInstanceToSecurityGroup: prepare Json response: %w", err)
+		return nil, fmt.Errorf("AttachInstanceToSecurityGroup: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -16848,7 +16912,7 @@ func (c Client) DetachInstanceFromSecurityGroup(ctx context.Context, id UUID, re
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("DetachInstanceFromSecurityGroup: prepare Json body: %w", err)
+		return nil, fmt.Errorf("DetachInstanceFromSecurityGroup: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -16887,7 +16951,7 @@ func (c Client) DetachInstanceFromSecurityGroup(ctx context.Context, id UUID, re
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DetachInstanceFromSecurityGroup: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DetachInstanceFromSecurityGroup: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -16904,7 +16968,7 @@ func (c Client) RemoveExternalSourceFromSecurityGroup(ctx context.Context, id UU
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("RemoveExternalSourceFromSecurityGroup: prepare Json body: %w", err)
+		return nil, fmt.Errorf("RemoveExternalSourceFromSecurityGroup: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -16943,7 +17007,7 @@ func (c Client) RemoveExternalSourceFromSecurityGroup(ctx context.Context, id UU
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("RemoveExternalSourceFromSecurityGroup: prepare Json response: %w", err)
+		return nil, fmt.Errorf("RemoveExternalSourceFromSecurityGroup: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -17010,7 +17074,7 @@ func (c Client) ListSKSClusters(ctx context.Context) (*ListSKSClustersResponse, 
 
 	bodyresp := new(ListSKSClustersResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListSKSClusters: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListSKSClusters: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -17066,7 +17130,7 @@ func (c Client) CreateSKSCluster(ctx context.Context, req CreateSKSClusterReques
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateSKSCluster: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateSKSCluster: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -17105,7 +17169,7 @@ func (c Client) CreateSKSCluster(ctx context.Context, req CreateSKSClusterReques
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateSKSCluster: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateSKSCluster: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -17149,7 +17213,7 @@ func (c Client) ListSKSClusterDeprecatedResources(ctx context.Context, id UUID) 
 
 	bodyresp := []SKSClusterDeprecatedResource{}
 	if err := prepareJSONResponse(response, &bodyresp); err != nil {
-		return nil, fmt.Errorf("ListSKSClusterDeprecatedResources: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListSKSClusterDeprecatedResources: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -17165,7 +17229,7 @@ func (c Client) GenerateSKSClusterKubeconfig(ctx context.Context, id UUID, req S
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("GenerateSKSClusterKubeconfig: prepare Json body: %w", err)
+		return nil, fmt.Errorf("GenerateSKSClusterKubeconfig: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -17204,7 +17268,7 @@ func (c Client) GenerateSKSClusterKubeconfig(ctx context.Context, id UUID, req S
 
 	bodyresp := new(GenerateSKSClusterKubeconfigResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GenerateSKSClusterKubeconfig: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GenerateSKSClusterKubeconfig: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -17268,7 +17332,7 @@ func (c Client) ListSKSClusterVersions(ctx context.Context, opts ...ListSKSClust
 
 	bodyresp := new(ListSKSClusterVersionsResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListSKSClusterVersions: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListSKSClusterVersions: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -17312,7 +17376,7 @@ func (c Client) DeleteSKSCluster(ctx context.Context, id UUID) (*Operation, erro
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteSKSCluster: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteSKSCluster: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -17356,7 +17420,7 @@ func (c Client) GetSKSCluster(ctx context.Context, id UUID) (*SKSCluster, error)
 
 	bodyresp := new(SKSCluster)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetSKSCluster: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetSKSCluster: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -17388,7 +17452,7 @@ func (c Client) UpdateSKSCluster(ctx context.Context, id UUID, req UpdateSKSClus
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateSKSCluster: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateSKSCluster: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -17427,7 +17491,7 @@ func (c Client) UpdateSKSCluster(ctx context.Context, id UUID, req UpdateSKSClus
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateSKSCluster: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateSKSCluster: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -17483,7 +17547,7 @@ func (c Client) GetSKSClusterAuthorityCert(ctx context.Context, id UUID, authori
 
 	bodyresp := new(GetSKSClusterAuthorityCertResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetSKSClusterAuthorityCert: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetSKSClusterAuthorityCert: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -17531,7 +17595,7 @@ func (c Client) GenerateSKSKarpenterExoscaleNodeclass(ctx context.Context, id UU
 
 	bodyresp := new(GenerateSKSKarpenterExoscaleNodeclassResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GenerateSKSKarpenterExoscaleNodeclass: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GenerateSKSKarpenterExoscaleNodeclass: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -17579,7 +17643,7 @@ func (c Client) GenerateSKSKarpenterNodepool(ctx context.Context, id UUID) (*Gen
 
 	bodyresp := new(GenerateSKSKarpenterNodepoolResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GenerateSKSKarpenterNodepool: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GenerateSKSKarpenterNodepool: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -17625,7 +17689,7 @@ func (c Client) GetSKSClusterInspection(ctx context.Context, id UUID) (*GetSKSCl
 
 	bodyresp := new(GetSKSClusterInspectionResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetSKSClusterInspection: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetSKSClusterInspection: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -17654,7 +17718,9 @@ type CreateSKSNodepoolRequest struct {
 	// Instance type reference
 	InstanceType *InstanceType `json:"instance-type" validate:"required"`
 	// Kubelet image GC options
-	KubeletImageGC *KubeletImageGC   `json:"kubelet-image-gc,omitempty"`
+	KubeletImageGC *KubeletImageGC `json:"kubelet-image-gc,omitempty"`
+	// Maximum number of pods per node (kubelet setting)
+	KubeletMaxPods *int64            `json:"kubelet-max-pods,omitempty" validate:"omitempty,gte=1,lte=65535"`
 	Labels         SKSNodepoolLabels `json:"labels,omitempty"`
 	// Nodepool name, lowercase only
 	Name string `json:"name" validate:"required,gte=1,lte=255"`
@@ -17679,7 +17745,7 @@ func (c Client) CreateSKSNodepool(ctx context.Context, id UUID, req CreateSKSNod
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateSKSNodepool: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateSKSNodepool: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -17718,7 +17784,7 @@ func (c Client) CreateSKSNodepool(ctx context.Context, id UUID, req CreateSKSNod
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateSKSNodepool: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateSKSNodepool: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -17762,7 +17828,7 @@ func (c Client) DeleteSKSNodepool(ctx context.Context, id UUID, sksNodepoolID UU
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteSKSNodepool: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteSKSNodepool: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -17806,7 +17872,7 @@ func (c Client) GetSKSNodepool(ctx context.Context, id UUID, sksNodepoolID UUID)
 
 	bodyresp := new(SKSNodepool)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetSKSNodepool: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetSKSNodepool: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -17833,7 +17899,9 @@ type UpdateSKSNodepoolRequest struct {
 	// Instance type reference
 	InstanceType *InstanceType `json:"instance-type,omitempty"`
 	// Kubelet image GC options
-	KubeletImageGC *KubeletImageGC   `json:"kubelet-image-gc,omitempty"`
+	KubeletImageGC *KubeletImageGC `json:"kubelet-image-gc,omitempty"`
+	// Maximum number of pods per node (kubelet setting)
+	KubeletMaxPods *int64            `json:"kubelet-max-pods,omitempty" validate:"omitempty,gte=1,lte=65535"`
 	Labels         SKSNodepoolLabels `json:"labels,omitempty"`
 	// Nodepool name, lowercase only
 	Name string `json:"name,omitempty" validate:"omitempty,gte=1,lte=255"`
@@ -17856,7 +17924,7 @@ func (c Client) UpdateSKSNodepool(ctx context.Context, id UUID, sksNodepoolID UU
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateSKSNodepool: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateSKSNodepool: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -17895,7 +17963,7 @@ func (c Client) UpdateSKSNodepool(ctx context.Context, id UUID, sksNodepoolID UU
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateSKSNodepool: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateSKSNodepool: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -17911,7 +17979,7 @@ func (c Client) EvictSKSNodepoolMembers(ctx context.Context, id UUID, sksNodepoo
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("EvictSKSNodepoolMembers: prepare Json body: %w", err)
+		return nil, fmt.Errorf("EvictSKSNodepoolMembers: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -17950,7 +18018,7 @@ func (c Client) EvictSKSNodepoolMembers(ctx context.Context, id UUID, sksNodepoo
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("EvictSKSNodepoolMembers: prepare Json response: %w", err)
+		return nil, fmt.Errorf("EvictSKSNodepoolMembers: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -17967,7 +18035,7 @@ func (c Client) ScaleSKSNodepool(ctx context.Context, id UUID, sksNodepoolID UUI
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("ScaleSKSNodepool: prepare Json body: %w", err)
+		return nil, fmt.Errorf("ScaleSKSNodepool: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -18006,7 +18074,7 @@ func (c Client) ScaleSKSNodepool(ctx context.Context, id UUID, sksNodepoolID UUI
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ScaleSKSNodepool: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ScaleSKSNodepool: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -18050,7 +18118,7 @@ func (c Client) RotateSKSCcmCredentials(ctx context.Context, id UUID) (*Operatio
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("RotateSKSCcmCredentials: prepare Json response: %w", err)
+		return nil, fmt.Errorf("RotateSKSCcmCredentials: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -18094,7 +18162,7 @@ func (c Client) RotateSKSCsiCredentials(ctx context.Context, id UUID) (*Operatio
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("RotateSKSCsiCredentials: prepare Json response: %w", err)
+		return nil, fmt.Errorf("RotateSKSCsiCredentials: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -18138,7 +18206,7 @@ func (c Client) RotateSKSKarpenterCredentials(ctx context.Context, id UUID) (*Op
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("RotateSKSKarpenterCredentials: prepare Json response: %w", err)
+		return nil, fmt.Errorf("RotateSKSKarpenterCredentials: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -18182,7 +18250,7 @@ func (c Client) RotateSKSOperatorsCA(ctx context.Context, id UUID) (*Operation, 
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("RotateSKSOperatorsCA: prepare Json response: %w", err)
+		return nil, fmt.Errorf("RotateSKSOperatorsCA: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -18199,7 +18267,7 @@ func (c Client) UpgradeSKSCluster(ctx context.Context, id UUID, req UpgradeSKSCl
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpgradeSKSCluster: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpgradeSKSCluster: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -18238,7 +18306,7 @@ func (c Client) UpgradeSKSCluster(ctx context.Context, id UUID, req UpgradeSKSCl
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpgradeSKSCluster: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpgradeSKSCluster: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -18282,7 +18350,7 @@ func (c Client) UpgradeSKSClusterServiceLevel(ctx context.Context, id UUID) (*Op
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpgradeSKSClusterServiceLevel: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpgradeSKSClusterServiceLevel: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -18337,7 +18405,7 @@ func (c Client) GetActiveNodepoolTemplate(ctx context.Context, kubeVersion strin
 
 	bodyresp := new(GetActiveNodepoolTemplateResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetActiveNodepoolTemplate: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetActiveNodepoolTemplate: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -18404,7 +18472,7 @@ func (c Client) ListSnapshots(ctx context.Context) (*ListSnapshotsResponse, erro
 
 	bodyresp := new(ListSnapshotsResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListSnapshots: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListSnapshots: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -18448,7 +18516,7 @@ func (c Client) DeleteSnapshot(ctx context.Context, id UUID) (*Operation, error)
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteSnapshot: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteSnapshot: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -18492,7 +18560,7 @@ func (c Client) GetSnapshot(ctx context.Context, id UUID) (*Snapshot, error) {
 
 	bodyresp := new(Snapshot)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetSnapshot: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetSnapshot: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -18536,7 +18604,7 @@ func (c Client) ExportSnapshot(ctx context.Context, id UUID) (*Operation, error)
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ExportSnapshot: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ExportSnapshot: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -18561,7 +18629,7 @@ func (c Client) PromoteSnapshotToTemplate(ctx context.Context, id UUID, req Prom
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("PromoteSnapshotToTemplate: prepare Json body: %w", err)
+		return nil, fmt.Errorf("PromoteSnapshotToTemplate: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -18600,7 +18668,7 @@ func (c Client) PromoteSnapshotToTemplate(ctx context.Context, id UUID, req Prom
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("PromoteSnapshotToTemplate: prepare Json response: %w", err)
+		return nil, fmt.Errorf("PromoteSnapshotToTemplate: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -18667,7 +18735,7 @@ func (c Client) ListSOSBucketsUsage(ctx context.Context) (*ListSOSBucketsUsageRe
 
 	bodyresp := new(ListSOSBucketsUsageResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListSOSBucketsUsage: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListSOSBucketsUsage: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -18731,7 +18799,7 @@ func (c Client) GetSOSPresignedURL(ctx context.Context, bucket string, opts ...G
 
 	bodyresp := new(GetSOSPresignedURLResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetSOSPresignedURL: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetSOSPresignedURL: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -18798,7 +18866,7 @@ func (c Client) ListSSHKeys(ctx context.Context) (*ListSSHKeysResponse, error) {
 
 	bodyresp := new(ListSSHKeysResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListSSHKeys: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListSSHKeys: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -18817,7 +18885,7 @@ func (c Client) RegisterSSHKey(ctx context.Context, req RegisterSSHKeyRequest) (
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("RegisterSSHKey: prepare Json body: %w", err)
+		return nil, fmt.Errorf("RegisterSSHKey: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -18856,7 +18924,7 @@ func (c Client) RegisterSSHKey(ctx context.Context, req RegisterSSHKeyRequest) (
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("RegisterSSHKey: prepare Json response: %w", err)
+		return nil, fmt.Errorf("RegisterSSHKey: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -18900,7 +18968,7 @@ func (c Client) DeleteSSHKey(ctx context.Context, name string) (*Operation, erro
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteSSHKey: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteSSHKey: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -18944,7 +19012,7 @@ func (c Client) GetSSHKey(ctx context.Context, name string) (*SSHKey, error) {
 
 	bodyresp := new(SSHKey)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetSSHKey: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetSSHKey: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -19040,7 +19108,7 @@ func (c Client) ListTemplates(ctx context.Context, opts ...ListTemplatesOpt) (*L
 
 	bodyresp := new(ListTemplatesResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListTemplates: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListTemplates: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -19088,7 +19156,7 @@ func (c Client) RegisterTemplate(ctx context.Context, req RegisterTemplateReques
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("RegisterTemplate: prepare Json body: %w", err)
+		return nil, fmt.Errorf("RegisterTemplate: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -19127,7 +19195,7 @@ func (c Client) RegisterTemplate(ctx context.Context, req RegisterTemplateReques
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("RegisterTemplate: prepare Json response: %w", err)
+		return nil, fmt.Errorf("RegisterTemplate: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -19171,7 +19239,7 @@ func (c Client) DeleteTemplate(ctx context.Context, id UUID) (*Operation, error)
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteTemplate: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteTemplate: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -19215,7 +19283,7 @@ func (c Client) GetTemplate(ctx context.Context, id UUID) (*Template, error) {
 
 	bodyresp := new(Template)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetTemplate: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetTemplate: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -19232,7 +19300,7 @@ func (c Client) CopyTemplate(ctx context.Context, id UUID, req CopyTemplateReque
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CopyTemplate: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CopyTemplate: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -19271,7 +19339,7 @@ func (c Client) CopyTemplate(ctx context.Context, id UUID, req CopyTemplateReque
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CopyTemplate: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CopyTemplate: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -19290,7 +19358,7 @@ func (c Client) UpdateTemplate(ctx context.Context, id UUID, req UpdateTemplateR
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateTemplate: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateTemplate: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -19329,7 +19397,7 @@ func (c Client) UpdateTemplate(ctx context.Context, id UUID, req UpdateTemplateR
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateTemplate: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateTemplate: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -19411,7 +19479,7 @@ func (c Client) GetUsageReport(ctx context.Context, opts ...GetUsageReportOpt) (
 
 	bodyresp := new(GetUsageReportResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetUsageReport: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetUsageReport: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -19477,7 +19545,7 @@ func (c Client) ListUsers(ctx context.Context) (*ListUsersResponse, error) {
 
 	bodyresp := new(ListUsersResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListUsers: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListUsers: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -19495,7 +19563,7 @@ func (c Client) CreateUser(ctx context.Context, req CreateUserRequest) (*Operati
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateUser: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateUser: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -19534,7 +19602,7 @@ func (c Client) CreateUser(ctx context.Context, req CreateUserRequest) (*Operati
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateUser: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateUser: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -19577,7 +19645,7 @@ func (c Client) DeleteUser(ctx context.Context, id UUID) (*Operation, error) {
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteUser: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteUser: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -19593,7 +19661,7 @@ func (c Client) UpdateUserRole(ctx context.Context, id UUID, req UpdateUserRoleR
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateUserRole: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateUserRole: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -19632,7 +19700,7 @@ func (c Client) UpdateUserRole(ctx context.Context, id UUID, req UpdateUserRoleR
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateUserRole: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateUserRole: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -19699,7 +19767,7 @@ func (c Client) ListVpcs(ctx context.Context) (*ListVpcsResponse, error) {
 
 	bodyresp := new(ListVpcsResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListVpcs: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListVpcs: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -19719,7 +19787,7 @@ func (c Client) CreateVpc(ctx context.Context, req CreateVpcRequest) (*Operation
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateVpc: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateVpc: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -19758,29 +19826,29 @@ func (c Client) CreateVpc(ctx context.Context, req CreateVpcRequest) (*Operation
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateVpc: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateVpc: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
 }
 
 // [BETA] Delete a VPC
-func (c Client) DeleteVpc(ctx context.Context, id UUID) (*Empty, error) {
+func (c Client) DeleteVpc(ctx context.Context, id UUID) error {
 	path := fmt.Sprintf("/vpc/%v", id)
 
 	request, err := http.NewRequestWithContext(ctx, "DELETE", c.serverEndpoint+path, nil)
 	if err != nil {
-		return nil, fmt.Errorf("DeleteVpc: new request: %w", err)
+		return fmt.Errorf("DeleteVpc: new request: %w", err)
 	}
 
 	request.Header.Add("User-Agent", c.getUserAgent())
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
-		return nil, fmt.Errorf("DeleteVpc: execute request editors: %w", err)
+		return fmt.Errorf("DeleteVpc: execute request editors: %w", err)
 	}
 
 	if err := c.signRequest(request); err != nil {
-		return nil, fmt.Errorf("DeleteVpc: sign request: %w", err)
+		return fmt.Errorf("DeleteVpc: sign request: %w", err)
 	}
 
 	if c.trace {
@@ -19789,7 +19857,7 @@ func (c Client) DeleteVpc(ctx context.Context, id UUID) (*Empty, error) {
 
 	response, err := c.httpClient.Do(request)
 	if err != nil {
-		return nil, fmt.Errorf("DeleteVpc: http client do: %w", err)
+		return fmt.Errorf("DeleteVpc: http client do: %w", err)
 	}
 
 	if c.trace {
@@ -19797,15 +19865,11 @@ func (c Client) DeleteVpc(ctx context.Context, id UUID) (*Empty, error) {
 	}
 
 	if err := handleHTTPErrorResp(response); err != nil {
-		return nil, fmt.Errorf("DeleteVpc: http response: %w", err)
+		return fmt.Errorf("DeleteVpc: http response: %w", err)
 	}
 
-	bodyresp := new(Empty)
-	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteVpc: prepare Json response: %w", err)
-	}
-
-	return bodyresp, nil
+	_ = response.Body.Close()
+	return nil
 }
 
 // [BETA] Retrieve VPC details
@@ -19846,7 +19910,7 @@ func (c Client) GetVpc(ctx context.Context, id UUID) (*Vpc, error) {
 
 	bodyresp := new(Vpc)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetVpc: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetVpc: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -19866,7 +19930,7 @@ func (c Client) UpdateVpc(ctx context.Context, id UUID, req UpdateVpcRequest) (*
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateVpc: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateVpc: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -19905,7 +19969,7 @@ func (c Client) UpdateVpc(ctx context.Context, id UUID, req UpdateVpcRequest) (*
 
 	bodyresp := new(Vpc)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateVpc: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateVpc: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -19972,7 +20036,7 @@ func (c Client) ListVpcRoutes(ctx context.Context, vpcID UUID) (*ListVpcRoutesRe
 
 	bodyresp := new(ListVpcRoutesResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListVpcRoutes: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListVpcRoutes: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -20039,7 +20103,7 @@ func (c Client) ListSubnets(ctx context.Context, vpcID UUID) (*ListSubnetsRespon
 
 	bodyresp := new(ListSubnetsResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListSubnets: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListSubnets: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -20077,7 +20141,7 @@ func (c Client) CreateSubnet(ctx context.Context, vpcID UUID, req CreateSubnetRe
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateSubnet: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateSubnet: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -20116,29 +20180,29 @@ func (c Client) CreateSubnet(ctx context.Context, vpcID UUID, req CreateSubnetRe
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateSubnet: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateSubnet: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
 }
 
 // [BETA] Delete a Subnet
-func (c Client) DeleteSubnet(ctx context.Context, vpcID UUID, id UUID) (*Empty, error) {
+func (c Client) DeleteSubnet(ctx context.Context, vpcID UUID, id UUID) error {
 	path := fmt.Sprintf("/vpc/%v/subnet/%v", vpcID, id)
 
 	request, err := http.NewRequestWithContext(ctx, "DELETE", c.serverEndpoint+path, nil)
 	if err != nil {
-		return nil, fmt.Errorf("DeleteSubnet: new request: %w", err)
+		return fmt.Errorf("DeleteSubnet: new request: %w", err)
 	}
 
 	request.Header.Add("User-Agent", c.getUserAgent())
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
-		return nil, fmt.Errorf("DeleteSubnet: execute request editors: %w", err)
+		return fmt.Errorf("DeleteSubnet: execute request editors: %w", err)
 	}
 
 	if err := c.signRequest(request); err != nil {
-		return nil, fmt.Errorf("DeleteSubnet: sign request: %w", err)
+		return fmt.Errorf("DeleteSubnet: sign request: %w", err)
 	}
 
 	if c.trace {
@@ -20147,7 +20211,7 @@ func (c Client) DeleteSubnet(ctx context.Context, vpcID UUID, id UUID) (*Empty, 
 
 	response, err := c.httpClient.Do(request)
 	if err != nil {
-		return nil, fmt.Errorf("DeleteSubnet: http client do: %w", err)
+		return fmt.Errorf("DeleteSubnet: http client do: %w", err)
 	}
 
 	if c.trace {
@@ -20155,15 +20219,11 @@ func (c Client) DeleteSubnet(ctx context.Context, vpcID UUID, id UUID) (*Empty, 
 	}
 
 	if err := handleHTTPErrorResp(response); err != nil {
-		return nil, fmt.Errorf("DeleteSubnet: http response: %w", err)
+		return fmt.Errorf("DeleteSubnet: http response: %w", err)
 	}
 
-	bodyresp := new(Empty)
-	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteSubnet: prepare Json response: %w", err)
-	}
-
-	return bodyresp, nil
+	_ = response.Body.Close()
+	return nil
 }
 
 // [BETA] Retrieve Subnet details
@@ -20204,7 +20264,7 @@ func (c Client) GetSubnet(ctx context.Context, vpcID UUID, id UUID) (*Subnet, er
 
 	bodyresp := new(Subnet)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetSubnet: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetSubnet: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -20213,9 +20273,7 @@ func (c Client) GetSubnet(ctx context.Context, vpcID UUID, id UUID) (*Subnet, er
 type UpdateSubnetRequest struct {
 	// Subnet description
 	Description *string `json:"description,omitempty" validate:"omitempty,lte=4096"`
-	// Subnet CIDR
-	Ipv4Block *string `json:"ipv4-block,omitempty"`
-	Labels    Labels  `json:"labels"`
+	Labels      Labels  `json:"labels"`
 	// Subnet name
 	Name *string `json:"name,omitempty" validate:"omitempty,gte=1,lte=255"`
 }
@@ -20226,7 +20284,7 @@ func (c Client) UpdateSubnet(ctx context.Context, vpcID UUID, id UUID, req Updat
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateSubnet: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateSubnet: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -20265,7 +20323,7 @@ func (c Client) UpdateSubnet(ctx context.Context, vpcID UUID, id UUID, req Updat
 
 	bodyresp := new(Subnet)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateSubnet: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateSubnet: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -20274,6 +20332,8 @@ func (c Client) UpdateSubnet(ctx context.Context, vpcID UUID, id UUID, req Updat
 type AttachInstanceToSubnetRequest struct {
 	// Target Instance
 	Instance *InstanceRef `json:"instance" validate:"required"`
+	// Instance IPv4
+	Ipv4 net.IP `json:"ipv4,omitempty"`
 }
 
 // [BETA] Attach a Compute instance to a Subnet
@@ -20282,7 +20342,7 @@ func (c Client) AttachInstanceToSubnet(ctx context.Context, vpcID UUID, subnetID
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("AttachInstanceToSubnet: prepare Json body: %w", err)
+		return nil, fmt.Errorf("AttachInstanceToSubnet: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -20321,7 +20381,7 @@ func (c Client) AttachInstanceToSubnet(ctx context.Context, vpcID UUID, subnetID
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("AttachInstanceToSubnet: prepare Json response: %w", err)
+		return nil, fmt.Errorf("AttachInstanceToSubnet: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -20338,7 +20398,7 @@ func (c Client) DetachInstanceFromSubnet(ctx context.Context, vpcID UUID, subnet
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("DetachInstanceFromSubnet: prepare Json body: %w", err)
+		return nil, fmt.Errorf("DetachInstanceFromSubnet: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -20377,7 +20437,7 @@ func (c Client) DetachInstanceFromSubnet(ctx context.Context, vpcID UUID, subnet
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DetachInstanceFromSubnet: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DetachInstanceFromSubnet: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -20444,7 +20504,7 @@ func (c Client) ListRoutes(ctx context.Context, vpcID UUID, subnetID UUID) (*Lis
 
 	bodyresp := new(ListRoutesResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListRoutes: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListRoutes: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -20465,7 +20525,7 @@ func (c Client) CreateRoute(ctx context.Context, vpcID UUID, subnetID UUID, req 
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateRoute: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateRoute: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -20504,29 +20564,29 @@ func (c Client) CreateRoute(ctx context.Context, vpcID UUID, subnetID UUID, req 
 
 	bodyresp := new(Route)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateRoute: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateRoute: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
 }
 
 // [BETA] Delete a route
-func (c Client) DeleteRoute(ctx context.Context, vpcID UUID, subnetID UUID, id UUID) (*Empty, error) {
+func (c Client) DeleteRoute(ctx context.Context, vpcID UUID, subnetID UUID, id UUID) error {
 	path := fmt.Sprintf("/vpc/%v/subnet/%v/route/%v", vpcID, subnetID, id)
 
 	request, err := http.NewRequestWithContext(ctx, "DELETE", c.serverEndpoint+path, nil)
 	if err != nil {
-		return nil, fmt.Errorf("DeleteRoute: new request: %w", err)
+		return fmt.Errorf("DeleteRoute: new request: %w", err)
 	}
 
 	request.Header.Add("User-Agent", c.getUserAgent())
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
-		return nil, fmt.Errorf("DeleteRoute: execute request editors: %w", err)
+		return fmt.Errorf("DeleteRoute: execute request editors: %w", err)
 	}
 
 	if err := c.signRequest(request); err != nil {
-		return nil, fmt.Errorf("DeleteRoute: sign request: %w", err)
+		return fmt.Errorf("DeleteRoute: sign request: %w", err)
 	}
 
 	if c.trace {
@@ -20535,7 +20595,7 @@ func (c Client) DeleteRoute(ctx context.Context, vpcID UUID, subnetID UUID, id U
 
 	response, err := c.httpClient.Do(request)
 	if err != nil {
-		return nil, fmt.Errorf("DeleteRoute: http client do: %w", err)
+		return fmt.Errorf("DeleteRoute: http client do: %w", err)
 	}
 
 	if c.trace {
@@ -20543,15 +20603,11 @@ func (c Client) DeleteRoute(ctx context.Context, vpcID UUID, subnetID UUID, id U
 	}
 
 	if err := handleHTTPErrorResp(response); err != nil {
-		return nil, fmt.Errorf("DeleteRoute: http response: %w", err)
+		return fmt.Errorf("DeleteRoute: http response: %w", err)
 	}
 
-	bodyresp := new(Empty)
-	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteRoute: prepare Json response: %w", err)
-	}
-
-	return bodyresp, nil
+	_ = response.Body.Close()
+	return nil
 }
 
 type ListZonesResponse struct {
@@ -20611,7 +20667,7 @@ func (c Client) ListZones(ctx context.Context) (*ListZonesResponse, error) {
 
 	bodyresp := new(ListZonesResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListZones: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListZones: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil

--- a/vendor/github.com/exoscale/egoscale/v3/schemas.go
+++ b/vendor/github.com/exoscale/egoscale/v3/schemas.go
@@ -337,6 +337,37 @@ type DBAASClickhouseAclConfig struct {
 	Users []DBAASClickhouseUserAclConfig `json:"users,omitempty"`
 }
 
+type DBAASClickhouseGrantedRole struct {
+	ISDefault *bool `json:"is-default,omitempty"`
+	// Granted role name
+	Name            string `json:"name" validate:"required"`
+	Uuid            string `json:"uuid,omitempty"`
+	WithAdminOption *bool  `json:"with-admin-option,omitempty"`
+}
+
+type DBAASClickhouseRole struct {
+	GrantedRoles []DBAASClickhouseGrantedRole   `json:"granted-roles,omitempty"`
+	Name         DBAASUserUsername              `json:"name" validate:"required,gte=1,lte=64"`
+	Privileges   []DBAASClickhouseRolePrivilege `json:"privileges,omitempty"`
+	Uuid         string                         `json:"uuid,omitempty"`
+}
+
+type DBAASClickhouseRolePrivilege struct {
+	// Column
+	Column string `json:"column,omitempty"`
+	// Database
+	Database        string            `json:"database,omitempty"`
+	GrantOption     *bool             `json:"grant-option,omitempty"`
+	ISPartialRevoke *bool             `json:"is-partial-revoke,omitempty"`
+	Name            DBAASUserUsername `json:"name" validate:"required,gte=1,lte=64"`
+	// Table
+	Table string `json:"table,omitempty"`
+}
+
+type DBAASClickhouseRoles struct {
+	Roles []DBAASClickhouseRole `json:"roles,omitempty"`
+}
+
 type DBAASClickhouseUser struct {
 	Required *bool             `json:"required,omitempty"`
 	Username DBAASUserUsername `json:"username" validate:"required,gte=1,lte=64"`
@@ -1040,8 +1071,10 @@ type DBAASServiceBackup struct {
 	BackupName string `json:"backup-name" validate:"required"`
 	// Backup timestamp (ISO 8601)
 	BackupTime time.Time `json:"backup-time" validate:"required"`
-	// Backup's original size before compression
+	// Backup's original size before compression, in bytes
 	DataSize int64 `json:"data-size" validate:"required,gte=0"`
+	// Amount of tiered storage data in bytes referenced by this backup
+	TieredStorageDataSize int64 `json:"tiered-storage-data-size,omitempty" validate:"omitempty,gte=0"`
 }
 
 type DBAASServiceClickhouseComponents struct {
@@ -2287,10 +2320,6 @@ type ElasticIPRef struct {
 	ID UUID `json:"id,omitempty"`
 }
 
-// An empty map response
-type Empty struct {
-}
-
 type EnableKmsKeyRotationRequest struct {
 	// The number of days between each automatic key rotation.
 	RotationPeriod int `json:"rotation-period,omitempty" validate:"omitempty,gte=90,lte=2560"`
@@ -2619,33 +2648,33 @@ const (
 // AI deployment
 type GetDeploymentResponse struct {
 	// Creation time
-	CreatedAT time.Time `json:"created-at" validate:"required"`
+	CreatedAT time.Time `json:"created-at,omitempty"`
 	// Deployment inference endpoint URL
 	DeploymentURL string `json:"deployment-url" validate:"required"`
 	// Number of GPUs
-	GpuCount int64 `json:"gpu-count" validate:"required,gte=1"`
+	GpuCount int64 `json:"gpu-count,omitempty" validate:"omitempty,gte=1"`
 	// GPU type family
-	GpuType string `json:"gpu-type" validate:"required,gte=1"`
+	GpuType string `json:"gpu-type,omitempty" validate:"omitempty,gte=1"`
 	// Deployment ID
-	ID UUID `json:"id" validate:"required"`
+	ID UUID `json:"id,omitempty"`
 	// Optional extra inference engine server CLI args
-	InferenceEngineParameters []string `json:"inference-engine-parameters" validate:"required"`
+	InferenceEngineParameters []string `json:"inference-engine-parameters,omitempty"`
 	// Inference engine version
-	InferenceEngineVersion InferenceEngineVersion `json:"inference-engine-version" validate:"required"`
+	InferenceEngineVersion InferenceEngineVersion `json:"inference-engine-version,omitempty"`
 	// Model reference. Provide either id or name.
 	Model *ModelRef `json:"model" validate:"required"`
 	// Deployment name
 	Name string `json:"name" validate:"required,gte=1"`
 	// Number of replicas (>=0)
-	Replicas int64 `json:"replicas" validate:"required,gte=0"`
+	Replicas int64 `json:"replicas,omitempty" validate:"omitempty,gte=0"`
 	// Service level
-	ServiceLevel string `json:"service-level" validate:"required,gte=1"`
+	ServiceLevel string `json:"service-level,omitempty" validate:"omitempty,gte=1"`
 	// Deployment state
 	State GetDeploymentResponseState `json:"state" validate:"required"`
 	// Deployment state details
-	StateDetails string `json:"state-details" validate:"required"`
+	StateDetails string `json:"state-details,omitempty"`
 	// Update time
-	UpdatedAT time.Time `json:"updated-at" validate:"required"`
+	UpdatedAT time.Time `json:"updated-at,omitempty"`
 	// Deployment visibility: private for your organization's deployments, public for Exoscale Managed Inference deployments.
 	Visibility GetDeploymentResponseVisibility `json:"visibility" validate:"required"`
 }
@@ -2820,6 +2849,30 @@ type IAMServicePolicyRule struct {
 	Resources  []string                   `json:"resources,omitempty"`
 }
 
+type ImpactBreakdown struct {
+	Impact map[string]ImpactValueWithUnit `json:"impact" validate:"required"`
+	Zones  map[string]ZoneImpact          `json:"zones" validate:"required"`
+}
+
+// Error response
+type ImpactErrorResponse struct {
+	Detail string `json:"detail" validate:"required"`
+	Status int    `json:"status" validate:"required,gte=100,lte=599"`
+	Title  string `json:"title" validate:"required"`
+}
+
+// Hierarchical breakdown of impact for a given level in the catalog tree
+type ImpactResourceTreeNode struct {
+	Impact    map[string]ImpactValueWithUnit    `json:"impact" validate:"required"`
+	Resources map[string]ImpactResourceTreeNode `json:"resources" validate:"required"`
+	Usage     *ImpactValueWithUnit              `json:"usage" validate:"required"`
+}
+
+type ImpactValueWithUnit struct {
+	Unit  string  `json:"unit" validate:"required"`
+	Value float64 `json:"value" validate:"required"`
+}
+
 // inference-engine parameter definition
 type InferenceEngineParameterEntry struct {
 	// Allowed values
@@ -2859,6 +2912,11 @@ const (
 	InferenceEngineVersion0230 InferenceEngineVersion = "0.23.0"
 	InferenceEngineVersion0240 InferenceEngineVersion = "0.24.0"
 	InferenceEngineVersion0250 InferenceEngineVersion = "0.25.0"
+	InferenceEngineVersion0251 InferenceEngineVersion = "0.25.1"
+	InferenceEngineVersion0260 InferenceEngineVersion = "0.26.0"
+	InferenceEngineVersion0270 InferenceEngineVersion = "0.27.0"
+	InferenceEngineVersion0271 InferenceEngineVersion = "0.27.1"
+	InferenceEngineVersion0280 InferenceEngineVersion = "0.28.0"
 )
 
 // Router flush payload: the router's full in-memory usage map with flush identity fields
@@ -2887,6 +2945,26 @@ type InstancePrivateNetworks struct {
 	ID UUID `json:"id,omitempty"`
 	// Private Network MAC address
 	MACAddress string `json:"mac-address,omitempty"`
+}
+
+// VPC subnet
+type InstanceVpcSubnets struct {
+	// VPC subnet ID
+	ID UUID `json:"id,omitempty"`
+	// Instance Subnet ipv4 address
+	Ipv4 net.IP `json:"ipv4,omitempty"`
+	// VPC subnet name
+	Name string `json:"name,omitempty"`
+}
+
+// VPC
+type InstanceVpc struct {
+	// VPC ID
+	ID UUID `json:"id,omitempty"`
+	// VPC name
+	Name string `json:"name,omitempty"`
+	// Instances attached to the subnet
+	Subnets []InstanceVpcSubnets `json:"subnets,omitempty"`
 }
 
 // Instance
@@ -2940,6 +3018,8 @@ type Instance struct {
 	TpmEnabled *bool `json:"tpm-enabled,omitempty"`
 	// Instance Cloud-init user-data (base64 encoded)
 	UserData string `json:"user-data,omitempty" validate:"omitempty,gte=1"`
+	// VPC
+	Vpc *InstanceVpc `json:"vpc,omitempty"`
 }
 
 // Instance password
@@ -3115,6 +3195,8 @@ type JSONSchemaClickhouseServerSettings struct {
 type JSONSchemaClickhouse struct {
 	// ClickHouse server settings, which can be found in the `system.server_settings` table.
 	ServerSettings *JSONSchemaClickhouseServerSettings `json:"server_settings,omitempty"`
+	// The percentage of free disk space required on local storage before data is moved to object storage. A value of 0.2 means data is moved when local storage has less than 20% free space.
+	TieredStorageMoveFactor float64 `json:"tiered_storage_move_factor,omitempty" validate:"omitempty,gte=0,lte=1"`
 }
 
 type JSONSchemaGrafanaAlertingErrorORTimeout string
@@ -4339,7 +4421,7 @@ type JSONSchemaValkey struct {
 }
 
 type KeyMaterial struct {
-	// A boolean flag indicating whether this specific material version was created during an automated system rotation window.
+	// Flag stating whether an automation run handled this historic mutation or if manual actor keys initiated it.
 	Automatic *bool `json:"automatic" validate:"required"`
 	// The UTC date-time indicating when this particular generation of physical cryptographic material was seeded.
 	CreatedAT time.Time `json:"created-at" validate:"required"`
@@ -4420,27 +4502,27 @@ const (
 // AI deployment
 type ListDeploymentsResponseEntry struct {
 	// Creation time
-	CreatedAT time.Time `json:"created-at" validate:"required"`
+	CreatedAT time.Time `json:"created-at,omitempty"`
 	// Deployment inference endpoint URL
 	DeploymentURL string `json:"deployment-url" validate:"required"`
 	// Number of GPUs
-	GpuCount int64 `json:"gpu-count" validate:"required,gte=1"`
+	GpuCount int64 `json:"gpu-count,omitempty" validate:"omitempty,gte=1"`
 	// GPU type family
-	GpuType string `json:"gpu-type" validate:"required,gte=1"`
+	GpuType string `json:"gpu-type,omitempty" validate:"omitempty,gte=1"`
 	// Deployment ID
-	ID UUID `json:"id" validate:"required"`
+	ID UUID `json:"id,omitempty"`
 	// Model reference. Provide either id or name.
 	Model *ModelRef `json:"model" validate:"required"`
 	// Deployment name
 	Name string `json:"name" validate:"required,gte=1"`
 	// Number of replicas (>=0)
-	Replicas int64 `json:"replicas" validate:"required,gte=0"`
+	Replicas int64 `json:"replicas,omitempty" validate:"omitempty,gte=0"`
 	// Service level
-	ServiceLevel string `json:"service-level" validate:"required,gte=1"`
+	ServiceLevel string `json:"service-level,omitempty" validate:"omitempty,gte=1"`
 	// Deployment state
 	State ListDeploymentsResponseEntryState `json:"state" validate:"required"`
 	// Update time
-	UpdatedAT time.Time `json:"updated-at" validate:"required"`
+	UpdatedAT time.Time `json:"updated-at,omitempty"`
 	// Deployment visibility: private for your organization's deployments, public for Exoscale Managed Inference deployments.
 	Visibility ListDeploymentsResponseEntryVisibility `json:"visibility" validate:"required"`
 }
@@ -4593,6 +4675,8 @@ type ListSubnetEntry struct {
 type ListVpcEntry struct {
 	// VPC creation date
 	CreatedAT time.Time `json:"created-at,omitempty"`
+	// Indicates if this is the organization's default VPC
+	Default *bool `json:"default,omitempty"`
 	// VPC description
 	Description string `json:"description,omitempty" validate:"omitempty,lte=4096"`
 	// VPC ID
@@ -4789,6 +4873,18 @@ const (
 	NvidiaMigProfileA3024gb4G24Gb   NvidiaMigProfileA3024gb = "4g.24gb"
 )
 
+type NvidiaMigProfileB300269gb string
+
+const (
+	NvidiaMigProfileB300269gb1G34Gb   NvidiaMigProfileB300269gb = "1g.34gb"
+	NvidiaMigProfileB300269gb1G34GbMe NvidiaMigProfileB300269gb = "1g.34gb+me"
+	NvidiaMigProfileB300269gb1G67Gb   NvidiaMigProfileB300269gb = "1g.67gb"
+	NvidiaMigProfileB300269gb2G67Gb   NvidiaMigProfileB300269gb = "2g.67gb"
+	NvidiaMigProfileB300269gb3G135Gb  NvidiaMigProfileB300269gb = "3g.135gb"
+	NvidiaMigProfileB300269gb4G135Gb  NvidiaMigProfileB300269gb = "4g.135gb"
+	NvidiaMigProfileB300269gb7G269Gb  NvidiaMigProfileB300269gb = "7g.269gb"
+)
+
 type NvidiaMigProfileRtxpro600096gb string
 
 const (
@@ -4808,6 +4904,7 @@ const (
 // Nvidia MIG Profiles enabled
 type NvidiaMigProfiles struct {
 	A3024gb        NvidiaMigProfileA3024gb        `json:"a30.24gb,omitempty"`
+	B300269gb      NvidiaMigProfileB300269gb      `json:"b300.269gb,omitempty"`
 	Rtxpro600096gb NvidiaMigProfileRtxpro600096gb `json:"rtxpro6000.96gb,omitempty"`
 }
 
@@ -4863,7 +4960,7 @@ type Operation struct {
 // Per-org Unit Of Measurement (UOM) consumption quota response
 type OrgConsumptionQuotaResponse struct {
 	// Per-org Unit Of Measurement (UOM) consumption quota (UOM/min). Null means unlimited. UOM represents weighted units across different AI workloads (e.g., tokens for LLMs, minutes for TTS, pages for OCR).
-	QuotaUomPerMinute int `json:"quota-uom-per-minute,omitempty" validate:"omitempty,gte=0"`
+	QuotaUomPerMinute *int `json:"quota-uom-per-minute,omitempty" validate:"omitempty,gte=0"`
 }
 
 // Organization
@@ -5039,12 +5136,6 @@ type Resource struct {
 	Name string `json:"name,omitempty"`
 }
 
-// Reveal AI API key response
-type RevealAIAPIKeyResponse struct {
-	// Plaintext AI API key value
-	Value string `json:"value" validate:"required"`
-}
-
 // AI deployment inference endpoint authentication key
 type RevealDeploymentAPIKeyResponse struct {
 	// Inference endpoint authentication key
@@ -5060,12 +5151,6 @@ type RevisionStamp struct {
 	AT time.Time `json:"at" validate:"required"`
 	// Monotonically increasing sequencing value utilized for optimistic concurrency control locks.
 	Seq int `json:"seq" validate:"required,gte=0"`
-}
-
-// Rotate AI API key response
-type RotateAIAPIKeyResponse struct {
-	// Plaintext AI API key value
-	Value string `json:"value" validate:"required"`
 }
 
 type RotateKmsKeyResponse struct {
@@ -5165,6 +5250,7 @@ type SecurityGroupRuleProtocol string
 const (
 	SecurityGroupRuleProtocolTCP    SecurityGroupRuleProtocol = "tcp"
 	SecurityGroupRuleProtocolEsp    SecurityGroupRuleProtocol = "esp"
+	SecurityGroupRuleProtocolAll    SecurityGroupRuleProtocol = "all"
 	SecurityGroupRuleProtocolICMP   SecurityGroupRuleProtocol = "icmp"
 	SecurityGroupRuleProtocolUDP    SecurityGroupRuleProtocol = "udp"
 	SecurityGroupRuleProtocolGre    SecurityGroupRuleProtocol = "gre"
@@ -5198,7 +5284,7 @@ type SecurityGroupRule struct {
 // Request to set per-org Unit Of Measurement (UOM) consumption quota
 type SetOrgConsumptionQuotaRequest struct {
 	// Per-org Unit Of Measurement (UOM) consumption quota (UOM/min). Pass null to remove the limit. UOM represents weighted units across different AI workloads (e.g., tokens for LLMs, minutes for TTS, pages for OCR).
-	QuotaUomPerMinute int `json:"quota-uom-per-minute,omitempty" validate:"omitempty,gte=0"`
+	QuotaUomPerMinute *int `json:"quota-uom-per-minute,omitempty" validate:"omitempty,gte=0"`
 }
 
 // Kubernetes Audit parameters
@@ -5342,6 +5428,7 @@ const (
 	SKSNodepoolStateCreating      SKSNodepoolState = "creating"
 	SKSNodepoolStateDeleting      SKSNodepoolState = "deleting"
 	SKSNodepoolStateRunning       SKSNodepoolState = "running"
+	SKSNodepoolStateDegraded      SKSNodepoolState = "degraded"
 	SKSNodepoolStateScaling       SKSNodepoolState = "scaling"
 	SKSNodepoolStateUpdating      SKSNodepoolState = "updating"
 	SKSNodepoolStateError         SKSNodepoolState = "error"
@@ -5370,7 +5457,9 @@ type SKSNodepool struct {
 	// Instance type reference
 	InstanceType *InstanceType `json:"instance-type,omitempty"`
 	// Kubelet image GC options
-	KubeletImageGC *KubeletImageGC   `json:"kubelet-image-gc,omitempty"`
+	KubeletImageGC *KubeletImageGC `json:"kubelet-image-gc,omitempty"`
+	// Maximum number of pods per node. Set to use a value other than the kubelet default.
+	KubeletMaxPods *int64            `json:"kubelet-max-pods,omitempty" validate:"omitempty,gte=1,lte=65535"`
 	Labels         SKSNodepoolLabels `json:"labels,omitempty"`
 	// Nodepool name
 	Name string `json:"name,omitempty" validate:"omitempty,gte=1,lte=255"`
@@ -5517,6 +5606,16 @@ const (
 	SubnetAddressfamilyDual  SubnetAddressfamily = "dual"
 )
 
+// Subnet attachements
+type SubnetInstances struct {
+	// Instance uuid
+	ID UUID `json:"id,omitempty"`
+	// Instance Ipv4 address
+	Ipv4 net.IP `json:"ipv4,omitempty"`
+	// Instance name
+	Name string `json:"name,omitempty"`
+}
+
 // Subnet
 type Subnet struct {
 	// Subnet address space
@@ -5529,6 +5628,8 @@ type Subnet struct {
 	Description string `json:"description,omitempty" validate:"omitempty,lte=4096"`
 	// Subnet ID
 	ID UUID `json:"id,omitempty"`
+	// Instances attached to the subnet
+	Instances []SubnetInstances `json:"instances,omitempty"`
 	// Subnet ipv4 CIDR
 	Ipv4Block string `json:"ipv4-block,omitempty"`
 	Labels    Labels `json:"labels,omitempty"`
@@ -5608,30 +5709,6 @@ type TemplateRef struct {
 	ID UUID `json:"id,omitempty"`
 }
 
-// Request to update an AI API key (at least one property required)
-type UpdateAIAPIKeyRequest struct {
-	// Human-readable name for the AI API key
-	Name string `json:"name,omitempty" validate:"omitempty,gte=1,lte=50"`
-	// Key scope: 'public' for all deployments, or a specific deployment UUID
-	Scope string `json:"scope,omitempty"`
-}
-
-// Update AI API key response
-type UpdateAIAPIKeyResponse struct {
-	// Creation timestamp
-	CreatedAT time.Time `json:"created-at" validate:"required"`
-	// AI API key ID
-	ID UUID `json:"id" validate:"required"`
-	// Human-readable name for the AI API key
-	Name string `json:"name" validate:"required"`
-	// Organization UUID that owns this key
-	OrgUuid UUID `json:"org-uuid" validate:"required"`
-	// Key scope: 'public' for all deployments, or a specific deployment UUID
-	Scope string `json:"scope" validate:"required"`
-	// Last update timestamp
-	UpdatedAT time.Time `json:"updated-at" validate:"required"`
-}
-
 // Update AI deployment
 type UpdateDeploymentRequest struct {
 	// Optional extra inference engine server CLI args
@@ -5662,6 +5739,8 @@ type User struct {
 type Vpc struct {
 	// VPC creation date
 	CreatedAT time.Time `json:"created-at,omitempty"`
+	// Indicates if this is the organization's default VPC
+	Default *bool `json:"default,omitempty"`
 	// VPC description
 	Description string `json:"description,omitempty" validate:"omitempty,lte=4096"`
 	// VPC ID
@@ -5678,6 +5757,12 @@ type Zone struct {
 	Name        ZoneName `json:"name,omitempty"`
 	// Zone SOS endpoint
 	SOSEndpoint Endpoint `json:"sos-endpoint,omitempty"`
+}
+
+// Hierarchical breakdown of impact in a given zone
+type ZoneImpact struct {
+	Impact    map[string]ImpactValueWithUnit    `json:"impact" validate:"required"`
+	Resources map[string]ImpactResourceTreeNode `json:"resources" validate:"required"`
 }
 
 type ZoneName string

--- a/vendor/github.com/exoscale/egoscale/v3/version.go
+++ b/vendor/github.com/exoscale/egoscale/v3/version.go
@@ -1,4 +1,4 @@
 package v3
 
 // Version represents the current egoscale v3 version.
-const Version = "v3.1.42"
+const Version = "v3.1.49"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -271,7 +271,7 @@ github.com/exoscale/egoscale/v2
 github.com/exoscale/egoscale/v2/api
 github.com/exoscale/egoscale/v2/oapi
 github.com/exoscale/egoscale/version
-# github.com/exoscale/egoscale/v3 v3.1.42
+# github.com/exoscale/egoscale/v3 v3.1.49
 ## explicit; go 1.25
 github.com/exoscale/egoscale/v3
 github.com/exoscale/egoscale/v3/credentials


### PR DESCRIPTION
# Description
<!--
* Prefix: the title with the component name being changed. Add a short and self describing sentence to ease the review
* Please add a few lines providing context and describing the change
* Please self comment changes whenever applicable to help with the review process
* Please keep the checklist as part of the PR. Tick what applies to this change.
-->

Add kubelet-max-pods SKS nodepool attribute support & bump egoscale

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Acceptance tests OK
* [x] For a new resource, datasource or new attributes: acceptance test added/updated

## Testing

<!--
Describe the tests you did
-->

```
❯ TF_ACC=1 go test ./... -run ".*SKS.*" -v
?       github.com/exoscale/terraform-provider-exoscale [no test files]
=== RUN   TestAccSKSDataSources
=== PAUSE TestAccSKSDataSources
=== RUN   TestAccResourceSKSCluster
=== PAUSE TestAccResourceSKSCluster
=== RUN   TestAccResourceSKSClusterSKSClusterWithAudit
=== PAUSE TestAccResourceSKSClusterSKSClusterWithAudit
=== RUN   TestAccResourceSKSClusterWithKarpenter
=== PAUSE TestAccResourceSKSClusterWithKarpenter
=== RUN   TestResolveSKSClusterVersions
=== PAUSE TestResolveSKSClusterVersions
=== RUN   TestAccResourceSKSKubeconfig
=== PAUSE TestAccResourceSKSKubeconfig
=== RUN   TestSKSNodepoolMIGProfiles
=== PAUSE TestSKSNodepoolMIGProfiles
=== RUN   TestSKSNodepoolMIGProfile
=== PAUSE TestSKSNodepoolMIGProfile
=== RUN   TestSKSNodepoolMIGProfilesRoundTrip
=== PAUSE TestSKSNodepoolMIGProfilesRoundTrip
=== RUN   TestAccResourceSKSNodepool
=== PAUSE TestAccResourceSKSNodepool
=== CONT  TestAccSKSDataSources
=== CONT  TestAccResourceSKSKubeconfig
=== CONT  TestSKSNodepoolMIGProfilesRoundTrip
=== CONT  TestAccResourceSKSNodepool
--- PASS: TestSKSNodepoolMIGProfilesRoundTrip (0.00s)
=== CONT  TestAccResourceSKSCluster
=== CONT  TestAccResourceSKSClusterWithKarpenter
=== CONT  TestAccResourceSKSClusterSKSClusterWithAudit
=== CONT  TestResolveSKSClusterVersions
=== CONT  TestSKSNodepoolMIGProfile
=== CONT  TestSKSNodepoolMIGProfiles
=== RUN   TestResolveSKSClusterVersions/major.minor_resolves_to_corresponding_major.minor.patch
=== RUN   TestSKSNodepoolMIGProfiles/a30_family
=== RUN   TestSKSNodepoolMIGProfile/nil
=== RUN   TestSKSNodepoolMIGProfile/empty_struct
=== RUN   TestSKSNodepoolMIGProfiles/rtxpro6000_family
=== RUN   TestSKSNodepoolMIGProfiles/non-GPU_family
=== RUN   TestResolveSKSClusterVersions/empty_version_resolves_to_latest_version
=== RUN   TestSKSNodepoolMIGProfiles/non-MIG_GPU_family
=== RUN   TestResolveSKSClusterVersions/#00
=== RUN   TestSKSNodepoolMIGProfiles/invalid_profile_for_family
=== RUN   TestResolveSKSClusterVersions/unsupported_major.minor_throws_error
--- PASS: TestSKSNodepoolMIGProfiles (0.00s)
    --- PASS: TestSKSNodepoolMIGProfiles/a30_family (0.00s)
    --- PASS: TestSKSNodepoolMIGProfiles/rtxpro6000_family (0.00s)
    --- PASS: TestSKSNodepoolMIGProfiles/non-GPU_family (0.00s)
    --- PASS: TestSKSNodepoolMIGProfiles/non-MIG_GPU_family (0.00s)
    --- PASS: TestSKSNodepoolMIGProfiles/invalid_profile_for_family (0.00s)
=== RUN   TestResolveSKSClusterVersions/version_fits_no_format
=== RUN   TestSKSNodepoolMIGProfile/a30_set
=== RUN   TestSKSNodepoolMIGProfile/rtxpro6000_set
--- PASS: TestSKSNodepoolMIGProfile (0.00s)
    --- PASS: TestSKSNodepoolMIGProfile/nil (0.00s)
    --- PASS: TestSKSNodepoolMIGProfile/empty_struct (0.00s)
    --- PASS: TestSKSNodepoolMIGProfile/a30_set (0.00s)
    --- PASS: TestSKSNodepoolMIGProfile/rtxpro6000_set (0.00s)
--- PASS: TestResolveSKSClusterVersions (0.00s)
    --- PASS: TestResolveSKSClusterVersions/major.minor_resolves_to_corresponding_major.minor.patch (0.00s)
    --- PASS: TestResolveSKSClusterVersions/empty_version_resolves_to_latest_version (0.00s)
    --- PASS: TestResolveSKSClusterVersions/#00 (0.00s)
    --- PASS: TestResolveSKSClusterVersions/unsupported_major.minor_throws_error (0.00s)
    --- PASS: TestResolveSKSClusterVersions/version_fits_no_format (0.00s)
--- PASS: TestAccResourceSKSKubeconfig (69.65s)
--- PASS: TestAccResourceSKSClusterSKSClusterWithAudit (121.26s)
--- PASS: TestAccResourceSKSClusterWithKarpenter (169.11s)
--- PASS: TestAccSKSDataSources (215.95s)
--- PASS: TestAccResourceSKSNodepool (269.24s)
--- PASS: TestAccResourceSKSCluster (317.49s)
PASS
ok      github.com/exoscale/terraform-provider-exoscale/exoscale        317.517s
?       github.com/exoscale/terraform-provider-exoscale/pkg/config      [no test files]
testing: warning: no tests to run
PASS
ok      github.com/exoscale/terraform-provider-exoscale/pkg/filter      0.004s [no tests to run]
?       github.com/exoscale/terraform-provider-exoscale/pkg/general     [no test files]
testing: warning: no tests to run
PASS
ok      github.com/exoscale/terraform-provider-exoscale/pkg/list        0.029s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/exoscale/terraform-provider-exoscale/pkg/provider    0.021s [no tests to run]
?       github.com/exoscale/terraform-provider-exoscale/pkg/provider/config     [no test files]
testing: warning: no tests to run
PASS
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/anti_affinity_group       0.028s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/block_storage     0.027s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/database  0.026s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/domain    0.040s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/iam       0.037s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/instance  0.037s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/instance_pool     0.038s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/kms       0.032s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/nlb_service       0.034s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/private_network   0.032s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/security_group    0.038s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/exoscale/terraform-provider-exoscale/pkg/resources/sos_bucket_policy 0.014s [no tests to run]
?       github.com/exoscale/terraform-provider-exoscale/pkg/resources/zones     [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/sos [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/testutils   [no test files]
testing: warning: no tests to run
PASS
ok      github.com/exoscale/terraform-provider-exoscale/pkg/utils       0.013s [no tests to run]
?       github.com/exoscale/terraform-provider-exoscale/pkg/validators  [no test files]
?       github.com/exoscale/terraform-provider-exoscale/pkg/version     [no test files]
?       github.com/exoscale/terraform-provider-exoscale/version [no test files]```
